### PR TITLE
feat: log all proxy API calls in agent trajectories (ORO-772)

### DIFF
--- a/src/agent/proxy_client.py
+++ b/src/agent/proxy_client.py
@@ -19,6 +19,58 @@ DEFAULT_RETRY_DELAY = 2
 DEFAULT_RATE_LIMIT_RETRY_DELAY = 5
 
 
+class RequestLog:
+    """Thread-safe log of all proxy HTTP calls.
+
+    Appends one JSONL entry per request so data survives process kills.
+    """
+
+    def __init__(self, log_file: Optional[str] = None):
+        self._lock = threading.Lock()
+        self._log_file = log_file
+
+    def record(
+        self,
+        method: str,
+        path: str,
+        params: Optional[Dict] = None,
+        json_data: Optional[Dict] = None,
+        status_code: Optional[int] = None,
+        response_body: object = None,
+        duration_ms: float = 0.0,
+    ) -> None:
+        if not self._log_file:
+            return
+        entry = {
+            "method": method,
+            "path": path,
+            "timestamp": int(time.time() * 1000),
+            "duration_ms": round(duration_ms, 1),
+            "status_code": status_code,
+        }
+        if params:
+            entry["params"] = {k: v for k, v in params.items() if v is not None}
+        if json_data:
+            if "/inference/" in path:
+                # Omit large message arrays from inference requests
+                entry["json_data"] = {k: v for k, v in json_data.items() if k != "messages"}
+            else:
+                entry["json_data"] = json_data
+        if response_body is not None:
+            body_str = json.dumps(response_body, default=str)
+            if len(body_str) > 2000:
+                entry["response_truncated"] = True
+                entry["response_length"] = len(body_str)
+            else:
+                entry["response"] = response_body
+        with self._lock:
+            try:
+                with open(self._log_file, "a") as f:
+                    f.write(json.dumps(entry, default=str) + "\n")
+            except OSError:
+                pass
+
+
 class InferenceStats:
     """Thread-safe counter for inference call outcomes.
 
@@ -102,6 +154,8 @@ class ProxyClient:
             "INFERENCE_STATS_FILE", "/app/logs/inference_stats.jsonl"
         )
         self.inference_stats = InferenceStats(stats_file)
+        request_log_file = os.environ.get("REQUEST_LOG_FILE")
+        self.request_log = RequestLog(request_log_file)
 
     def _build_url(self, path: str, params: Optional[Dict] = None) -> str:
         """
@@ -175,40 +229,29 @@ class ProxyClient:
         return None
 
     def get(self, path: str, params: Optional[Dict] = None) -> Optional[Dict]:
-        """
-        Make a GET request to the proxy.
-
-        Args:
-            path: API path
-            params: Query parameters
-
-        Returns:
-            JSON response as dict, or None if request failed
-        """
+        """Make a GET request to the proxy."""
         url = self._build_url(path, params)
 
         def make_request():
             return requests.get(url, timeout=self.timeout)
 
+        t0 = time.monotonic()
         response = self._make_request_with_retries(make_request, f"GET {path}")
-        if response:
-            return response.json()
-        return None
+        duration_ms = (time.monotonic() - t0) * 1000
+        result = response.json() if response else None
+
+        self.request_log.record(
+            method="GET",
+            path=path,
+            params=params,
+            status_code=response.status_code if response else None,
+            response_body=result,
+            duration_ms=duration_ms,
+        )
+        return result
 
     def post(self, path: str, json_data: Optional[Dict] = None) -> Optional[Dict]:
-        """
-        Make a POST request to the proxy.
-
-        Inference requests (paths containing "/inference/") automatically include
-        an Authorization header when an API key is available (CHUTES_ACCESS_TOKEN env var).
-
-        Args:
-            path: API path
-            json_data: JSON data to send in request body
-
-        Returns:
-            JSON response as dict, or None if request failed
-        """
+        """Make a POST request to the proxy."""
         url = self._build_url(path)
         headers: Dict[str, str] = {}
         if self.api_key and "/inference/" in path:
