### PR TITLE
fix: give judge ground-truth search results and narrow Rule 5 scope

### DIFF
--- a/src/agent/proxy_client.py
+++ b/src/agent/proxy_client.py
@@ -61,6 +61,14 @@ class RequestLog:
             if len(body_str) > 2000:
                 entry["response_truncated"] = True
                 entry["response_length"] = len(body_str)
+                if "/search/find_product" in path and isinstance(response_body, list):
+                    # Preserve product IDs so the reasoning judge can verify the
+                    # agent's selections came from actual search results.
+                    entry["result_product_ids"] = [
+                        str(item["product_id"])
+                        for item in response_body
+                        if isinstance(item, dict) and "product_id" in item
+                    ]
             else:
                 entry["response"] = response_body
         with self._lock:

--- a/src/agent/reasoning_scorer.py
+++ b/src/agent/reasoning_scorer.py
@@ -107,9 +107,9 @@ Score 0.6-0.8 — GENUINE reasoning:
 
 Score 0.9-1.0 — STRONG reasoning:
 - All of the above, plus:
-- Agent compares options, applies constraints (budget, voucher rules, product requirements)
-- Explains trade-offs in product selection
+- Agent compares options and explains its selection rationale, citing specific data from proxy results
 - Thinking is consistent with the exact calls shown in proxy logs
+- Do NOT reward or penalize based on whether the final product satisfies query constraints — that is scored separately.
 
 Be generous with agents genuinely reasoning, even if imperfectly. Be harsh with fakers.
 

--- a/src/agent/reasoning_scorer.py
+++ b/src/agent/reasoning_scorer.py
@@ -84,7 +84,7 @@ The key question: **Is this agent actually reasoning, or faking it?**
 2. **Token output**: Check `tokens=N` on inference calls. Real reasoning produces 50-300 tokens per call. Trivial or cached responses produce <10 tokens — this indicates the agent is calling inference as a decoy without actually using the output.
 3. **Call ordering**: Real agents interleave inference and search (think → search → think → search → decide). Regex agents do search → search → recommend with no inference between.
 4. **Search query diversity**: Real agents adapt search queries based on results (refining terms, trying alternatives). Regex agents use hardcoded query templates.
-5. **Thinking-to-action consistency**: Does the thinking text describe what the proxy calls actually show? If thinking says "I will search for X" but proxy logs show a different query (or no search at all), the trajectory is fabricated.
+5. **Thinking-to-action consistency**: Does the agent actually make the calls its thinking describes? If thinking claims "I will search for X" but no such search appears in proxy logs, the trajectory is fabricated. Scope: evaluate ONLY whether described actions occurred — do NOT judge whether the final product satisfies query constraints (price, brand, attributes, availability). Constraint matching is scored separately.
 6. **Duration plausibility**: LLM inference typically takes 3-30s. Sub-second inference calls are suspicious (trivial prompts or cached responses).
 
 ## Scoring
@@ -121,6 +121,7 @@ MAX_THINK_CHARS = 1000
 MAX_RESULT_CHARS = 300
 MAX_PROXY_PARAM_CHARS = 200
 MAX_PROXY_CALLS_SHOWN = 30
+MAX_SEARCH_IDS_SHOWN = 20
 
 
 def _get_completion_tokens(call: dict[str, Any]) -> Any:
@@ -156,7 +157,14 @@ def _format_proxy_call(call: dict[str, Any]) -> str:
     comp = _get_completion_tokens(call)
     tokens_str = f" tokens={comp}" if comp is not None else ""
 
-    return f"  {method} {path}{param_str}{model_str}{tokens_str} → {status} ({duration:.0f}ms)"
+    line = f"  {method} {path}{param_str}{model_str}{tokens_str} → {status} ({duration:.0f}ms)"
+
+    result_ids = call.get("result_product_ids")
+    if isinstance(result_ids, list) and result_ids:
+        shown = result_ids[:MAX_SEARCH_IDS_SHOWN]
+        suffix = f" (+{len(result_ids) - len(shown)} more)" if len(result_ids) > len(shown) else ""
+        line += f"\n    returned product_ids: {','.join(shown)}{suffix}"
+    return line
 
 
 def _summarize_proxy_calls(proxy_calls: list[dict[str, Any]]) -> str:

--- a/subnet/tests/test_proxy_client.py
+++ b/subnet/tests/test_proxy_client.py
@@ -225,6 +225,59 @@ class TestRequestLog:
         finally:
             os.unlink(path)
 
