### PR TITLE
fix: distribute proxy calls across steps by timestamp

### DIFF
--- a/src/agent/sandbox_executor.py
+++ b/src/agent/sandbox_executor.py
@@ -324,9 +324,26 @@ def _format_single_result(result: ExecutionResult) -> Optional[str]:
         if result.problem_id and "problem_id" not in step.get("extra_info", {}):
             step.setdefault("extra_info", {})["problem_id"] = result.problem_id
 
-    # Attach proxy call log to first step's extra_info for complete observability
+    # Distribute proxy calls across steps by timestamp approximation.
+    # Calls before the first step go to step 0; calls between step N and N+1
+    # go to step N.
     if result.proxy_calls and dialogue_steps:
-        dialogue_steps[0].setdefault("extra_info", {})["proxy_calls"] = result.proxy_calls
+        step_timestamps = [
+            s.get("extra_info", {}).get("timestamp", 0) for s in dialogue_steps
+        ]
+        # Bucket each call into the latest step whose timestamp <= call timestamp
+        buckets: Dict[int, List[Dict]] = {}
+        for call in result.proxy_calls:
+            call_ts = call.get("timestamp", 0)
+            target = 0
+            for i, st in enumerate(step_timestamps):
+                if st <= call_ts:
+                    target = i
+                else:
+                    break
+            buckets.setdefault(target, []).append(call)
+        for idx, calls in buckets.items():
+            dialogue_steps[idx].setdefault("extra_info", {})["proxy_calls"] = calls
 
     return json.dumps(dialogue_steps)
 


### PR DESCRIPTION
## Description

Follow-up to PR #66. Previously all proxy calls were dumped into step 1's `extra_info.proxy_calls`. Now each call is assigned to the dialogue step whose timestamp is closest, giving a per-step view of what API calls the agent made.

## Changes Made

- Updated `_format_single_result` in `sandbox_executor.py` to bucket proxy calls by matching timestamps to dialogue steps

## Issue Link

- Related to: ORO-772

## Testing

Verified against production trajectory data — timestamps align correctly across steps.

## Checklist

- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes