### PR TITLE
feat: increase default sandbox workers from 6 to 10

### DIFF
--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -93,7 +93,7 @@ class Validator:
         parser.add_argument(
             "--sandbox-max-workers",
             type=int,
-            default=int(os.environ.get("SANDBOX_MAX_WORKERS", "6")),
+            default=int(os.environ.get("SANDBOX_MAX_WORKERS", "10")),
             help="Number of parallel problem workers in sandbox (env: SANDBOX_MAX_WORKERS).",
         )
         parser.add_argument(


### PR DESCRIPTION
## Summary
- Increase `SANDBOX_MAX_WORKERS` default from 6 to 10
- Cuts sandbox execution from ~5 batches to ~3 batches (30 problems / 10 workers)
- Expected savings: ~3.5 min per evaluation (~19 min → ~15 min)
- Still overridable via `SANDBOX_MAX_WORKERS` env var

## Test plan
- [ ] Deploy to staging via `latest` tag
- [ ] Monitor memory usage and Chutes rate limits during evaluation
- [ ] Confirm evaluations complete successfully at 10 workers
- [ ] If stable, promote to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)