### PR TITLE
fix: reduce search-server JVM heap to prevent OOM

### DIFF
--- a/docker/search-server/entrypoint.sh
+++ b/docker/search-server/entrypoint.sh
@@ -18,7 +18,7 @@ echo "Java version: $(java -version 2>&1 | head -1)" >&2
 
 # Set JVM memory options for pyserini/Lucene (default: 8GB heap, adjust as needed)
 # Use JAVA_OPTS environment variable if set, otherwise use defaults
-export JAVA_OPTS="${JAVA_OPTS:--Xmx8g -Xms4g}"
+export JAVA_OPTS="${JAVA_OPTS:--Xmx4g -Xms2g}"
 
 echo "JVM Options: $JAVA_OPTS" >&2
 


### PR DESCRIPTION
## Summary
- Lower JVM heap from `Xmx8g -Xms4g` to `Xmx4g -Xms2g`
- Production search-server stabilizes at ~2.9GB — previous 4GB initial allocation left only 223MB free on the 7.6GB host
- Frees ~1GB headroom to prevent OOM during 10-worker sandbox evaluations
- Still overridable via `JAVA_OPTS` env var

## Test plan
- [ ] Deploy to staging, verify search latency unchanged
- [ ] Monitor memory on prod after promotion — should see ~1GB more free
- [ ] Verify no search failures during evaluation runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)