### PR TITLE
feat: track inference stats via shared JSONL — validator-controlled

### DIFF
--- a/src/agent/proxy_client.py
+++ b/src/agent/proxy_client.py
@@ -10,8 +10,11 @@ This module provides a minimal HTTP client that handles:
 All requests go through the proxy service for network isolation.
 """
 
+import atexit
+import json
 import os
 import logging
+import threading
 import time
 from typing import Dict, Optional, Callable
 from urllib.parse import urlencode
@@ -24,6 +27,43 @@ logger = logging.getLogger(__name__)
 DEFAULT_TIMEOUT = 120
 DEFAULT_MAX_RETRIES = 3
 DEFAULT_RETRY_DELAY = 2
+
+
+class InferenceStats:
+    """Thread-safe counter for inference call outcomes."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._success = 0
+        self._failed = 0
+
+    def record_success(self):
+        with self._lock:
+            self._success += 1
+
+    def record_failure(self):
+        with self._lock:
+            self._failed += 1
+
+    def to_dict(self) -> dict:
+        with self._lock:
+            return {
+                "inference_success": self._success,
+                "inference_failed": self._failed,
+                "inference_total": self._success + self._failed,
+            }
+
+    def append_to_file(self, path: str) -> None:
+        """Append stats as a JSONL line, keyed by problem_id from env."""
+        try:
+            problem_data = os.environ.get("PROBLEM_DATA", "{}")
+            problem = json.loads(problem_data)
+            problem_id = problem.get("problem_id") or problem.get("id", "unknown")
+            entry = {"problem_id": str(problem_id), **self.to_dict()}
+            with open(path, "a") as f:
+                f.write(json.dumps(entry) + "\n")
+        except (OSError, json.JSONDecodeError):
+            pass  # Best-effort; don't crash the agent
 
 
 class ProxyClient:
@@ -57,6 +97,10 @@ class ProxyClient:
         self.max_retries = max_retries
         self.retry_delay = retry_delay
         self.api_key = api_key or os.getenv("CHUTES_ACCESS_TOKEN")
+        self.inference_stats = InferenceStats()
+        stats_file = os.environ.get("INFERENCE_STATS_FILE")
+        if stats_file:
+            atexit.register(self.inference_stats.append_to_file, stats_file)
 
     def _build_url(self, path: str, params: Optional[Dict] = None) -> str:
         """
@@ -165,6 +209,11 @@ class ProxyClient:
             return response
 
         response = self._make_request_with_retries(make_request, f"POST {path}")
+        if "/inference/" in path:
+            if response and response.status_code == 200:
+                self.inference_stats.record_success()
+            else:
+                self.inference_stats.record_failure()
         if response and response.status_code == 200:
             return response.json()
         return None

--- a/src/agent/sandbox_executor.py
+++ b/src/agent/sandbox_executor.py
@@ -35,6 +35,8 @@ class ProblemResult:
     error: Optional[str] = None
     execution_time: float = 0.0
     problem_id: Optional[str] = None  # UUID or identifier from problem metadata
+    inference_failure_count: int = 0
+    inference_total: int = 0
 
 
 def load_problems(problem_file: str) -> List[Dict]:
@@ -140,10 +142,31 @@ def _load_agent(agent_file: Optional[str] = None) -> Callable:
     return agent_main
 
 
+def _read_inference_stats(path: str, problem_id: str) -> tuple:
+    """Read inference stats for a problem from the shared JSONL file.
+
+    Each line is a JSON object with problem_id, inference_success, inference_failed, inference_total.
+    Returns (failure_count, total) for the matching problem_id.
+    """
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                entry = json.loads(line)
+                if str(entry.get("problem_id")) == str(problem_id):
+                    return entry.get("inference_failed", 0), entry.get("inference_total", 0)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        pass
+    return 0, 0
+
+
 def _run_in_process(
     problem: Dict,
     agent_file: Optional[str],
     result_queue: multiprocessing.Queue,
+    stats_file: Optional[str] = None,
 ) -> None:
     """Target function executed in a child process.
 
@@ -151,6 +174,8 @@ def _run_in_process(
     *result_queue*.  Any exception is caught and sent back as an error string
     so the parent never blocks on a dead queue.
     """
+    if stats_file:
+        os.environ["INFERENCE_STATS_FILE"] = stats_file
     os.environ["PROBLEM_DATA"] = json.dumps(problem)
     try:
         agent_fn = _load_agent(agent_file)
@@ -184,10 +209,15 @@ def execute_single_problem(
     problem_id = problem.get("problem_id") or problem.get("id")
     start_time = time.time()
 
+    # All processes append to a shared JSONL file alongside output.jsonl.
+    # Each line includes problem_id so the reader can match.
+    output_file = os.environ.get("SANDBOX_OUTPUT_FILE", "")
+    output_dir = os.path.dirname(output_file) if output_file else "/tmp"
+    stats_file = os.path.join(output_dir, "inference_stats.jsonl")
     result_queue: multiprocessing.Queue = multiprocessing.Queue()
     process = multiprocessing.Process(
         target=_run_in_process,
-        args=(problem, agent_file, result_queue),
+        args=(problem, agent_file, result_queue, stats_file),
     )
     process.start()
     process.join(timeout=timeout)
@@ -202,6 +232,7 @@ def execute_single_problem(
         if process.is_alive():
             process.kill()
             process.join()
+        inf_failures, inf_total = _read_inference_stats(stats_file, str(problem_id))
         result_queue.close()
         return ProblemResult(
             query=query,
@@ -209,8 +240,11 @@ def execute_single_problem(
             error=f"Execution exceeded timeout of {timeout}s",
             execution_time=execution_time,
             problem_id=problem_id,
+            inference_failure_count=inf_failures,
+            inference_total=inf_total,
         )
 
+    inf_failures, inf_total = _read_inference_stats(stats_file, str(problem_id))
     try:
         if not result_queue.empty():
             status, data = result_queue.get_nowait()
@@ -221,6 +255,8 @@ def execute_single_problem(
                     result=data,
                     execution_time=execution_time,
                     problem_id=problem_id,
+                    inference_failure_count=inf_failures,
+                    inference_total=inf_total,
                 )
             return ProblemResult(
                 query=query,
@@ -228,6 +264,8 @@ def execute_single_problem(
                 error=data,
                 execution_time=execution_time,
                 problem_id=problem_id,
+                inference_failure_count=inf_failures,
+                inference_total=inf_total,
             )
         return ProblemResult(
             query=query,
@@ -235,6 +273,8 @@ def execute_single_problem(
             error=f"Process exited with code {process.exitcode} but produced no result",
             execution_time=execution_time,
             problem_id=problem_id,
+            inference_failure_count=inf_failures,
+            inference_total=inf_total,
         )
     finally:
         result_queue.close()

--- a/subnet/tests/test_proxy_client.py
+++ b/subnet/tests/test_proxy_client.py
@@ -1,9 +1,12 @@
-"""Tests for proxy_client Authorization header injection."""
+"""Tests for proxy_client Authorization header injection and inference stats."""
 
+import json
+import os
+import tempfile
 from unittest.mock import patch, MagicMock
 
 
-from src.agent.proxy_client import ProxyClient
+from src.agent.proxy_client import InferenceStats, ProxyClient
 
 
 class TestProxyClientAuth:
@@ -54,3 +57,54 @@ class TestProxyClientAuth:
         with patch.dict("os.environ", {"CHUTES_ACCESS_TOKEN": "env-token"}):
             client = ProxyClient(proxy_url="http://proxy:80", api_key="explicit")
             assert client.api_key == "explicit"
+
+
+class TestInferenceStats:
+    def test_to_dict(self):
+        stats = InferenceStats()
+        stats.record_success()
+        stats.record_success()
+        stats.record_failure()
+        assert stats.to_dict() == {
+            "inference_success": 2,
+            "inference_failed": 1,
+            "inference_total": 3,
+        }
+
+    def test_append_to_file(self):
+        stats = InferenceStats()
+        stats.record_success()
+        stats.record_failure()
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
+            path = f.name
+        try:
+            with patch.dict("os.environ", {"PROBLEM_DATA": '{"problem_id": "p-123"}'}):
+                stats.append_to_file(path)
+            with open(path) as f:
+                entry = json.loads(f.readline())
+            assert entry["problem_id"] == "p-123"
+            assert entry["inference_success"] == 1
+            assert entry["inference_failed"] == 1
+            assert entry["inference_total"] == 2
+        finally:
+            os.unlink(path)
+
+    def test_append_multiple_problems(self):
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
+            path = f.name
+        try:
+            for pid, successes, failures in [("a", 3, 1), ("b", 0, 2)]:
+                stats = InferenceStats()
+                for _ in range(successes):
+                    stats.record_success()
+                for _ in range(failures):
+                    stats.record_failure()
+                with patch.dict("os.environ", {"PROBLEM_DATA": json.dumps({"problem_id": pid})}):
+                    stats.append_to_file(path)
+            with open(path) as f:
+                lines = [json.loads(line) for line in f if line.strip()]
+            assert len(lines) == 2
+            assert lines[0]["problem_id"] == "a"
+            assert lines[1]["problem_id"] == "b"
+        finally:
+            os.unlink(path)

--- a/subnet/tests/test_sandbox_executor.py
+++ b/subnet/tests/test_sandbox_executor.py
@@ -1,9 +1,12 @@
 """Tests for process-based timeout enforcement in sandbox_executor."""
 
+import json
+import os
+import tempfile
 import time
 from pathlib import Path
 
-from src.agent.sandbox_executor import execute_single_problem
+from src.agent.sandbox_executor import execute_single_problem, _read_inference_stats
 
 FIXTURES = Path(__file__).parent / "fixtures"
 FAST = str(FIXTURES / "fast_agent.py")
@@ -40,3 +43,33 @@ def test_missing_agent_file():
         {"query": "x"}, timeout=10.0, agent_file="/tmp/no_such_agent.py"
     )
     assert not result.success
+
+
+class TestReadInferenceStats:
+    def test_reads_matching_problem(self):
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False, mode="w") as f:
+            f.write(json.dumps({"problem_id": "p1", "inference_failed": 2, "inference_total": 8}) + "\n")
+            f.write(json.dumps({"problem_id": "p2", "inference_failed": 0, "inference_total": 5}) + "\n")
+            path = f.name
+        try:
+            failures, total = _read_inference_stats(path, "p1")
+            assert failures == 2
+            assert total == 8
+        finally:
+            os.unlink(path)
+
+    def test_missing_problem_returns_zeros(self):
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False, mode="w") as f:
+            f.write(json.dumps({"problem_id": "p1", "inference_failed": 1, "inference_total": 3}) + "\n")
+            path = f.name
+        try:
+            failures, total = _read_inference_stats(path, "p99")
+            assert failures == 0
+            assert total == 0
+        finally:
+            os.unlink(path)
+
+    def test_missing_file_returns_zeros(self):
+        failures, total = _read_inference_stats("/tmp/nonexistent.jsonl", "p1")
+        assert failures == 0
+        assert total == 0

--- a/subnet/validator/progress_reporter.py
+++ b/subnet/validator/progress_reporter.py
@@ -101,9 +101,14 @@ class ProgressReporter:
             os.chdir(str(self.workspace_dir))
 
             # Add workspace to path so we can import ShoppingBench modules
-            sys.path.insert(0, str(self.workspace_dir / "src" / "agent"))
+            scorer_path = str(self.workspace_dir / "src" / "agent")
+            if scorer_path not in sys.path:
+                sys.path.insert(0, scorer_path)
 
-            from problem_scorer import ProblemScorer
+            from problem_scorer import ProblemScorer, clear_product_cache
+
+            # Clear product cache from previous evaluation runs
+            clear_product_cache()
 
             # Group rewards and vouchers by category
             category_rewards: Dict[str, Dict] = {}
@@ -256,6 +261,26 @@ class ProgressReporter:
             return ProblemStatus.SUCCESS
         return ProblemStatus.FAILED
 
+    def _read_inference_stats(self, problem_id: str) -> tuple[int, int]:
+        """Read inference stats for a problem from the shared JSONL file.
+
+        ProxyClient appends one line per problem to inference_stats.jsonl
+        in the same directory as the output file. Returns (failure_count, total).
+        """
+        stats_path = self.output_file.parent / "inference_stats.jsonl"
+        try:
+            with open(stats_path) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    entry = json.loads(line)
+                    if str(entry.get("problem_id")) == str(problem_id):
+                        return entry.get("inference_failed", 0), entry.get("inference_total", 0)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            pass
+        return 0, 0
+
     def _process_line(self, line: str) -> Optional[ProblemProgressUpdate]:
         """Parse a dialogue entry from sandbox output and score it.
 
@@ -339,13 +364,25 @@ class ProgressReporter:
             if self._completed_count == self._total_problems:
                 self._compute_aggregate()
 
-            return ProblemProgressUpdate(
+            # Read inference stats from sidecar file written by ProxyClient
+            inf_failures, inf_total = self._read_inference_stats(problem_id)
+
+            update = ProblemProgressUpdate(
                 problem_id=UUID(problem_id)
                 if isinstance(problem_id, str)
                 else problem_id,
                 status=status,
                 score=score,
             )
+            # Add inference stats to score_components_summary (Backend stores all JSONB fields)
+            if inf_total > 0:
+                from oro_sdk.models import ProblemProgressUpdateScoreComponentsSummaryType0
+                summary = ProblemProgressUpdateScoreComponentsSummaryType0.from_dict({
+                    "inference_failure_count": inf_failures,
+                    "inference_total": inf_total,
+                })
+                update.score_components_summary = summary
+            return update
 
         except json.JSONDecodeError:
             logging.warning(f"Failed to parse dialogue line: {line[:100]}...")
@@ -471,9 +508,7 @@ class ProgressReporter:
         if not unscored_ids:
             return
 
-        logging.info(
-            f"Reporting {len(unscored_ids)} unscored problems as TIMED_OUT"
-        )
+        logging.info(f"Reporting {len(unscored_ids)} unscored problems as TIMED_OUT")
         for problem_id_str in unscored_ids:
             try:
                 from uuid import UUID
@@ -541,7 +576,4 @@ class ProgressReporter:
             )
         except Exception as e:
             self._failed_reports.append(progress)
-            logging.warning(
-                f"Failed to report progress for {progress.problem_id}: {e}"
-            )
-
+            logging.warning(f"Failed to report progress for {progress.problem_id}: {e}")


### PR DESCRIPTION
## Description

Cherry-pick of ShoppingBench#81. Tracks inference call success/failure per problem using validator-controlled infrastructure.

## Changes Made

- `InferenceStats` in `ProxyClient` tracks calls, appends to shared `inference_stats.jsonl` via `atexit`
- Sandbox executor sets `INFERENCE_STATS_FILE` per child process, reads stats by `problem_id`
- `ProgressReporter` reads JSONL to include stats in progress updates

## Issue Link

- Related to: ORO-509

## Checklist

- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes