### PR TITLE
fix: increase scoring timeout from 5 to 15 minutes (ORO-669)

### DIFF
--- a/subnet/validator/progress_reporter.py
+++ b/subnet/validator/progress_reporter.py
@@ -60,7 +60,7 @@ class ProgressReporter:
         workspace_dir: Path,
         poll_interval: float = 1.0,
         retry_queue: Optional["LocalRetryQueue"] = None,
-        scoring_timeout: float = 300.0,
+        scoring_timeout: float = 900.0,
     ):
         self.backend_client = backend_client
         self.eval_run_id = eval_run_id


### PR DESCRIPTION
## Description

Per-problem scoring on some validators takes 10-32 seconds due to `get_product` HTTP calls to the search-server and embedding model encode. At 17s average, 30 problems takes ~8.5 minutes — exceeding the 5-minute scoring timeout. This caused incomplete scoring and wrong aggregate scores on Yuma and TAO.com validators.

Evidence from production data: Yuma's progress updates for agent `069d0035` show 14 problems reported at completion time, then 16 more arriving over the next 4.3 minutes with 10-32 second gaps between each.

## Changes Made

- Increased `scoring_timeout` default from 300s (5 min) to 900s (15 min)

## Issue Link

- Related to: ORO-669

## Testing

Compiles and lints clean.

**Test Command(s):**
```bash
python3.11 -m py_compile subnet/validator/progress_reporter.py
ruff check subnet/validator/progress_reporter.py
```

## Checklist

- [x] My changes generate no new warnings or errors

## Additional Notes

One-line change. The join timeout (`scoring_timeout + 30`) adjusts automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)