### PR TITLE
fix: pin async-substrate-interface to fix validator crash loop

### DIFF
--- a/docker/validator/requirements-base.txt
+++ b/docker/validator/requirements-base.txt
@@ -1,3 +1,4 @@
+async-substrate-interface==1.6.4
 bittensor==10.1.0
 bittensor_wallet==4.0.1
 requests==2.32.5


### PR DESCRIPTION
## Summary
- Pin `async-substrate-interface==1.6.4` in validator Docker requirements
- Fixes crash loop where fresh builds pull a newer version that requires `cyscale` instead of `scalecodec`, causing `ImportError: cannot import name 'ScaleBytes'`

## Test plan
- [x] Verified locally — validator starts and completes evaluations with the pin
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)