+    def test_find_product_preserves_ids_when_truncated(self):
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
+            path = f.name
+        try:
+            log = RequestLog(log_file=path)
+            large_results = [
+                {"product_id": f"pid-{i}", "title": "x" * 300, "price": 100.0}
+                for i in range(10)
+            ]
+            log.record(
+                method="GET",
+                path="/search/find_product",
+                params={"q": "laptop"},
+                status_code=200,
+                response_body=large_results,
+                duration_ms=100.0,
+            )
+
+            with open(path) as f:
+                entry = json.loads(f.readline())
+
+            assert entry["response_truncated"] is True
+            assert entry["result_product_ids"] == [f"pid-{i}" for i in range(10)]
+            assert "response" not in entry
+        finally:
+            os.unlink(path)
+
+    def test_view_product_truncation_does_not_add_result_ids(self):
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
+            path = f.name
+        try:
+            log = RequestLog(log_file=path)
+            large_results = [
+                {"product_id": f"pid-{i}", "title": "x" * 300}
+                for i in range(10)
+            ]
+            log.record(
+                method="GET",
+                path="/search/view_product_information",
+                params={"product_ids": "pid-0"},
+                status_code=200,
+                response_body=large_results,
+                duration_ms=50.0,
+            )
+
+            with open(path) as f:
+                entry = json.loads(f.readline())
+
+            assert entry["response_truncated"] is True
+            assert "result_product_ids" not in entry
+        finally:
+            os.unlink(path)
+
     def test_no_file_does_not_crash(self):
         log = RequestLog(log_file=None)
         log.record(method="GET", path="/search/find_product", status_code=200)

--- a/subnet/tests/test_reasoning_scorer.py
+++ b/subnet/tests/test_reasoning_scorer.py
@@ -216,6 +216,32 @@ class TestFormatProxyCall:
         result = _format_proxy_call(call)
         assert "..." in result
 
+    def test_includes_returned_product_ids(self):
+        call = {
+            "method": "GET",
+            "path": "/search/find_product",
+            "params": {"q": "laptop"},
+            "status_code": 200,
+            "duration_ms": 100,
+            "result_product_ids": ["123", "456", "789"],
+        }
+        result = _format_proxy_call(call)
+        assert "returned product_ids: 123,456,789" in result
+
+    def test_truncates_long_returned_product_ids_list(self):
+        ids = [str(i) for i in range(30)]
+        call = {
+            "method": "GET",
+            "path": "/search/find_product",
+            "params": {"q": "laptop"},
+            "status_code": 200,
+            "duration_ms": 100,
+            "result_product_ids": ids,
+        }
+        result = _format_proxy_call(call)
+        assert "returned product_ids: 0,1,2" in result
+        assert "(+10 more)" in result
+
 
 class TestSummarizeProxyCalls:
     def test_empty_list(self):


### PR DESCRIPTION
## Description

Fixes two sources of false-positive "fabricated trajectory" flags from the reasoning judge:

1. The judge could see that the agent called `view_product_information` with a list of product IDs, but had no way to verify those IDs came from an actual `find_product` search. When the search response was truncated (>2KB, which is the common case), the judge flagged legitimate selections as hallucinated.
2. Rule 5 ("Thinking-to-action consistency") was being applied too broadly. In practice, the judge was using it to evaluate whether the final product matched query constraints (price, brand, attributes) — which is already scored separately via `success_rate` / `field_matching`. This produced duplicate penalties and outright errors (e.g. judges miscomputing whether a price was in range).

## Changes Made

- `proxy_client.py`: When a `/search/find_product` response is large enough to be truncated, preserve the returned `product_id` values in `entry["result_product_ids"]`. The full response body is still dropped to keep logs bounded.
- `reasoning_scorer.py`: `_format_proxy_call()` now emits a `returned product_ids:` line under any find_product call that has preserved IDs. Capped at 20 shown with a `+N more` suffix.
- `reasoning_scorer.py`: Rewrote Rule 5 of the judge system prompt to:
  - only ask whether the agent actually made the calls its thinking describes, and
  - explicitly exclude constraint matching (price/brand/attributes/availability) from the judge's scope.
- Added 4 tests covering both changes.

## Issue Link

- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing

Reproduced the symptom against a real run where the judge flagged two Product problems with "recommended product does not appear in search results." Inspected the raw trajectory and confirmed the product IDs *did* appear in the `view_product_information` call params (which come directly from a preceding `find_product` response). With this change, the `returned product_ids` line on each search call now makes that grounding visible to the judge.

**Test Results:**

```
subnet/tests/test_proxy_client.py .................. 18 passed
subnet/tests/test_reasoning_scorer.py ............ 28 passed
```

### Automated Testing

**Test Command(s):**
```bash
python3 -m pytest subnet/tests/test_proxy_client.py subnet/tests/test_reasoning_scorer.py -v
```

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**

N/A — internal validator component.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

The 0.9-1.0 scoring tier still mentions "applies constraints (budget, voucher rules, product requirements)." That phrasing reinforces constraint-checking behavior and may be worth tightening in a follow-up — I kept this PR scoped to the two specific issues above.

Old trajectories captured before this change do not have `result_product_ids`; the judge will continue to score those without the new context. Only new runs benefit.