### PR TITLE
feat: track inference call success/failure per problem

### DIFF
--- a/src/agent/agent.py
+++ b/src/agent/agent.py
@@ -840,4 +840,9 @@ def agent_main(problem_data: Dict) -> List[Dict]:
         steps.append(fallback_step)
 
     logger.info(f"[ReAct] Completed with {len(steps)} steps")
+
+    # Inject inference stats into final dialogue step for downstream tracking
+    if steps and hasattr(_proxy, 'inference_stats'):
+        steps[-1].setdefault("extra_info", {}).update(_proxy.inference_stats.to_dict())
+
     return steps

--- a/src/agent/proxy_client.py
+++ b/src/agent/proxy_client.py
@@ -12,6 +12,7 @@ All requests go through the proxy service for network isolation.
 
 import os
 import logging
+import threading
 import time
 from typing import Dict, Optional, Callable
 from urllib.parse import urlencode
@@ -24,6 +25,31 @@ logger = logging.getLogger(__name__)
 DEFAULT_TIMEOUT = 120
 DEFAULT_MAX_RETRIES = 3
 DEFAULT_RETRY_DELAY = 2
+
+
+class InferenceStats:
+    """Thread-safe counter for inference call outcomes."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._success = 0
+        self._failed = 0
+
+    def record_success(self):
+        with self._lock:
+            self._success += 1
+
+    def record_failure(self):
+        with self._lock:
+            self._failed += 1
+
+    def to_dict(self) -> dict:
+        with self._lock:
+            return {
+                "inference_success": self._success,
+                "inference_failed": self._failed,
+                "inference_total": self._success + self._failed,
+            }
 
 
 class ProxyClient:
@@ -57,6 +83,7 @@ class ProxyClient:
         self.max_retries = max_retries
         self.retry_delay = retry_delay
         self.api_key = api_key or os.getenv("CHUTES_ACCESS_TOKEN")
+        self.inference_stats = InferenceStats()
 
     def _build_url(self, path: str, params: Optional[Dict] = None) -> str:
         """
@@ -165,6 +192,12 @@ class ProxyClient:
             return response
 
         response = self._make_request_with_retries(make_request, f"POST {path}")
+        # Track inference call outcomes
+        if "/inference/" in path:
+            if response and response.status_code == 200:
+                self.inference_stats.record_success()
+            else:
+                self.inference_stats.record_failure()
         if response and response.status_code == 200:
             return response.json()
         return None

--- a/subnet/tests/test_proxy_client.py
+++ b/subnet/tests/test_proxy_client.py
@@ -3,7 +3,7 @@
 from unittest.mock import patch, MagicMock
 
 
-from src.agent.proxy_client import ProxyClient
+from src.agent.proxy_client import InferenceStats, ProxyClient
 
 
 class TestProxyClientAuth:
@@ -54,3 +54,33 @@ class TestProxyClientAuth:
         with patch.dict("os.environ", {"CHUTES_ACCESS_TOKEN": "env-token"}):
             client = ProxyClient(proxy_url="http://proxy:80", api_key="explicit")
             assert client.api_key == "explicit"
+
+
+class TestInferenceStats:
+    def test_initial_state(self):
+        stats = InferenceStats()
+        assert stats.to_dict() == {"inference_success": 0, "inference_failed": 0, "inference_total": 0}
+
+    def test_record_success(self):
+        stats = InferenceStats()
+        stats.record_success()
+        d = stats.to_dict()
+        assert d["inference_success"] == 1
+        assert d["inference_failed"] == 0
+        assert d["inference_total"] == 1
+
+    def test_record_failure(self):
+        stats = InferenceStats()
+        stats.record_failure()
+        d = stats.to_dict()
+        assert d["inference_failed"] == 1
+        assert d["inference_success"] == 0
+        assert d["inference_total"] == 1
+
+    def test_mixed(self):
+        stats = InferenceStats()
+        stats.record_success()
+        stats.record_success()
+        stats.record_failure()
+        d = stats.to_dict()
+        assert d == {"inference_success": 2, "inference_failed": 1, "inference_total": 3}

