### PR TITLE
feat: increase default sandbox workers from 10 to 15

### DIFF
--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -93,7 +93,7 @@ class Validator:
         parser.add_argument(
             "--sandbox-max-workers",
             type=int,
-            default=int(os.environ.get("SANDBOX_MAX_WORKERS", "10")),
+            default=int(os.environ.get("SANDBOX_MAX_WORKERS", "15")),
             help="Number of parallel problem workers in sandbox (env: SANDBOX_MAX_WORKERS).",
         )
         parser.add_argument(


### PR DESCRIPTION
## Description

Increase the default number of parallel problem-solving workers in the validator sandbox from 10 to 15.

## Changes Made

- Changed `SANDBOX_MAX_WORKERS` default from `10` to `15` in `subnet/validator/main.py`

## Testing

Config change only — the env var `SANDBOX_MAX_WORKERS` still overrides the default if set.

## Checklist

- [x] My changes generate no new warnings or errors
- [x] Any dependent changes have been published and merged