@@ -218,17 +261,30 @@ class ProxyClient:
             response = requests.post(
                 url, json=json_data, headers=headers, timeout=self.timeout
             )
-            # Don't retry on 404 (e.g., model not found)
             if response.status_code == 404:
                 logger.error(f"Resource not found: {path}")
             return response
 
+        t0 = time.monotonic()
         response = self._make_request_with_retries(make_request, f"POST {path}")
+        duration_ms = (time.monotonic() - t0) * 1000
+
         if "/inference/" in path:
             if response and response.status_code == 200:
                 self.inference_stats.record_success()
             else:
                 self.inference_stats.record_failure()
+
+        result = None
         if response and response.status_code == 200:
-            return response.json()
-        return None
+            result = response.json()
+
+        self.request_log.record(
+            method="POST",
+            path=path,
+            json_data=json_data,
+            status_code=response.status_code if response else None,
+            response_body=result,
+            duration_ms=duration_ms,
+        )
+        return result

--- a/src/agent/sandbox_executor.py
+++ b/src/agent/sandbox_executor.py
@@ -26,9 +26,10 @@ class ExecutionResult:
     result: Optional[Dict] = None
     error: Optional[str] = None
     execution_time: float = 0.0
-    problem_id: Optional[str] = None  # UUID or identifier from problem metadata
+    problem_id: Optional[str] = None
     inference_failure_count: int = 0
     inference_total: int = 0
+    proxy_calls: Optional[List[Dict]] = None
 
 
 def load_problems(problem_file: str) -> List[Dict]:
@@ -153,11 +154,26 @@ def _read_inference_stats(path: str, problem_id: str) -> tuple:
     return last_failed, last_total
 
 
+def _read_request_log(path: str) -> List[Dict]:
+    """Read all proxy call entries from the JSONL sidecar file."""
+    entries = []
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    entries.append(json.loads(line))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        pass
+    return entries
+
+
 def _run_in_process(
     problem: Dict,
     agent_file: Optional[str],
     result_queue: multiprocessing.Queue,
     stats_file: Optional[str] = None,
+    request_log_file: Optional[str] = None,
 ) -> None:
     """Target function executed in a child process.
 
@@ -167,6 +183,8 @@ def _run_in_process(
     """
     if stats_file:
         os.environ["INFERENCE_STATS_FILE"] = stats_file
+    if request_log_file:
+        os.environ["REQUEST_LOG_FILE"] = request_log_file
     os.environ["PROBLEM_DATA"] = json.dumps(problem)
     try:
         agent_fn = _load_agent(agent_file)
