### PR TITLE
fix: lower JVM heap in docker-compose.yml (completes v1.0.38)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       - HOST=${HOST:-0.0.0.0}
       - PORT=${PORT:-5632}
-      - JAVA_OPTS=${JAVA_OPTS:--Xmx8g -Xms4g}
+      - JAVA_OPTS=${JAVA_OPTS:--Xmx4g -Xms2g}
       - WAITRESS_CONNECTION_LIMIT=${WAITRESS_CONNECTION_LIMIT:-1000}
     ports:
       - "${PORT:-5632}:${PORT:-5632}"


### PR DESCRIPTION
## Summary
The entrypoint.sh change in PR #74 had no effect because docker-compose.yml passes `JAVA_OPTS` explicitly as an env var, which overrides the entrypoint default. This PR updates the compose file to match.

## Changes Made
- `JAVA_OPTS` default in docker-compose.yml: `Xmx8g -Xms4g` → `Xmx4g -Xms2g`

🤖 Generated with [Claude Code](https://claude.com/claude-code)