### PR TITLE
Fix Docker Desktop context compatibility for validator (ORO-482)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,7 @@ services:
       - ./logs:/app/logs
       - validator-data:/root/.validator
     environment:
+      - DOCKER_CONTEXT=default
       - HOST_PROJECT_DIR=${PWD}
       - SANDBOX_IMAGE=${SANDBOX_IMAGE:-ghcr.io/oro-ai/oro/sandbox:latest}
       - SANDBOX_NETWORK=sandbox-network


### PR DESCRIPTION
## Description

Docker Desktop sets `"currentContext": "desktop-linux"` in `~/.docker/config.json`. The validator mounts this config but the `desktop-linux` context doesn't exist inside the container, causing immediate sandbox failures with "context not found". This made every sandbox execution fail, triggering auto-discard of all agent versions.

## Changes Made

- Added `DOCKER_CONTEXT=default` to the validator service environment in `docker-compose.yml`

## Issue Link

- Closes: ORO-482

## Testing

### Manual Testing
One-line env var addition. `DOCKER_CONTEXT=default` is the documented workaround that was already verified working.

### Automated Testing
N/A — docker-compose config change.

## Checklist

- [x] My changes generate no new warnings or errors

## Additional Notes

This affects developers testing locally on macOS with Docker Desktop. Production validators on Linux are unaffected (no `desktop-linux` context in their Docker config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)