### PR TITLE
fix: include response body in validator error messages

### DIFF
--- a/subnet/validator/backend_client.py
+++ b/subnet/validator/backend_client.py
@@ -217,10 +217,15 @@ class BackendClient:
                 status_code=status,
             )
 
-        # Error cases - extract detail from parsed error
-        detail = f"HTTP {status}"
+        # Error cases - extract detail from parsed error, fall back to body
+        detail = None
         if response.parsed is not None and hasattr(response.parsed, "detail"):
             detail = response.parsed.detail
+        elif hasattr(response, "content") and response.content:
+            body = response.content[:500].decode("utf-8", errors="replace")
+            detail = f"HTTP {status}: {body}"
+        if not detail:
+            detail = f"HTTP {status}"
 
         raise BackendError(
             f"{operation}: {detail}",
@@ -258,8 +263,11 @@ class BackendClient:
         except httpx.ConnectError as e:
             raise BackendError(f"{operation}: Connection error: {e}")
         except sdk_errors.UnexpectedStatus as e:
+            body = ""
+            if hasattr(e, "content") and e.content:
+                body = f": {e.content[:500].decode('utf-8', errors='replace')}"
             raise BackendError(
-                f"{operation}: Unexpected status {e.status_code}",
+                f"{operation}: Unexpected status {e.status_code}{body}",
                 status_code=e.status_code,
             )
 


### PR DESCRIPTION
## Description

Validator error logs only show the HTTP status code when the SDK's parsed error detail isn't available (e.g., `"HTTP 503"` instead of the actual error message). This makes it hard for operators to diagnose issues.

## Changes Made

- `_handle_response` falls back to raw response body (truncated to 500 chars) when `parsed.detail` is unavailable
- `_call_api` extracts response body from `UnexpectedStatus` exceptions

## Testing

Tested against staging with real API calls and mock responses covering all fallback paths.

```bash
ruff check . && python3.11 -m pytest tests/
```

38 passed, 5 skipped.

## Checklist

- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)