### PR TITLE
sync: cherry-pick fixes from ShoppingBench (ORO-544, ORO-552, ORO-583)

### DIFF
--- a/src/agent/problem_scorer.py
+++ b/src/agent/problem_scorer.py
@@ -77,6 +77,10 @@ FIELDS = ["title", "price", "service", "sku & attrs"]
 
 VALID_TASKS = ["product", "shop", "voucher"]
 
+# Multiplier applied to per-step format score when extra_info.timestamp is missing.
+# 1.0 = no penalty, 0.0 = full penalty. Tunable at launch.
+TIMESTAMP_MISSING_PENALTY = 0.5
+
 
 class ProblemScorer:
     """Scores individual shopping benchmark problems independently.
@@ -145,18 +149,23 @@ class ProblemScorer:
         length_score = length_reward(output)
         score["length"] = length_score
 
-        # Format score
+        # Format score (includes timestamp presence penalty)
         format_score = 0
         if model != "human":
             for step in output:
                 try:
                     message = Message.from_dict(step["completion"]["message"])
                     completion = message.to_string(OUTPUT_ROLES)
-                    format_score += (
+                    step_format = (
                         format_reward(completion)
                         if mode == "think"
                         else format_reward(completion, ["tool_call"])
                     )
+                    # Penalize steps missing a valid timestamp in extra_info
+                    ts = step.get("extra_info", {}).get("timestamp")
+                    if not isinstance(ts, (int, float)) or ts <= 0:
+                        step_format *= TIMESTAMP_MISSING_PENALTY
+                    format_score += step_format
                 except (KeyError, TypeError, AttributeError) as e:
                     logging.warning(
                         "Malformed output step during format scoring: %s", e

--- a/src/agent/problem_scorer.py
+++ b/src/agent/problem_scorer.py
@@ -9,6 +9,7 @@ for local Java/Pyserini installation.
 
 import os
 import logging
+
 try:
     import ujson as json
 except ImportError:
@@ -31,6 +32,11 @@ SEARCH_SERVER_URL = os.getenv("SEARCH_SERVER_URL", "http://localhost:5632")
 
 # Cache for product lookups to avoid repeated HTTP calls
 _product_cache: dict[str, Optional[dict]] = {}
+
+
+def clear_product_cache() -> None:
+    """Clear the product cache between evaluation runs to prevent unbounded growth."""
+    _product_cache.clear()
 
 
 def get_product(product_id: str) -> Optional[dict]:
@@ -152,7 +158,9 @@ class ProblemScorer:
                         else format_reward(completion, ["tool_call"])
                     )
                 except (KeyError, TypeError, AttributeError) as e:
-                    logging.warning("Malformed output step during format scoring: %s", e)
+                    logging.warning(
+                        "Malformed output step during format scoring: %s", e
+                    )
                     continue
         format_score = format_score / len(output) if output else 0
         score["format"] = format_score
@@ -185,7 +193,9 @@ class ProblemScorer:
                         if command["name"] == "recommend_product":
                             product_ids = command["parameters"].get("product_ids", "")
             except (KeyError, TypeError, AttributeError) as e:
-                logging.warning("Malformed output step during product extraction: %s", e)
+                logging.warning(
+                    "Malformed output step during product extraction: %s", e
+                )
                 continue
 
         if not isinstance(product_ids, str):

--- a/subnet/tests/test_timestamp_scoring.py
+++ b/subnet/tests/test_timestamp_scoring.py
@@ -1,0 +1,51 @@
+"""Tests for timestamp penalty in format scoring."""
+
+import pytest
+from unittest.mock import patch
+from src.agent.problem_scorer import ProblemScorer, TIMESTAMP_MISSING_PENALTY
+
+PENALTY = TIMESTAMP_MISSING_PENALTY
+
+
+def _make_step(timestamp=None):
+    """Build a minimal step dict with valid format tags."""
+    step = {
+        "completion": {
+            "message": {
+                "think": "reasoning",
+                "tool_call": [{"name": "find_product", "parameters": {"q": "test"}}],
+                "response": "answer",
+            },
+        },
+        "extra_info": {"step": 1},
+    }
+    if timestamp is not None:
+        step["extra_info"]["timestamp"] = timestamp
+    return step
+
+
+def _score_format(steps):
+    """Score format for a list of steps, mocking out product lookup."""
+    with patch("src.agent.problem_scorer.get_product", return_value=None):
+        scorer = ProblemScorer("product", {"q": {}}, {})
+        return scorer.score_problem("q", steps)["format"]
+
+
+@pytest.mark.parametrize("timestamp,expected", [
+    (1711234567000, 1.0),
+    (1711234567.0, 1.0),
+    (None, PENALTY),
+    ("not a number", PENALTY),
+    (0, PENALTY),
+    (-1, PENALTY),
+], ids=["valid_int", "valid_float", "missing", "wrong_type", "zero", "negative"])
+def test_single_step_timestamp_scoring(timestamp, expected):
+    assert _score_format([_make_step(timestamp=timestamp)]) == expected
+
+
+def test_mixed_steps_average_correctly():
+    steps = [
+        _make_step(timestamp=1711234567000),
+        _make_step(timestamp=None),
+    ]
+    assert _score_format(steps) == (1.0 + PENALTY) / 2

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -17,7 +17,6 @@ from bittensor_wallet import Wallet
 from oro_sdk.models.terminal_status import TerminalStatus
 from oro_sdk.models.claim_work_response import ClaimWorkResponse
 from oro_sdk.models.problem_progress_update import ProblemProgressUpdate
-from oro_sdk.models.problem_status import ProblemStatus
 from oro_sdk.types import Unset
 from .backend_client import BackendClient, BackendError
 from .heartbeat_manager import HeartbeatManager
@@ -698,7 +697,9 @@ class Validator:
             logging.info(f"Aggregate score from ProgressReporter: {score:.4f}")
 
             # Step 5: Upload logs
-            results_s3_key = self._upload_logs(eval_run_id, output_file, problem_ids)
+            results_s3_key = self._upload_logs(
+                eval_run_id, output_file, problem_ids, progress_reporter
+            )
 
             # Step 6: Complete the run
             self._complete_run(
@@ -729,7 +730,11 @@ class Validator:
                     pass
 
     def _upload_logs(
-        self, eval_run_id: UUID, output_file: Path, problem_ids: list[UUID]
+        self,
+        eval_run_id: UUID,
+        output_file: Path,
+        problem_ids: list[UUID],
+        progress_reporter: "ProgressReporter",
     ) -> str:
         """Upload per-problem evaluation logs to S3.
 
@@ -745,6 +750,7 @@ class Validator:
             eval_run_id: The evaluation run ID (UUID).
             output_file: Path to the output JSONL file.
             problem_ids: List of problem UUIDs from the suite.
+            progress_reporter: ProgressReporter with per-problem scoring results.
 
         Returns:
             S3 key of the last successfully uploaded log (stored on the run).
@@ -820,7 +826,7 @@ class Validator:
                 progress_updates = [
                     ProblemProgressUpdate(
                         problem_id=pid,
-                        status=ProblemStatus.SUCCESS,
+                        status=progress_reporter.get_problem_status(str(pid)),
                         logs_s3_key=s3_key,
                     )
                     for pid, s3_key in uploaded_keys.items()


### PR DESCRIPTION
## Description

Cherry-pick 3 commits from ShoppingBench that were missing in oro-public.

## Changes Made

- `a1a2439` Fix _upload_logs overwriting problem statuses to SUCCESS (ORO-544)
- `e6e7b63` Clear product cache between evaluation runs (ORO-552)
- `d1e1891` Penalize missing timestamps in format score (ORO-583)

## Issue Link

- Related to: ORO-544, ORO-552, ORO-583

## Checklist

- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes