### PR TITLE
fix: sanitize null bytes from agent output (ORO-633)

### DIFF
--- a/subnet/validator/progress_reporter.py
+++ b/subnet/validator/progress_reporter.py
@@ -321,6 +321,10 @@ class ProgressReporter:
         if not self._scorers:
             return
 
+        # Sanitize null bytes — agents can produce \x00 in output which
+        # PostgreSQL rejects with CharacterNotInRepertoireError
+        line = line.replace("\x00", "")
+
         try:
             dialogue = json.loads(line.strip())
             if not isinstance(dialogue, list) or not dialogue:


### PR DESCRIPTION
## Description

Agents can produce null bytes (\x00) in their output during evaluation, which PostgreSQL rejects. Strip them before JSON parsing or backend calls.

## Changes Made

- Added `line = line.replace("\x00", "")` in `_score_and_report()` entry point

## Issue Link

- Closes: ORO-633

## Testing

### Automated Testing
14/14 progress reporter tests pass.

## Checklist

- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)