### PR TITLE
fix: default inference stats path for Docker sandbox

### DIFF
--- a/src/agent/proxy_client.py
+++ b/src/agent/proxy_client.py
@@ -98,9 +98,10 @@ class ProxyClient:
         self.retry_delay = retry_delay
         self.api_key = api_key or os.getenv("CHUTES_ACCESS_TOKEN")
         self.inference_stats = InferenceStats()
-        stats_file = os.environ.get("INFERENCE_STATS_FILE")
-        if stats_file:
-            atexit.register(self.inference_stats.append_to_file, stats_file)
+        stats_file = os.environ.get(
+            "INFERENCE_STATS_FILE", "/app/logs/inference_stats.jsonl"
+        )
+        atexit.register(self.inference_stats.append_to_file, stats_file)
 
     def _build_url(self, path: str, params: Optional[Dict] = None) -> str:
         """


### PR DESCRIPTION
## Description

Inference stats (`inference_failure_count`, `inference_total`) were always `null` in evaluation results because the `INFERENCE_STATS_FILE` env var was never passed to Docker sandbox containers. The `ProxyClient` only wrote stats when the env var was explicitly set.

Fix: default to `/app/logs/inference_stats.jsonl` (inside the already-mounted logs volume) so stats are always written. The progress reporter already reads from this path.

## Changes Made

- `src/agent/proxy_client.py`: Default `INFERENCE_STATS_FILE` to `/app/logs/inference_stats.jsonl` instead of requiring the env var

## Testing

38 passed, 5 skipped.

```bash
ruff check . && python3.11 -m pytest tests/
```

## Checklist

- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)