### PR TITLE
fix: override ENTRYPOINT in publish-images smoke test

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -151,12 +151,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # --entrypoint overrides the image's ENTRYPOINT. Without it, argv is
+      # appended to the validator's entrypoint and a live validator boots.
       - name: Smoke test validator image
         run: |
-          docker run --rm ${{ env.IMAGE_PREFIX }}/validator:${{ needs.determine-tag.outputs.tag }} \
-            python -c "from subnet.validator.main import Validator; print('Validator import OK')"
+          docker run --rm --entrypoint python ${{ env.IMAGE_PREFIX }}/validator:${{ needs.determine-tag.outputs.tag }} \
+            -c "from subnet.validator.main import Validator; print('Validator import OK')"
 
       - name: Smoke test sandbox image
         run: |
-          docker run --rm ${{ env.IMAGE_PREFIX }}/sandbox:${{ needs.determine-tag.outputs.tag }} \
-            python -c "from src.agent.agent_interface import AgentInterface; print('Sandbox import OK')"
+          docker run --rm --entrypoint python ${{ env.IMAGE_PREFIX }}/sandbox:${{ needs.determine-tag.outputs.tag }} \
+            -c "from src.agent.agent_interface import AgentInterface; print('Sandbox import OK')"


### PR DESCRIPTION
## Description

The validator Dockerfile sets `ENTRYPOINT ["uv", "run", "python", "-m", "subnet.validator.main"]`, so a smoke test run as `docker run <image> python -c "..."` passes `python -c "..."` as argv to the validator entrypoint. argparse ignores the unknown tokens and the module's `__main__` block proceeds to `Validator().run()` — a live validator boots inside the GitHub-hosted runner (attempts subtensor connection, wallet load, work claim). The v1.0.44 publish run sat in this state for 4+ hours before we noticed and cancelled it; v1.0.45 was about to do the same.

## Changes Made

- Added `--entrypoint python` to both smoke-test `docker run` commands in `.github/workflows/publish-images.yml`.
- Sandbox uses `CMD` (not `ENTRYPOINT`) so its step was unaffected, but the override is applied for consistency.

## Issue Link

- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing

Verified against local images after the fix: `docker run --rm --entrypoint python <image> -c "..."` runs the import and exits cleanly, no validator boot.

**Test Results:**

- v1.0.44 and v1.0.45 publish runs cancelled.
- Next tag after merge will run the corrected smoke test.

### Automated Testing

N/A — workflow change, validated by the next publish run.

**Test Command(s):**
```bash
# The next `git push origin v*` will trigger publish-images.yml with the fix.
```

## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**

N/A

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

After this merges, tag a new version (e.g. `v1.0.46`) so the corrected smoke test runs and catches this class of regression going forward. The v1.0.44 and v1.0.45 images are already published and tagged `:latest`; no re-publish needed unless we want a tag associated with a clean run.