### PR TITLE
fix: set inference stats as top-level fields on progress update

### DIFF
--- a/subnet/validator/progress_reporter.py
+++ b/subnet/validator/progress_reporter.py
@@ -398,20 +398,9 @@ class ProgressReporter:
                 else problem_id,
                 status=status,
                 score=score,
+                inference_failure_count=inf_failures if inf_total > 0 else None,
+                inference_total=inf_total if inf_total > 0 else None,
             )
-            if inf_total > 0:
-                from oro_sdk.models import (
-                    ProblemProgressUpdateScoreComponentsSummaryType0,
-                )
-
-                update.score_components_summary = (
-                    ProblemProgressUpdateScoreComponentsSummaryType0.from_dict(
-                        {
-                            "inference_failure_count": inf_failures,
-                            "inference_total": inf_total,
-                        }
-                    )
-                )
             self._report_progress(update)
 
         except json.JSONDecodeError:


### PR DESCRIPTION
## Description

Inference stats were being stuffed into `score_components_summary` dict instead of set as the top-level `inference_failure_count` and `inference_total` fields on `ProblemProgressUpdate`. The backend stores these as top-level fields, so the data was never populated.

## Changes Made

- `subnet/validator/progress_reporter.py`: Set `inference_failure_count` and `inference_total` directly on `ProblemProgressUpdate` constructor instead of nesting in `score_components_summary`

## Testing

38 passed, 5 skipped.

## Checklist

- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)