### PR TITLE
fix: CRITICAL — remove data/ volume mount from sandbox (ORO-698)

### DIFF
--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -254,17 +254,15 @@ class Validator:
         # its own agent, problems, and output — not other evaluations' files.
         eval_dir_host = host_path(str(eval_dir), workspace_dir=ws)
 
-        extra_volumes = [
-            (host_path(str(workspace_dir / "data"), workspace_dir=ws), "/app/data"),
-        ]
-
-        # Build docker run command — mount eval dir at /app/eval
+        # Build docker run command — mount eval dir at /app/logs
+        # NOTE: Do NOT mount data/ into the sandbox — it contains the problem
+        # suite with ground truth answers (product_ids). Agents could read it
+        # to cheat. The sandbox only needs the proxy for search/inference.
         cmd = build_sandbox_command(
             agent_host_path="",
             logs_host_path=eval_dir_host,
             problem_file_arg="/app/logs/problems.jsonl",
             output_path="/app/logs/output.jsonl",
-            extra_volumes=extra_volumes,
             chutes_access_token=chutes_access_token,
             agent_container_path="/app/logs/agent.py",
             max_workers=self.config.sandbox_max_workers,


### PR DESCRIPTION
## Description

**CRITICAL SECURITY FIX.** The sandbox container had the entire `data/` directory (including `data/suites/problem_suite_v1.json` with ground truth answers) mounted at `/app/data`. Agents could read the problem suite to extract correct `product_id` values and achieve near-100% scores without solving problems.

## Root Cause

The validator mounted `data/` as an `extra_volume` into the sandbox for convenience, but the sandbox doesn't need it — problems are already written to `/app/logs/problems.jsonl` with reward fields stripped. The `data/` mount gave agents access to the full problem suite including ground truth.

## Active Exploitation

Confirmed by security probe (ORO-693). An active cheating agent (`aaa_top`) exploits this:
1. At load time, walks up from `__file__` to find `/app/data/suites/`
2. Reads `problem_suite_v1.json` and extracts `product_id` from `reward` fields
3. Builds a query → correct answer lookup map
4. Substitutes correct answers in `_finalize_recommendation()` instead of search results

## Fix

Remove the `extra_volumes` mount. One line change. The sandbox accesses search and inference through the proxy — it doesn't need `data/`.

## Testing

- Verified no sandbox code references `/app/data`
- The `problems.jsonl` in `/app/logs/` was already sanitized (reward/voucher stripped at line 581)
- Will re-run security probe agent after deploy to confirm `CHEATING_POSSIBLE=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)