### PR TITLE
fix: make Qwen3-32B the primary judge with throttle-based fallback

### DIFF
--- a/src/agent/reasoning_scorer.py
+++ b/src/agent/reasoning_scorer.py
@@ -22,24 +22,39 @@ logger = logging.getLogger(__name__)
 
 PROXY_URL = "http://proxy:80"
 
-# Chutes TEE models (must use -TEE suffix for proxy allowlist).
-# Used as fallback when utilization API is unavailable.
-JUDGE_MODELS = [
-    "Qwen/Qwen3-32B-TEE",
-    "MiniMaxAI/MiniMax-M2.5-TEE",
-    "deepseek-ai/DeepSeek-V3.2-TEE",
-    "Qwen/Qwen3-235B-A22B-Instruct-2507-TEE",
+# Chutes TEE judges (must use -TEE suffix for proxy allowlist).
+#
+# Qwen3-32B is the primary judge; the DeepSeek variants are fallbacks
+# used only when the primary is rate-limiting above
+# PRIMARY_THROTTLE_THRESHOLD. MiniMax-M2.5 and Qwen3-235B-Instruct were
+# removed after per-agent measurements showed they scored identical
+# trajectories ~29 and ~25 points lower than Qwen3-32B respectively —
+# a systematic bias large enough to swing leaderboard ranking based on
+# which judge a run happened to route to.
+PRIMARY_JUDGE_MODEL = "Qwen/Qwen3-32B-TEE"
+FALLBACK_JUDGE_MODELS = [
     "deepseek-ai/DeepSeek-V3-0324-TEE",
+    "deepseek-ai/DeepSeek-V3.2-TEE",
 ]
+JUDGE_MODELS = [PRIMARY_JUDGE_MODEL, *FALLBACK_JUDGE_MODELS]
+
+# If the primary's 5-minute rate-limit ratio exceeds this fraction,
+# route to the least-loaded fallback first.
+PRIMARY_THROTTLE_THRESHOLD = 0.5
 
 CHUTES_UTILIZATION_URL = "https://api.chutes.ai/chutes/utilization"
 CHUTES_UTILIZATION_TIMEOUT = 5
 
 
 def _select_models_by_utilization() -> list[str]:
-    """Query Chutes utilization API and return JUDGE_MODELS sorted by load.
+    """Return judge models in order of preference.
 
-    Returns models sorted by utilization_current (ascending = least loaded first).
+    Default: primary first, then fallbacks ordered by current utilization
+    (least-loaded first). If the primary's 5-minute rate-limit ratio
+    exceeds PRIMARY_THROTTLE_THRESHOLD, the least-loaded fallback is
+    promoted to first — the primary still stays in the list as a last
+    resort.
+
     Falls back to the static JUDGE_MODELS list on any failure.
     """
     try:
@@ -47,21 +62,36 @@ def _select_models_by_utilization() -> list[str]:
         if resp.status_code != 200:
             return list(JUDGE_MODELS)
 
-        entries = resp.json()
-        util_by_name = {e["name"]: e.get("utilization_current", 1.0) for e in entries}
+        by_name = {e["name"]: e for e in resp.json()}
 
-        scored = []
-        for model in JUDGE_MODELS:
-            util = util_by_name.get(model, 1.0)
-            scored.append((util, model))
-
-        scored.sort()
-        result = [model for _, model in scored]
-        logger.info(
-            "Judge model order by utilization: "
-            + ", ".join(f"{m}({util_by_name.get(m, -1):.0%})" for m in result)
+        fallbacks_scored = sorted(
+            (by_name.get(m, {}).get("utilization_current", 1.0), m)
+            for m in FALLBACK_JUDGE_MODELS
         )
-        return result
+        fallbacks = [m for _, m in fallbacks_scored]
+
+        primary_throttle = by_name.get(PRIMARY_JUDGE_MODEL, {}).get(
+            "rate_limit_ratio_5m", 0.0
+        )
+        if primary_throttle > PRIMARY_THROTTLE_THRESHOLD:
+            logger.warning(
+                f"Primary judge {PRIMARY_JUDGE_MODEL} rate-limiting at "
+                f"{primary_throttle:.0%} (> {PRIMARY_THROTTLE_THRESHOLD:.0%}); "
+                f"routing to fallback first"
+            )
+            return [*fallbacks, PRIMARY_JUDGE_MODEL]
+
+        primary_util = by_name.get(PRIMARY_JUDGE_MODEL, {}).get(
+            "utilization_current", -1
+        )
+        logger.info(
+            f"Judge order: {PRIMARY_JUDGE_MODEL}({primary_util:.0%}), fallbacks: "
+            + ", ".join(
+                f"{m}({by_name.get(m, {}).get('utilization_current', -1):.0%})"
+                for m in fallbacks
+            )
+        )
+        return [PRIMARY_JUDGE_MODEL, *fallbacks]
     except Exception as e:
         logger.warning(f"Failed to fetch Chutes utilization, using static model list: {e}")
         return list(JUDGE_MODELS)

--- a/src/agent/reasoning_scorer.py
+++ b/src/agent/reasoning_scorer.py
@@ -64,15 +64,14 @@ def _select_models_by_utilization() -> list[str]:
 
         by_name = {e["name"]: e for e in resp.json()}
 
-        fallbacks_scored = sorted(
-            (by_name.get(m, {}).get("utilization_current", 1.0), m)
-            for m in FALLBACK_JUDGE_MODELS
-        )
-        fallbacks = [m for _, m in fallbacks_scored]
+        def field(model: str, key: str, default: float) -> float:
+            return by_name.get(model, {}).get(key, default)
 
-        primary_throttle = by_name.get(PRIMARY_JUDGE_MODEL, {}).get(
-            "rate_limit_ratio_5m", 0.0
-        )
+        fallbacks = [m for _, m in sorted(
+            (field(m, "utilization_current", 1.0), m) for m in FALLBACK_JUDGE_MODELS
+        )]
+
+        primary_throttle = field(PRIMARY_JUDGE_MODEL, "rate_limit_ratio_5m", 0.0)
         if primary_throttle > PRIMARY_THROTTLE_THRESHOLD:
             logger.warning(
                 f"Primary judge {PRIMARY_JUDGE_MODEL} rate-limiting at "
@@ -81,14 +80,12 @@ def _select_models_by_utilization() -> list[str]:
             )
             return [*fallbacks, PRIMARY_JUDGE_MODEL]
 
-        primary_util = by_name.get(PRIMARY_JUDGE_MODEL, {}).get(
-            "utilization_current", -1
-        )
         logger.info(
-            f"Judge order: {PRIMARY_JUDGE_MODEL}({primary_util:.0%}), fallbacks: "
+            f"Judge order: {PRIMARY_JUDGE_MODEL}"
+            f"({field(PRIMARY_JUDGE_MODEL, 'utilization_current', -1):.0%}), "
+            "fallbacks: "
             + ", ".join(
-                f"{m}({by_name.get(m, {}).get('utilization_current', -1):.0%})"
-                for m in fallbacks
+                f"{m}({field(m, 'utilization_current', -1):.0%})" for m in fallbacks
             )
         )
         return [PRIMARY_JUDGE_MODEL, *fallbacks]

--- a/subnet/tests/test_reasoning_scorer.py
+++ b/subnet/tests/test_reasoning_scorer.py
@@ -4,11 +4,14 @@ from unittest.mock import patch, MagicMock
 
 from reasoning_scorer import (
     _format_proxy_call,
+    _select_models_by_utilization,
     _summarize_proxy_calls,
     score_reasoning_quality,
     format_trajectory_for_judge,
     parse_judge_response,
+    FALLBACK_JUDGE_MODELS,
     JUDGE_MODELS,
+    PRIMARY_JUDGE_MODEL,
 )
 
 
@@ -162,8 +165,59 @@ class TestScoreReasoningQuality:
         result = score_reasoning_quality([], api_key="test-key")
         assert result["score"] == 0.0
 
-    def test_judge_models_is_nonempty(self):
-        assert len(JUDGE_MODELS) >= 3
+    def test_judge_models_has_primary_and_fallbacks(self):
+        assert JUDGE_MODELS[0] == PRIMARY_JUDGE_MODEL
+        assert JUDGE_MODELS[1:] == FALLBACK_JUDGE_MODELS
+        assert len(FALLBACK_JUDGE_MODELS) >= 1
+
+
+class TestSelectModelsByUtilization:
+    """Tests for _select_models_by_utilization routing logic."""
+
+    def _mock_response(self, entries):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = entries
+        return resp
+
+    def test_primary_first_when_not_throttled(self):
+        entries = [
+            {"name": PRIMARY_JUDGE_MODEL, "utilization_current": 0.3, "rate_limit_ratio_5m": 0.0},
+            {"name": FALLBACK_JUDGE_MODELS[0], "utilization_current": 0.5, "rate_limit_ratio_5m": 0.0},
+            {"name": FALLBACK_JUDGE_MODELS[1], "utilization_current": 0.9, "rate_limit_ratio_5m": 0.0},
+        ]
+        with patch("reasoning_scorer.requests.get", return_value=self._mock_response(entries)):
+            result = _select_models_by_utilization()
+        assert result[0] == PRIMARY_JUDGE_MODEL
+        # Fallbacks ordered by utilization (lowest first)
+        assert result[1:] == [FALLBACK_JUDGE_MODELS[0], FALLBACK_JUDGE_MODELS[1]]
+
+    def test_fallback_first_when_primary_throttled(self):
+        entries = [
+            {"name": PRIMARY_JUDGE_MODEL, "utilization_current": 0.4, "rate_limit_ratio_5m": 0.8},
+            {"name": FALLBACK_JUDGE_MODELS[0], "utilization_current": 0.3, "rate_limit_ratio_5m": 0.0},
+            {"name": FALLBACK_JUDGE_MODELS[1], "utilization_current": 0.1, "rate_limit_ratio_5m": 0.0},
+        ]
+        with patch("reasoning_scorer.requests.get", return_value=self._mock_response(entries)):
+            result = _select_models_by_utilization()
+        # Least-loaded fallback first, primary pushed to last resort
+        assert result[0] == FALLBACK_JUDGE_MODELS[1]
+        assert result[-1] == PRIMARY_JUDGE_MODEL
+
+    def test_primary_throttle_at_threshold_stays_primary(self):
+        # Boundary: exactly 0.5 should NOT demote the primary
+        entries = [
+            {"name": PRIMARY_JUDGE_MODEL, "utilization_current": 0.4, "rate_limit_ratio_5m": 0.5},
+            {"name": FALLBACK_JUDGE_MODELS[0], "utilization_current": 0.1, "rate_limit_ratio_5m": 0.0},
+        ]
+        with patch("reasoning_scorer.requests.get", return_value=self._mock_response(entries)):
+            result = _select_models_by_utilization()
+        assert result[0] == PRIMARY_JUDGE_MODEL
+
+    def test_api_failure_returns_static_list(self):
+        with patch("reasoning_scorer.requests.get", side_effect=Exception("boom")):
+            result = _select_models_by_utilization()
+        assert result == JUDGE_MODELS
 
 
 class TestFormatProxyCall:


### PR DESCRIPTION
## Description

A direct per-agent comparison across 500 leaderboard agents' problem-level judge scores shows the current multi-model judge pool is producing systematically different reasoning scores for identical trajectories, enough to swing final scores and distort leaderboard ranking.

Measurements on the same agent's trajectories judged by multiple models:

| Comparison | Agents | A > B | Mean Δ | Median Δ |
|---|---|---|---|---|
| Qwen3-32B vs MiniMax-M2.5 | 34 | **34 / 34** | **+0.294** | +0.309 |
| Qwen3-32B vs Qwen3-235B-Instruct | 20 | 20 / 20 | +0.251 | +0.258 |
| Qwen3-235B vs MiniMax | 23 | 19 / 23 | +0.060 | +0.053 |

Because `final_score = success_rate × reasoning_coefficient`, a ~30-point reasoning delta on a 70% success rate is a ~21-point final-score swing — purely from which judge the utilization router picked. Agents submitted when Qwen3-32B was loaded got harder-judge treatment; others got the lighter touch.

## Changes Made

- Remove MiniMax-M2.5-TEE and Qwen3-235B-A22B-Instruct-TEE from the judge pool entirely (systematic bias).
- Qwen3-32B is now the declared primary; route all judgments to it by default.
- If the primary's 5-minute rate-limit ratio exceeds 50% (new `PRIMARY_THROTTLE_THRESHOLD` constant), route to the least-loaded remaining fallback (DeepSeek-V3-0324 or V3.2) first. Primary stays in the list as a last-resort option.
- Reworked `_select_models_by_utilization` to encode primary-vs-fallback rather than a flat sort. Structured logging on both paths.
- Added `TestSelectModelsByUtilization` covering primary-preferred, throttle-demoted, threshold-boundary, and API-failure paths.

## Issue Link

- Related to: tao.bot / judge-bias investigation session

## Testing

### Manual Testing

Verified current Chutes utilization makes this safe:
- Qwen3-32B at 30% load, 0 rate-limit errors in the past hour, absorbing 69% of current judge traffic already.
- With MiniMax + Qwen3-235B dropped, Qwen3-32B's share rises to ~95% — expected util 40-45%, still well under capacity.
- DeepSeek-V3-0324 at 34.6% util is healthy as the primary fallback. V3.2 is at 99.6% currently but the retry path already rotates on 429.

**Test Results:**
32 tests pass (4 new, 28 existing).

### Automated Testing

New test class `TestSelectModelsByUtilization`:
- Primary first when not throttled, fallbacks ordered by utilization
- Fallback promoted when primary's `rate_limit_ratio_5m` > threshold
- Boundary: exactly 0.5 doesn't demote the primary
- API failure returns the static JUDGE_MODELS list

**Test Command(s):**
\`\`\`bash
PYTHONPATH=subnet python -m pytest subnet/tests/test_reasoning_scorer.py
\`\`\`


## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:** Inline docstring + module-level comment explain the primary/fallback split and why the two dropped models were removed.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

Qwen3-32B reports `scalable: false` with 7 instances on the Chutes side. Today we have significant headroom, but if ORO traffic grows 3× without Chutes unlocking more Qwen3-32B instances, the throttle path will start firing. Worth monitoring after rollout.