### PR TITLE
fix: restore reasoning_details in complete_run payload

### DIFF
--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -750,8 +750,7 @@ class Validator:
             aggregate["judge_inference_failed"] = reasoning_result["judge_inference_failed"]
             aggregate["judge_inference_total"] = reasoning_result["judge_inference_total"]
             aggregate["reasoning_scores"] = reasoning_result["reasoning_scores"]
-            # reasoning_details (LLM explanations) uploaded to S3 with trajectories,
-            # not sent in API call to avoid exceeding WAF body size limits.
+            aggregate["reasoning_details"] = reasoning_result["reasoning_details"]
 
             logging.info(
                 f"Score: final={score:.4f} "


### PR DESCRIPTION
## Description

`reasoning_details` (per-problem LLM judge explanations) was accidentally dropped from the `complete_run` payload in v1.0.21. The WAF body size restriction that motivated the removal has been fixed (Infrastructure PR #60).

Without this, the frontend can't show reasoning explanations on the eval run page.

## Changes Made

- Restored `aggregate["reasoning_details"] = reasoning_result["reasoning_details"]`

## Checklist

- [x] One-line fix, no logic change