@@ -205,16 +223,18 @@ def execute_single_problem(
     output_file = os.environ.get("SANDBOX_OUTPUT_FILE", "")
     output_dir = os.path.dirname(output_file) if output_file else "/tmp"
     stats_file = os.path.join(output_dir, "inference_stats.jsonl")
+    request_log_file = os.path.join(output_dir, f"request_log_{problem_id}.jsonl")
     result_queue: multiprocessing.Queue = multiprocessing.Queue()
     process = multiprocessing.Process(
         target=_run_in_process,
-        args=(problem, agent_file, result_queue, stats_file),
+        args=(problem, agent_file, result_queue, stats_file, request_log_file),
     )
     process.start()
     process.join(timeout=timeout)
     execution_time = time.time() - start_time
 
-    if process.is_alive():
+    timed_out = process.is_alive()
+    if timed_out:
         logger.warning(
             f"Problem '{query}' exceeded timeout of {timeout}s, terminating process"
         )
@@ -223,7 +243,11 @@ def execute_single_problem(
         if process.is_alive():
             process.kill()
             process.join()
-        inf_failures, inf_total = _read_inference_stats(stats_file, str(problem_id))
+
+    inf_failures, inf_total = _read_inference_stats(stats_file, str(problem_id))
+    proxy_calls = _read_request_log(request_log_file)
+
+    if timed_out:
         result_queue.close()
         return ExecutionResult(
             query=query,
@@ -233,9 +257,9 @@ def execute_single_problem(
             problem_id=problem_id,
             inference_failure_count=inf_failures,
             inference_total=inf_total,
+            proxy_calls=proxy_calls or None,
         )
 
-    inf_failures, inf_total = _read_inference_stats(stats_file, str(problem_id))
     try:
         if not result_queue.empty():
             status, data = result_queue.get_nowait()
@@ -248,6 +272,7 @@ def execute_single_problem(
                     problem_id=problem_id,
                     inference_failure_count=inf_failures,
                     inference_total=inf_total,
+                    proxy_calls=proxy_calls or None,
                 )
             return ExecutionResult(
                 query=query,
@@ -257,6 +282,7 @@ def execute_single_problem(
                 problem_id=problem_id,
                 inference_failure_count=inf_failures,
                 inference_total=inf_total,
+                proxy_calls=proxy_calls or None,
             )
         return ExecutionResult(
             query=query,
@@ -266,6 +292,7 @@ def execute_single_problem(
             problem_id=problem_id,
             inference_failure_count=inf_failures,
             inference_total=inf_total,
+            proxy_calls=proxy_calls or None,
         )
     finally:
         result_queue.close()
@@ -296,6 +323,10 @@ def _format_single_result(result: ExecutionResult) -> Optional[str]:
             step.setdefault("extra_info", {})["query"] = result.query
         if result.problem_id and "problem_id" not in step.get("extra_info", {}):
             step.setdefault("extra_info", {})["problem_id"] = result.problem_id
+
+    # Attach proxy call log to first step's extra_info for complete observability
+    if result.proxy_calls and dialogue_steps:
+        dialogue_steps[0].setdefault("extra_info", {})["proxy_calls"] = result.proxy_calls
 
     return json.dumps(dialogue_steps)
 

--- a/subnet/tests/test_proxy_client.py
+++ b/subnet/tests/test_proxy_client.py
@@ -6,7 +6,7 @@ import tempfile
 from unittest.mock import patch, MagicMock
 
 
-from src.agent.proxy_client import InferenceStats, ProxyClient
+from src.agent.proxy_client import InferenceStats, ProxyClient, RequestLog
 
 
 class TestProxyClientAuth:
@@ -121,5 +121,142 @@ class TestInferenceStats:
             with open(path) as f:
                 entry = json.loads(f.readline())
             assert entry["problem_id"] == "unknown"
+        finally:
+            os.unlink(path)
+
+
+class TestRequestLog:
+    """Tests for proxy call request logging."""
+
+    def test_records_get_call(self):
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
+            path = f.name
+        try:
+            log = RequestLog(log_file=path)
+            log.record(
+                method="GET",
+                path="/search/find_product",
+                params={"q": "laptop", "page": 1},
+                status_code=200,
+                response_body=[{"product_id": "123", "title": "Laptop"}],
+                duration_ms=150.5,
+            )
+
+            with open(path) as f:
+                entry = json.loads(f.readline())
+
+            assert entry["method"] == "GET"
+            assert entry["path"] == "/search/find_product"
+            assert entry["params"] == {"q": "laptop", "page": 1}
+            assert entry["status_code"] == 200
+            assert entry["duration_ms"] == 150.5
+            assert entry["response"] == [{"product_id": "123", "title": "Laptop"}]
+            assert "timestamp" in entry
+        finally:
+            os.unlink(path)
+
+    def test_records_post_call(self):
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
+            path = f.name
+        try:
+            log = RequestLog(log_file=path)
+            log.record(
+                method="POST",
+                path="/search/view_product_information",
+                json_data={"product_id": "456"},
+                status_code=200,
+                duration_ms=80.0,
+            )
+
+            with open(path) as f:
+                entry = json.loads(f.readline())
+
+            assert entry["method"] == "POST"
+            assert entry["json_data"] == {"product_id": "456"}
+        finally:
+            os.unlink(path)
+
+    def test_inference_body_omits_messages(self):
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
+            path = f.name
+        try:
+            log = RequestLog(log_file=path)
+            log.record(
+                method="POST",
+                path="/inference/chat/completions",
+                json_data={
+                    "model": "gpt-4",
+                    "messages": [{"role": "user", "content": "very long prompt..."}],
+                    "temperature": 0.7,
+                },
+                status_code=200,
+                duration_ms=2000.0,
+            )
+
+            with open(path) as f:
+                entry = json.loads(f.readline())
+
+            assert "messages" not in entry["json_data"]
+            assert entry["json_data"]["model"] == "gpt-4"
+            assert entry["json_data"]["temperature"] == 0.7
+        finally:
+            os.unlink(path)
+
+    def test_large_response_truncated(self):
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
+            path = f.name
+        try:
+            log = RequestLog(log_file=path)
+            large_body = {"data": "x" * 3000}
+            log.record(
+                method="GET",
+                path="/search/find_product",
+                status_code=200,
+                response_body=large_body,
+                duration_ms=100.0,
+            )
+
+            with open(path) as f:
+                entry = json.loads(f.readline())
+
+            assert entry["response_truncated"] is True
+            assert entry["response_length"] > 2000
+            assert "response" not in entry
+        finally:
+            os.unlink(path)
+
+    def test_no_file_does_not_crash(self):
+        log = RequestLog(log_file=None)
+        log.record(method="GET", path="/search/find_product", status_code=200)
+
+    def test_none_params_omitted(self):
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
+            path = f.name
+        try:
+            log = RequestLog(log_file=path)
+            log.record(method="GET", path="/health", status_code=200, duration_ms=5.0)
+
+            with open(path) as f:
+                entry = json.loads(f.readline())
+
+            assert "params" not in entry
+            assert "json_data" not in entry
+        finally:
+            os.unlink(path)
+
+    def test_multiple_calls_append(self):
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
+            path = f.name
+        try:
+            log = RequestLog(log_file=path)
+            log.record(method="GET", path="/a", status_code=200, duration_ms=1.0)
+            log.record(method="GET", path="/b", status_code=200, duration_ms=2.0)
+            log.record(method="POST", path="/c", status_code=200, duration_ms=3.0)
+
+            with open(path) as f:
+                lines = [json.loads(line) for line in f if line.strip()]
+
+            assert len(lines) == 3
+            assert [e["path"] for e in lines] == ["/a", "/b", "/c"]
         finally:
             os.unlink(path)

--- a/subnet/tests/test_sandbox_executor.py
+++ b/subnet/tests/test_sandbox_executor.py
@@ -6,7 +6,7 @@ import tempfile
 import time
 from pathlib import Path
 
-from src.agent.sandbox_executor import execute_single_problem, _read_inference_stats
+from src.agent.sandbox_executor import execute_single_problem, _read_inference_stats, _read_request_log
 
 FIXTURES = Path(__file__).parent / "fixtures"
 FAST = str(FIXTURES / "fast_agent.py")
@@ -73,3 +73,34 @@ class TestReadInferenceStats:
         failures, total = _read_inference_stats("/tmp/nonexistent.jsonl", "p1")
         assert failures == 0
         assert total == 0
+
+
+class TestReadRequestLog:
+    def test_reads_all_entries(self):
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False, mode="w") as f:
+            f.write(json.dumps({"method": "GET", "path": "/a"}) + "\n")
+            f.write(json.dumps({"method": "POST", "path": "/b"}) + "\n")
+            path = f.name
+        try:
+            entries = _read_request_log(path)
+            assert len(entries) == 2
+            assert entries[0]["path"] == "/a"
+            assert entries[1]["path"] == "/b"
+        finally:
+            os.unlink(path)
+
+    def test_missing_file_returns_empty(self):
+        entries = _read_request_log("/tmp/nonexistent_request_log.jsonl")
+        assert entries == []
+
+    def test_skips_blank_lines(self):
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False, mode="w") as f:
+            f.write(json.dumps({"method": "GET", "path": "/a"}) + "\n")
+            f.write("\n")
+            f.write(json.dumps({"method": "GET", "path": "/b"}) + "\n")
+            path = f.name
+        try:
+            entries = _read_request_log(path)
+            assert len(entries) == 2
+        finally:
+            os.unlink(path)

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -632,13 +632,19 @@ class Validator:
         agent_path = None
         workspace_dir = Path(self.config.workspace_dir)
 
-        # Step 0: Verify miner Chutes token is present (before starting heartbeat)
+        # Step 0: Verify miner Chutes token is present and valid
         if not chutes_access_token:
             self._complete_with_failure(
                 eval_run_id,
                 TerminalStatus.FAILED,
                 "Miner has no Chutes token — cannot fund inference",
             )
+            return
+
+        # Validate the token can actually make inference calls
+        token_valid, token_reason = self._validate_chutes_token(chutes_access_token)
+        if not token_valid:
+            self._complete_with_failure(eval_run_id, TerminalStatus.FAILED, token_reason)
             return
 
         # Start heartbeat manager only after token validation passes
@@ -958,6 +964,34 @@ class Validator:
                 )
             else:
                 logging.error(f"Non-transient error completing run {eval_run_id}: {e}")
+
+    @staticmethod
+    def _validate_chutes_token(access_token: str) -> tuple[bool, str]:
+        """Validate a Chutes access token can make inference calls.
+
+        Returns (is_valid, failure_reason). On transient errors (5xx,
+        timeout), returns (True, "") to avoid failing runs unnecessarily.
+        """
+        import requests
+
+        try:
+            resp = requests.get(
+                "https://chutes.ai/api/v1/models",
+                headers={"Authorization": f"Bearer {access_token}"},
+                timeout=5,
+            )
+            if resp.status_code == 200:
+                return True, ""
+            if resp.status_code == 401:
+                return False, "Chutes token invalid or expired (HTTP 401)"
+            if resp.status_code == 402:
+                return False, "Miner's Chutes account has no credits (HTTP 402)"
+            # 403, 5xx, or unexpected — could be throttling/transient, proceed
+            logging.warning("Chutes token validation inconclusive: status=%s", resp.status_code)
+            return True, ""
+        except Exception as exc:
+            logging.warning("Chutes token validation error: %s", exc)
+            return True, ""
 
     def _complete_with_failure(
         self,


### PR DESCRIPTION
## Description

Agents that bypass the `@Tool` decorator and call `ProxyClient` directly produce incomplete trajectories. This makes trajectory data unusable for training (trajectory distillation, ORO-568) and makes it impossible to fully verify agent behavior.

Adds a `RequestLog` sidecar that records every `ProxyClient.get()` and `.post()` call, following the existing `InferenceStats` pattern.

## Changes Made

- `proxy_client.py`: Add `RequestLog` class, instrument `get()` and `post()` with timing and logging
- `sandbox_executor.py`: Wire `REQUEST_LOG_FILE` env var, read sidecar file after execution, attach `proxy_calls` array to trajectory output
- 10 new tests for `RequestLog` and `_read_request_log`

## Issue Link

- Closes: ORO-772

## Testing

### Automated Testing

**Test Command(s):**
```bash
python3.11 -m pytest subnet/tests/test_proxy_client.py subnet/tests/test_sandbox_executor.py -v
```

26 tests passing (16 existing + 10 new).

### Manual Testing

N/A — requires sandbox environment. Should be validated by running an agent locally and inspecting the trajectory output for `proxy_calls` in `extra_info`.

## Documentation

- [x] Code comments added/updated
- [ ] README updated
- [ ] API documentation updated
- [ ] Configuration documentation updated

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

**Backward compatible:** Output format remains a JSON array of dialogue steps. The `proxy_calls` array is stored inside `extra_info` of the first step, which existing consumers ignore.

**Response truncation:** Responses over 2KB are truncated (length recorded, body omitted). Inference request bodies omit the `messages` array to keep logs small.

**Per-problem isolation:** Each problem gets its own `request_log_{problem_id}.jsonl` file to prevent cross-contamination in parallel runs.