### PR TITLE
fix: increase nginx subrequest_output_buffer_size to 256k (ORO-614)

### DIFF
--- a/docker/proxy/nginx.conf.template
+++ b/docker/proxy/nginx.conf.template
@@ -9,6 +9,9 @@ http {
     # Limit request body size (prevents memory exhaustion from oversized payloads)
     client_max_body_size 10m;
 
+    # Allow large LLM responses through njs subrequests (default 4KB is too small)
+    subrequest_output_buffer_size 256k;
+
     # Rate limiting zone: 30 requests/second per client IP
     limit_req_zone $binary_remote_addr zone=agent:10m rate=30r/s;
 


### PR DESCRIPTION
## Description
Increase the nginx `subrequest_output_buffer_size` from the default 4KB to 256KB in the proxy config. Large LLM responses (e.g. from Kimi) were being silently dropped by nginx because the njs subrequest handler buffers the full response before forwarding.

## Changes Made
- Added `subrequest_output_buffer_size 256k;` to the `http` block in `docker/proxy/nginx.conf.template`

## Issue Link
- Closes: ORO-614

## Testing

### Manual Testing
Reported by miner Dustin in SN15 Discord. One-line nginx config change.

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)