### PR TITLE
fix: pin bittensor_wallet to 4.0.1

### DIFF
--- a/docker/validator/requirements-base.txt
+++ b/docker/validator/requirements-base.txt
@@ -1,5 +1,5 @@
 bittensor==10.1.0
-bittensor_wallet==4.0.2
+bittensor_wallet==4.0.1
 requests==2.32.5
 sentence-transformers==5.3.0
 ujson==5.12.0


### PR DESCRIPTION
Docker image build for v1.0.14 failed because `bittensor_wallet==4.0.2` doesn't exist on PyPI. Latest available is `4.0.1`.