### PR TITLE
fix: validator digest reporting after Watchtower recreation

### DIFF
--- a/subnet/validator/version_collector.py
+++ b/subnet/validator/version_collector.py
@@ -19,9 +19,7 @@ SERVICE_CONTAINERS = [
 ]
 
 # Sandbox image to inspect (pulled but not always running)
-SANDBOX_IMAGE = os.environ.get(
-    "SANDBOX_IMAGE", "ghcr.io/oro-ai/oro/sandbox:latest"
-)
+SANDBOX_IMAGE = os.environ.get("SANDBOX_IMAGE", "ghcr.io/oro-ai/oro/sandbox:latest")
 
 # Short name mapping for output keys
 CONTAINER_KEY_MAP = {
@@ -93,17 +91,26 @@ def _get_image_digest(image_name: str) -> Optional[str]:
 def _get_validator_digest() -> Optional[str]:
     """Get the image digest of the validator's own container.
 
-    Inside Docker, the hostname equals the container ID.
+    The hostname does not always match the container ID (e.g. after
+    Watchtower recreates the container). Instead, inspect the validator
+    image directly — it's always available since we're running inside it.
     """
+    for image_ref in [
+        "ghcr.io/oro-ai/oro/validator:stable",
+        "ghcr.io/oro-ai/oro/validator:latest",
+    ]:
+        digest = _get_image_digest(image_ref)
+        if digest:
+            return digest
+
+    # Fallback: try hostname-based lookup (works on some Docker setups)
     container_id = socket.gethostname()
-    if not container_id:
-        return None
+    if container_id:
+        image = _run_docker_inspect(container_id, "{{.Config.Image}}")
+        if image:
+            return _get_image_digest(image)
 
-    # Get the image used by this container, then its digest
-    image = _run_docker_inspect(container_id, "{{.Config.Image}}")
-    if image:
-        return _get_image_digest(image)
-
+    logger.warning("Could not determine validator digest")
     return None
 
 


### PR DESCRIPTION
## Description

Validator stopped reporting its own image digest in `service_versions` after Watchtower recreated the container. The hostname-based container ID lookup fails because the hostname retains the old container ID which Docker can't resolve.

Fix: inspect the validator image (`ghcr.io/oro-ai/oro/validator:stable`) directly instead of trying to resolve the container by hostname. The image is always available since we're running inside it.

## Root cause

```
hostname inside container: c73223bdf6bb
actual container ID:       7c33eba52373
docker inspect c73223bdf6bb → "No such object"
docker inspect ghcr.io/oro-ai/oro/validator:stable → works
```

## Testing

53 passed, 5 skipped.

## Checklist

- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)