### PR TITLE
Update README for launch (ORO-542)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,86 +1,74 @@
+<div align="center">
+
 # ORO
 
-**ORO** is a Bittensor subnet dedicated to advancing AI agents for online commerce.
+**AI shopping agents, evaluated on Bittensor.**
+
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/MHqAVWTdka)
+[![Docs](https://img.shields.io/badge/Docs-docs.oroagents.com-0A3815)](https://docs.oroagents.com)
+[![Leaderboard](https://img.shields.io/badge/Leaderboard-oroagents.com-FF9138)](https://oroagents.com)
+[![X](https://img.shields.io/badge/@oroagents-000000?logo=x&logoColor=white)](https://x.com/oroagents)
+[![Paper](https://img.shields.io/badge/Paper-arXiv:2508.04266-red)](https://arxiv.org/abs/2508.04266)
+[![License](https://img.shields.io/badge/License-MIT-blue)](LICENSE)
+
+</div>
+
+---
+
+ORO is a Bittensor subnet (SN15) that evaluates AI agents on real-world shopping tasks. Miners submit Python agents that search products, compare prices, and make purchase decisions. Validators run those agents in sandboxed Docker environments against [ShoppingBench](https://arxiv.org/abs/2508.04266) — a benchmark with 2.5 million real products. The best agents earn emissions.
+
+## How It Works
+
+<img src="img/how-it-works.svg" alt="ORO subnet architecture — Miner submits agent, Backend orchestrates, Validator evaluates in Docker sandbox, Bittensor distributes emissions" />
+
+1. **Miners** write Python agents that solve shopping problems — finding products, comparing options, applying vouchers
+2. **Validators** run each agent in an isolated Docker sandbox against the ShoppingBench problem suite
+3. **Scoring** evaluates ground truth accuracy, format compliance, and field matching
+4. **The best agent** earns top position on the [leaderboard](https://oroagents.com) and receives TAO emissions proportional to validator stake
+5. **Challengers** must exceed a decaying score threshold to claim the top spot — preventing trivial improvements from churning the leader
+
+## For Miners
+
+Miners submit Python agents that define an `agent_main()` function. Inside the sandbox, your agent can search 2.5M real products, view product details, and make recommendations — all scored against ground truth.
+
+Available tools: `find_product`, `view_product_information`, `recommend_product`
+
+**Get started:** [Miner Quickstart Guide](https://docs.oroagents.com/docs/miners/quick-start) — build an agent, test locally with Docker, and submit to the network.
+
+See [`src/agent/agent.py`](src/agent/agent.py) for a reference agent implementation.
+
+## For Validators
+
+Validators run the evaluation infrastructure — claiming work from the Backend, executing miner agents in Docker sandboxes, scoring results, and setting on-chain weights.
+
+**Requirements:** Docker, registered Bittensor hotkey on SN15, [minimum stake weight](https://docs.oroagents.com/docs/validators/overview#minimum-stake-weight), 16+ GB RAM (32 GB recommended).
+
+```bash
+git clone https://github.com/ORO-AI/oro.git
+cd oro
+cp .env.example .env    # Set WALLET_NAME and WALLET_HOTKEY
+
+WALLET_NAME=my-validator docker compose --profile validator up
+```
+
+**Full guide:** [Validator Overview](https://docs.oroagents.com/docs/validators/overview) — hardware requirements, configuration, monitoring, and troubleshooting.
 
 ## What is ORO?
 
-ORO is building infrastructure to evaluate, benchmark, and incentivize the development of AI agents that can navigate and operate in online commerce environments. We believe the future of online shopping and transactions will be powered by intelligent agents acting on behalf of users.
+ORO means "gold" in Spanish and Italian — representing the value we aim to create in the AI agent ecosystem. In Ancient Greek, *oro-* (ὄρος) means "mountain," an homage to where the founders of ORO met and live.
 
-## The Problem We're Solving
+We're building infrastructure to evaluate, benchmark, and incentivize the development of AI agents that can navigate and operate in online commerce environments. Bittensor provides decentralized validation, transparent incentive distribution via TAO emissions, and open participation for anyone to submit agents or run validators.
 
-The rise of AI agents presents new challenges for online commerce:
+## Documentation
 
-- **Evaluation**: How do we objectively measure an AI agent's ability to perform complex online tasks?
-- **Trust**: How do users know which agents are reliable and effective?
-- **Incentives**: How do we align incentives to encourage development of better, safer agents?
+Full documentation at **[docs.oroagents.com](https://docs.oroagents.com)**:
 
-ORO creates a decentralized marketplace where AI agents compete on standardized benchmarks, with transparent scoring and rewards distributed via the Bittensor network.
-
-## Why Bittensor?
-
-Bittensor provides the ideal foundation for ORO:
-
-- **Decentralized Validation**: Validators independently evaluate agent performance
-- **Transparent Incentives**: TAO emissions reward the best-performing agents
-- **Open Participation**: Anyone can submit agents to compete on the leaderboard
-- **Open Source**: We're going to open source the core infrastructure and benchmarks to the community to help advance the state of the art in AI shopping agents.
-
----
-
-## FAQ
-
-### General
-
-**Q: What does "ORO" mean?**
-
-A: ORO means "gold" in Spanish and Italian—representing the value we aim to create in the AI agent ecosystem. In Ancient Greek, "oro-" (ὄρος) means "mountain," an homage to where the founders of ORO met and live currently :)
-
-**Q: Is ORO live yet?**
-
-A: We are currently in development. Follow this repository and join our community channels for launch announcements.
-
-### For Miners
-
-**Q: How do I participate as a miner?**
-
-A: Miners submit AI agents that are evaluated against our benchmark suite. Detailed documentation will be released closer to launch.
-
-**Q: What kind of agents can I submit?**
-
-A: Agents that can perform tasks in online commerce environments. More details on supported capabilities and requirements will be published in our technical documentation.
-
-### For Validators
-
-**Q: How does validation work?**
-
-A: Validators run evaluation jobs on submitted agents and report results to the network. The validation process ensures fair and accurate scoring.
-
-**Q: What are the hardware requirements?**
-
-A: Validator requirements will be published before mainnet launch.
-
-**Q: Can I run a validator now?**
-
-A: We are currently burning emissions to UID 0 while we finalize our infrastructure. 
-
-### Technical
-
-**Q: What benchmarks do you use?**
-
-A: We're working on improving the best open source shopping benchmarks for evaluating AI agents in commerce scenarios. Benchmark details will be published in our technical documentation soon before our mainnet launch.
-
-**Q: Is the code open source?**
-
-A: Core evaluation infrastructure will be open-sourced. Some components may remain private to prevent gaming of the benchmark.
-
----
-
-## Stay Connected
-
-- **Twitter/X**: [@ORO AI](https://x.com/oroagents)
-
----
+| | Miners | Validators | Platform |
+|---|--------|------------|----------|
+| Getting started | [Quickstart](https://docs.oroagents.com/docs/miners/quick-start) | [Overview](https://docs.oroagents.com/docs/validators/overview) | [Architecture](https://docs.oroagents.com/docs/architecture) |
+| Reference | [Agent Interface](https://docs.oroagents.com/docs/miners/agent-interface) | [Configuration](https://docs.oroagents.com/docs/validators/configuration) | [API Endpoints](https://docs.oroagents.com/docs/api/endpoints) |
+| Testing | [Local Testing](https://docs.oroagents.com/docs/miners/local-testing) | [Installation](https://docs.oroagents.com/docs/validators/installation) | [FAQ](https://docs.oroagents.com/docs/resources/faq) |
 
 ## License
 
-This repository is provided for informational purposes. Additional licensing information will be added as components are released.
+MIT — see [LICENSE](LICENSE).

--- a/img/how-it-works.svg
+++ b/img/how-it-works.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 320" fill="none">
+  <style>
+    text { font-family: 'Plus Jakarta Sans', system-ui, sans-serif; }
+    .box-label { font-size: 16px; font-weight: 800; fill: #FCFAF2; }
+    .box-sub { font-size: 11px; fill: #A8BFA9; }
+    .actor-label { font-size: 10px; font-weight: 600; fill: #956825; text-transform: uppercase; letter-spacing: 0.5px; }
+    .arrow-label { font-size: 10px; fill: #6B7C6E; }
+    .conn { stroke: #E2DBC9; stroke-width: 2; }
+    .desc { font-size: 11px; fill: #6B7C6E; }
+    .dashed { stroke: #C8C3B0; stroke-width: 1.5; stroke-dasharray: 5 4; opacity: 0.45; fill: none; }
+    .dashed-arrow { fill: #C8C3B0; opacity: 0.45; }
+  </style>
+
+  <!-- Miner -->
+  <text x="110" y="28" text-anchor="middle" class="actor-label">Miner</text>
+  <rect x="30" y="38" width="160" height="70" rx="14" fill="#0A3815"/>
+  <text x="110" y="68" text-anchor="middle" class="box-label">Submit Agent</text>
+  <text x="110" y="86" text-anchor="middle" class="box-sub">Python agent file</text>
+  <text x="110" y="130" text-anchor="middle" class="desc">Write a shopping agent</text>
+  <text x="110" y="144" text-anchor="middle" class="desc">that finds the right product</text>
+
+  <!-- Arrow Miner → Backend -->
+  <line x1="195" y1="73" x2="270" y2="73" class="conn"/>
+  <polygon points="270,68 280,73 270,78" fill="#E2DBC9"/>
+  <text x="237" y="63" text-anchor="middle" class="arrow-label">upload</text>
+
+  <!-- Backend -->
+  <text x="390" y="28" text-anchor="middle" class="actor-label">ORO Backend</text>
+  <rect x="285" y="38" width="210" height="70" rx="14" fill="#0A3815"/>
+  <text x="390" y="68" text-anchor="middle" class="box-label">Queue &amp; Orchestrate</text>
+  <text x="390" y="86" text-anchor="middle" class="box-sub">Leaderboard · Scoring · API</text>
+  <text x="390" y="130" text-anchor="middle" class="desc">Assigns work to validators</text>
+  <text x="390" y="144" text-anchor="middle" class="desc">Tracks scores and rankings</text>
+
+  <!-- Arrow Backend → Validator -->
+  <line x1="500" y1="73" x2="575" y2="73" class="conn"/>
+  <polygon points="575,68 585,73 575,78" fill="#E2DBC9"/>
+  <text x="542" y="63" text-anchor="middle" class="arrow-label">assign</text>
+
+  <!-- Validator -->
+  <text x="690" y="28" text-anchor="middle" class="actor-label">Validator</text>
+  <rect x="590" y="38" width="200" height="70" rx="14" fill="#0A3815"/>
+  <text x="690" y="68" text-anchor="middle" class="box-label">Evaluate &amp; Score</text>
+  <text x="690" y="86" text-anchor="middle" class="box-sub">Docker sandbox · ShoppingBench</text>
+  <text x="690" y="130" text-anchor="middle" class="desc">Runs agents in isolation</text>
+  <text x="690" y="144" text-anchor="middle" class="desc">Scores against ground truth</text>
+
+  <!-- Progress bar -->
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#0A3815"/>
+      <stop offset="50%" stop-color="#EDD03A"/>
+      <stop offset="100%" stop-color="#FF9138"/>
+    </linearGradient>
+  </defs>
+  <rect x="30" y="180" width="760" height="4" rx="2" fill="url(#grad)"/>
+
+  <!-- Bittensor row -->
+  <text x="400" y="215" text-anchor="middle" class="actor-label">Bittensor Network (SN15)</text>
+
+  <!-- Emissions box -->
+  <rect x="220" y="228" width="160" height="56" rx="14" fill="#FF9138"/>
+  <text x="300" y="254" text-anchor="middle" style="font-size:14px;font-weight:800;fill:#0A3815;">Emissions</text>
+  <text x="300" y="272" text-anchor="middle" style="font-size:10px;fill:#5C3D18;">Best agent earns rewards</text>
+
+  <!-- Weights box -->
+  <rect x="420" y="228" width="160" height="56" rx="14" fill="#EDD03A"/>
+  <text x="500" y="254" text-anchor="middle" style="font-size:14px;font-weight:800;fill:#0A3815;">Set Weights</text>
+  <text x="500" y="272" text-anchor="middle" style="font-size:10px;fill:#5C3D18;">Validators vote on-chain</text>
+
+  <!-- Dashed arrow: Emissions → Miner (left from Emissions, curve up to Miner) -->
+  <path d="M 220,256 L 140,256 Q 110,256 110,226 L 110,155" class="dashed"/>
+  <polygon points="105,157 110,149 115,157" class="dashed-arrow"/>
+
+  <!-- Dashed arrow: Validator → Set Weights (straight down, 90° left turn into Set Weights) -->
+  <line x1="690" y1="155" x2="690" y2="256" class="dashed"/>
+  <line x1="690" y1="256" x2="585" y2="256" class="dashed"/>
+  <polygon points="588,251 580,256 588,261" class="dashed-arrow"/>
+</svg>


### PR DESCRIPTION
## Description

Rewrites the placeholder README for public launch. Replaces "coming soon" content with actionable documentation, architecture diagram, and links to full docs.

## Changes Made

- Added centered header with badges (Discord, Docs, Leaderboard, X, Paper, License)
- Added brand-styled SVG architecture diagram showing miner → backend → validator → Bittensor flow
- Added "How It Works" section explaining the subnet loop
- Added slim "For Miners" section linking to docs quickstart
- Added slim "For Validators" section with 3-command setup + link to full guide
- Kept "What is ORO?" section from original README (name meaning, vision)
- Added documentation table organized by role (Miners/Validators/Platform)
- Removed all "coming soon" / placeholder FAQ content

## Issue Link

- Closes: ORO-542

## Testing

### Manual Testing
Previewed on GitHub branch — badges render, SVG diagram displays correctly, all links point to correct docs pages.

**Test Results:**
Renders correctly on GitHub.

### Automated Testing
N/A — documentation only.

## Documentation

- [x] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
Complete README rewrite for launch.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)