### PR TITLE
fix: precomputed embeddings scoring for all problem types

### DIFF
--- a/src/agent/rewards/orm.py
+++ b/src/agent/rewards/orm.py
@@ -37,14 +37,23 @@ def rule_score_reward(product: dict, reward: dict) -> tuple[float, Counter, Coun
 
     is_ground_truth = ground_truth_reward(product, reward) == 1
 
-    # title
+    # title — use precomputed embeddings if available, otherwise encode both
     model = _get_sentence_model()
-    if "title" in reward and model is not None:
+    precomputed = reward.get("_title_embeddings", {})
+    if "title" in reward and (model is not None or precomputed):
         for title in reward["title"]:
-            sentences = [product["title"], title]
-            embeddings = model.encode(sentences)
-            similarities = model.similarity(embeddings, embeddings)
-            sim = similarities[0][1]
+            if title in precomputed and model is not None:
+                # Only encode the agent's product title; reuse cached GT embedding
+                product_emb = model.encode([product["title"]])
+                gt_emb = [precomputed[title]]
+            elif model is not None:
+                # Fallback: encode both
+                both = model.encode([product["title"], title])
+                product_emb = [both[0]]
+                gt_emb = [both[1]]
+            else:
+                continue
+            sim = model.similarity(product_emb, gt_emb)[0][0]
             total_count += 1
             total_counter["title"] += 1
             if sim >= 0.7:

--- a/subnet/sandbox.py
+++ b/subnet/sandbox.py
@@ -75,6 +75,22 @@ def load_problems(problem_path: Path) -> list[dict]:
     return problems
 
 
+def attach_title_embeddings(reward, title_embeddings) -> None:
+    """Attach precomputed title embeddings to reward dict(s) in-place.
+
+    Rewards can be a single dict (Product) or a list of dicts (Shop/Voucher).
+    Modifies the reward structure directly — no return value.
+    """
+    if not title_embeddings:
+        return
+    if isinstance(reward, dict):
+        reward["_title_embeddings"] = title_embeddings
+    elif isinstance(reward, list):
+        for item in reward:
+            if isinstance(item, dict):
+                item["_title_embeddings"] = title_embeddings
+
+
 def build_sandbox_command(
     *,
     agent_host_path: str,

--- a/subnet/test_runner.py
+++ b/subnet/test_runner.py
@@ -30,6 +30,7 @@ from subnet.sandbox import (  # noqa: E402
     host_path,
     load_problems,
     build_sandbox_command,
+    attach_title_embeddings,
 )
 
 # Default test problem file — problem suite v1 (90 problems)
@@ -59,10 +60,8 @@ def _score_output(output_file: Path, problems: list[dict]) -> float:
         reward = p.get("reward")
         category = p.get("category", "Product").lower()
         if query and reward:
-            # Attach precomputed title embeddings to the reward dict if available
-            title_embeddings = p.get("reward_title_embeddings")
-            if title_embeddings:
-                reward["_title_embeddings"] = title_embeddings
+            # Attach precomputed title embeddings to the reward dict(s)
+            attach_title_embeddings(reward, p.get("reward_title_embeddings"))
             rewards[query] = reward
             task_for_query[query] = category
             voucher = p.get("voucher")

--- a/subnet/test_runner.py
+++ b/subnet/test_runner.py
@@ -59,6 +59,10 @@ def _score_output(output_file: Path, problems: list[dict]) -> float:
         reward = p.get("reward")
         category = p.get("category", "Product").lower()
         if query and reward:
+            # Attach precomputed title embeddings to the reward dict if available
+            title_embeddings = p.get("reward_title_embeddings")
+            if title_embeddings:
+                reward["_title_embeddings"] = title_embeddings
             rewards[query] = reward
             task_for_query[query] = category
             voucher = p.get("voucher")

--- a/subnet/tests/test_sandbox.py
+++ b/subnet/tests/test_sandbox.py
@@ -5,7 +5,7 @@ import os
 from unittest import mock
 
 
-from subnet.sandbox import host_path, load_problems, build_sandbox_command
+from subnet.sandbox import host_path, load_problems, build_sandbox_command, attach_title_embeddings
 
 
 # ---------------------------------------------------------------------------
@@ -238,3 +238,47 @@ class TestBuildSandboxCommand:
         # Writable /tmp with noexec (Python tempfile needs /tmp)
         tmpfs_idx = cmd.index("--tmpfs")
         assert "/tmp:rw,noexec,nosuid,size=256m" in cmd[tmpfs_idx + 1]
+
+
+# ---------------------------------------------------------------------------
+# attach_title_embeddings()
+# ---------------------------------------------------------------------------
+
+
+class TestAttachTitleEmbeddings:
+    """Tests for attach_title_embeddings() shared utility."""
+
+    def test_dict_reward_gets_embeddings(self):
+        reward = {"product_id": "123", "title": "Test"}
+        embeddings = [0.1, 0.2, 0.3]
+        attach_title_embeddings(reward, embeddings)
+        assert reward["_title_embeddings"] == [0.1, 0.2, 0.3]
+
+    def test_list_reward_all_dicts_get_embeddings(self):
+        reward = [{"product_id": "1"}, {"product_id": "2"}]
+        embeddings = [0.4, 0.5]
+        attach_title_embeddings(reward, embeddings)
+        assert reward[0]["_title_embeddings"] == [0.4, 0.5]
+        assert reward[1]["_title_embeddings"] == [0.4, 0.5]
+
+    def test_list_reward_skips_non_dict_items(self):
+        reward = [{"product_id": "1"}, "not-a-dict", None]
+        embeddings = [0.1]
+        attach_title_embeddings(reward, embeddings)
+        assert reward[0]["_title_embeddings"] == [0.1]
+        assert reward[1] == "not-a-dict"
+
+    def test_none_embeddings_is_noop(self):
+        reward = {"product_id": "123"}
+        attach_title_embeddings(reward, None)
+        assert "_title_embeddings" not in reward
+
+    def test_empty_list_embeddings_is_noop(self):
+        reward = {"product_id": "123"}
+        attach_title_embeddings(reward, [])
+        assert "_title_embeddings" not in reward
+
+    def test_non_dict_non_list_reward_is_noop(self):
+        reward = "just-a-string"
+        attach_title_embeddings(reward, [0.1, 0.2])
+        # No crash, no mutation possible on a string

--- a/subnet/validator/backend_client.py
+++ b/subnet/validator/backend_client.py
@@ -526,7 +526,8 @@ class BackendClient:
         try:
             # Use public client (no auth required)
             response = self._public_client.get_httpx_client().get(
-                f"/v1/public/suites/{suite_id}/problems"
+                f"/v1/public/suites/{suite_id}/problems",
+                params={"include_embeddings": "true"},
             )
 
             if response.status_code == 200:

--- a/subnet/validator/progress_reporter.py
+++ b/subnet/validator/progress_reporter.py
@@ -23,6 +23,7 @@ from oro_sdk.models import ProblemProgressUpdate, ProblemStatus
 from bittensor.utils.btlogging import logging
 
 from src.agent.scoring import is_problem_successful, compute_aggregate
+from subnet.sandbox import attach_title_embeddings
 from .backend_client import BackendClient
 
 if TYPE_CHECKING:
@@ -118,14 +119,7 @@ class ProgressReporter:
                     category = "product"
 
                 if query and reward:
-                    title_embeddings = problem.get("reward_title_embeddings")
-                    if title_embeddings:
-                        if isinstance(reward, dict):
-                            reward["_title_embeddings"] = title_embeddings
-                        elif isinstance(reward, list):
-                            for item in reward:
-                                if isinstance(item, dict):
-                                    item["_title_embeddings"] = title_embeddings
+                    attach_title_embeddings(reward, problem.get("reward_title_embeddings"))
                     category_rewards.setdefault(category, {})[query] = reward
 
                 if category == "voucher":


### PR DESCRIPTION
## Description

Fix precomputed ground truth embeddings handling to support all problem categories (Product, Shop, Voucher). The existing code assumed rewards are always dicts, but Shop/Voucher rewards are lists of dicts — causing a TypeError crash when embeddings are present.

Also extracts the duplicated embedding attachment logic into a shared utility so both `test_runner` and `progress_reporter` use the same code path.

## Changes Made

- Fix `test_runner._score_output()` to handle list rewards (Shop/Voucher) when attaching `_title_embeddings`
- Extract `attach_title_embeddings()` into `subnet/sandbox.py` as a shared utility
- Update `progress_reporter._initialize_scorers()` to use the shared utility (was duplicating the same logic)
- Add 6 unit tests covering dict rewards, list rewards, edge cases (None, empty, non-dict items)

## Issue Link

- Closes: ORO-596

## Testing

### Manual Testing
- Built local Docker images with the fix
- Ran test suite with one Product, one Shop, and one Voucher problem — all with precomputed embeddings from staging API
- Confirmed the `TypeError` crash on list rewards is resolved

### Automated Testing
- 6 new unit tests for `attach_title_embeddings()` covering all code paths

**Test Command(s):**
```bash
uv run pytest subnet/tests/test_sandbox.py -v
```

**Test Results:**
27 passed (21 existing + 6 new), 0 failed.

## Documentation

- [x] Code comments added/updated
- [ ] README updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
N/A

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)