### PR TITLE
ci: add smoke test after image publish

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -137,3 +137,26 @@ jobs:
             -t ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:${{ needs.determine-tag.outputs.tag }} \
             -t ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:latest \
             $(printf '${{ env.IMAGE_PREFIX }}/${{ matrix.image }}@sha256:%s ' $(ls /tmp/digests/))
+
+  smoke-test:
+    needs: [determine-tag, merge]
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Smoke test validator image
+        run: |
+          docker run --rm ${{ env.IMAGE_PREFIX }}/validator:${{ needs.determine-tag.outputs.tag }} \
+            python -c "from subnet.validator.main import Validator; print('Validator import OK')"
+
+      - name: Smoke test sandbox image
+        run: |
+          docker run --rm ${{ env.IMAGE_PREFIX }}/sandbox:${{ needs.determine-tag.outputs.tag }} \
+            python -c "from src.agent.agent_interface import AgentInterface; print('Sandbox import OK')"


### PR DESCRIPTION
## Description

Adds a smoke test step to the image publish workflow that runs after images are built and pushed. Catches dependency conflicts and import failures before the image can be promoted to stable.

This would have caught the v1.0.42 crash-loop (scalecodec/cyscale conflict) before it reached production validators.

## Changes Made

- New `smoke-test` job that runs after the `merge` step
- Pulls the freshly published validator and sandbox images
- Verifies each can import their entrypoint module without crashing
- If the smoke test fails, the workflow fails (visible before promoting)

## Checklist

- [x] My changes generate no new warnings or errors