--- a/subnet/tests/validator/test_progress_reporter.py
+++ b/subnet/tests/validator/test_progress_reporter.py
@@ -17,7 +17,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 from oro_sdk.models import ProblemProgressUpdate, ProblemStatus
 
 from validator.backend_client import BackendError
-from validator.progress_reporter import ProgressReporter
+from validator.progress_reporter import ProgressReporter, extract_inference_stats
 from validator.retry_queue import LocalRetryQueue
 
 
@@ -367,3 +367,31 @@ class TestReportProgressRetry:
         reporter.start_monitoring()
         assert reporter._failed_reports == []
         reporter.stop_monitoring()
+
+
+class TestExtractInferenceStats:
+    def test_from_last_step(self):
+        dialogue = [
+            {"extra_info": {"step": 1}},
+            {"extra_info": {"step": 2, "inference_failed": 3, "inference_total": 10}},
+        ]
+        failed, total = extract_inference_stats(dialogue)
+        assert failed == 3
+        assert total == 10
+
+    def test_missing_stats_returns_zeros(self):
+        dialogue = [{"extra_info": {"step": 1}}]
+        failed, total = extract_inference_stats(dialogue)
+        assert failed == 0
+        assert total == 0
+
+    def test_empty_dialogue_returns_zeros(self):
+        failed, total = extract_inference_stats([])
+        assert failed == 0
+        assert total == 0
+
+    def test_no_extra_info_returns_zeros(self):
+        dialogue = [{"completion": {}}]
+        failed, total = extract_inference_stats(dialogue)
+        assert failed == 0
+        assert total == 0

--- a/subnet/validator/progress_reporter.py
+++ b/subnet/validator/progress_reporter.py
@@ -17,6 +17,18 @@ if TYPE_CHECKING:
     from .retry_queue import LocalRetryQueue
 
 
+def extract_inference_stats(dialogue: list[dict]) -> tuple[int, int]:
+    """Extract inference failure count and total from the last dialogue step's extra_info.
+
+    Returns:
+        (inference_failed, inference_total)
+    """
+    if not dialogue:
+        return 0, 0
+    extra_info = dialogue[-1].get("extra_info", {})
+    return extra_info.get("inference_failed", 0), extra_info.get("inference_total", 0)
+
+
 class ProgressReporter:
     """Monitors sandbox output file, scores problems, and reports to Backend.
 
@@ -339,12 +351,27 @@ class ProgressReporter:
             if self._completed_count == self._total_problems:
                 self._compute_aggregate()
 
+            # Extract inference stats from the last dialogue step
+            inference_failure_count, inference_total = extract_inference_stats(dialogue)
+
+            # Build score_components_summary with inference stats
+            # (inference fields will be promoted to top-level fields in Task 4)
+            from oro_sdk.models import ProblemProgressUpdateScoreComponentsSummaryType0
+
+            score_summary = ProblemProgressUpdateScoreComponentsSummaryType0.from_dict(
+                {
+                    "inference_failure_count": inference_failure_count,
+                    "inference_total": inference_total,
+                }
+            )
+
             return ProblemProgressUpdate(
                 problem_id=UUID(problem_id)
                 if isinstance(problem_id, str)
                 else problem_id,
                 status=status,
                 score=score,
+                score_components_summary=score_summary,
             )
 
         except json.JSONDecodeError:


### PR DESCRIPTION
## Description

Cherry-pick of ORO-AI/ShoppingBench#78. Track inference call outcomes per problem during sandbox execution.

## Changes Made

- `InferenceStats` class in `ProxyClient` tracks success/failure per inference call
- Stats injected into final dialogue step at end of `agent_main()`
- `ProgressReporter` extracts stats and includes in progress updates to Backend

## Issue Link

- Related to: ORO-509

## Checklist

- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes