### PR TITLE
fix: bake JVM heap into search-server Docker image for automatic rollout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     environment:
       - HOST=${HOST:-0.0.0.0}
       - PORT=${PORT:-5632}
-      - JAVA_OPTS=${JAVA_OPTS:--Xmx4g -Xms2g}
       - WAITRESS_CONNECTION_LIMIT=${WAITRESS_CONNECTION_LIMIT:-1000}
     ports:
       - "${PORT:-5632}:${PORT:-5632}"

--- a/docker/search-server/Dockerfile
+++ b/docker/search-server/Dockerfile
@@ -16,6 +16,7 @@ EXPOSE 5632
 # Set environment variables
 ENV HOST=0.0.0.0
 ENV PORT=5632
+ENV JAVA_OPTS="-Xmx4g -Xms2g"
 
 # Use entrypoint script
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker/search-server/entrypoint.sh
+++ b/docker/search-server/entrypoint.sh
@@ -16,9 +16,8 @@ if ! command -v java &> /dev/null; then
 fi
 echo "Java version: $(java -version 2>&1 | head -1)" >&2
 
-# Set JVM memory options for pyserini/Lucene (default: 8GB heap, adjust as needed)
-# Use JAVA_OPTS environment variable if set, otherwise use defaults
-export JAVA_OPTS="${JAVA_OPTS:--Xmx4g -Xms2g}"
+# JAVA_OPTS default is set in the Dockerfile ENV.
+# Override at runtime via docker-compose or -e JAVA_OPTS="..." if needed.
 
 echo "JVM Options: $JAVA_OPTS" >&2
 


### PR DESCRIPTION
## Summary
- Add `ENV JAVA_OPTS="-Xmx4g -Xms2g"` to the search-server Dockerfile
- Watchtower only updates containers when the **image** changes — compose env var changes (v1.0.38/v1.0.39) require manual `docker compose up` on every validator
- Baking into the Dockerfile means all validators pick it up automatically via Watchtower
- Still overridable via docker-compose.yml or runtime env var

## Test plan
- [x] Tested on staging EC2 validator — search-server stable at 912MB, eval completed normally (691s, 30/30)
- [ ] Promote to stable and verify all prod validators pick up the change automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)