### PR TITLE
revert: sandbox workers back to 6 from 10

### DIFF
--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -93,7 +93,7 @@ class Validator:
         parser.add_argument(
             "--sandbox-max-workers",
             type=int,
-            default=int(os.environ.get("SANDBOX_MAX_WORKERS", "10")),
+            default=int(os.environ.get("SANDBOX_MAX_WORKERS", "6")),
             help="Number of parallel problem workers in sandbox (env: SANDBOX_MAX_WORKERS).",
         )
         parser.add_argument(


### PR DESCRIPTION
## Description

Reverts PR #64. Testing showed 10 parallel workers hit Chutes rate limits (31 429s in a single eval run). The bottleneck is inference API concurrency, not sandbox parallelism. 6 workers is the sweet spot for current Chutes quotas.

## Testing

Local 6-worker run: 30 reasoning scores, 2 judge timeouts, 31 rate limits
Staging 10-worker run: similar timing (~11m vs ~10m), no speed improvement

## Checklist

- [x] My changes generate no new warnings or errors