### PR TITLE
fix: bump oro-sdk to 1.0.36

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ duckduckgo_search==8.1.1
 colorama==0.4.6
 googlesearch-python==1.3.0
 bittensor==10.1.0
-oro-sdk==1.0.1
+oro-sdk==1.0.36


### PR DESCRIPTION
## Description

The validator crashes on `_batch_report()` with `TypeError: ProblemProgressUpdate.__init__() got an unexpected keyword argument 'reasoning_score'` because `oro-sdk==1.0.1` doesn't have the `reasoning_score` or `score_components_summary` fields that ORO-811 added.

## Changes Made

- Bumped `oro-sdk` from `1.0.1` to `1.0.36` in `requirements.txt`

## Issue Link

- N/A (production incident follow-up)

## Testing

### Manual Testing
- Will verify on staging after deploy

## Checklist

- [x] My changes generate no new warnings or errors

## Additional Notes

This is blocking all scoring on staging validators running v1.0.24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)