### PR TITLE
fix: remove DeepSeek-V3.1-Terminus-TEE from allowed models

### DIFF
--- a/docker/proxy/allowed_models.json
+++ b/docker/proxy/allowed_models.json
@@ -1,7 +1,6 @@
 [
   "deepseek-ai/DeepSeek-V3.2-TEE",
   "deepseek-ai/DeepSeek-V3.1-TEE",
-  "deepseek-ai/DeepSeek-V3.1-Terminus-TEE",
   "deepseek-ai/DeepSeek-V3-0324-TEE",
   "deepseek-ai/DeepSeek-R1-0528-TEE",
   "Qwen/Qwen3-32B-TEE",


### PR DESCRIPTION
## Description

Remove DeepSeek-V3.1-Terminus-TEE from the proxy allowed models list.

## Changes Made

- Removed `deepseek-ai/DeepSeek-V3.1-Terminus-TEE` from `docker/proxy/allowed_models.json`

## Issue Link

- N/A

## Testing

### Manual Testing
One-line deletion from a static JSON list.

### Automated Testing

N/A

## Documentation

- [x] N/A

## Checklist

- [x] My changes generate no new warnings or errors

## Additional Notes

Corresponding change in Frontend repo (inference-status.tsx).