### PR TITLE
fix: smoke test imports modules, not specific symbols

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -157,9 +157,9 @@ jobs:
       - name: Smoke test validator image
         run: |
           docker run --rm --entrypoint uv ${{ env.IMAGE_PREFIX }}/validator:${{ needs.determine-tag.outputs.tag }} \
-            run python -c "from subnet.validator.main import Validator; print('Validator import OK')"
+            run python -c "import subnet.validator.main; print('Validator module OK')"
 
       - name: Smoke test sandbox image
         run: |
           docker run --rm --entrypoint python ${{ env.IMAGE_PREFIX }}/sandbox:${{ needs.determine-tag.outputs.tag }} \
-            -c "from src.agent.agent_interface import AgentInterface; print('Sandbox import OK')"
+            -c "import src.agent.agent_interface; print('Sandbox module OK')"


### PR DESCRIPTION
## Description

v1.0.47's smoke test failed because the sandbox step tried to import `AgentInterface` from `src.agent.agent_interface`, but that class doesn't exist — the module exposes `ToolCallResult`, `register_tool`, `Tool`, etc. The original smoke step (added in #81) asserted a symbol that was never there; the check only started running once #86 and #87 fixed the earlier issues that kept it from reaching the import.

Switch both steps to import the module itself instead of pulling a named symbol. That still proves the image can load the code — the actual value of a smoke test — without coupling to exports that drift over time.

## Changes Made

- Validator smoke step: `import subnet.validator.main`
- Sandbox smoke step: `import src.agent.agent_interface`

## Issue Link

- Related to: follow-up to #86, #87
- Closes: N/A

## Testing

### Manual Testing

Ran both commands locally against the published v1.0.47 images before committing:

```
$ docker run --rm --entrypoint python ghcr.io/oro-ai/oro/sandbox:v1.0.47 \
    -c "import src.agent.agent_interface; print('Sandbox module OK')"
Sandbox module OK

$ docker run --rm --entrypoint uv ghcr.io/oro-ai/oro/validator:v1.0.47 \
    run python -c "import subnet.validator.main; print('Validator module OK')"
Validator module OK
```

**Test Results:** both exit 0.

### Automated Testing

N/A — workflow-only change; next `v*` push exercises it end-to-end.

**Test Command(s):**
```bash
git tag -a v1.0.48 <sha> -m "..." && git push origin v1.0.48
```

## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**

N/A

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

Validated against real published images this time, so the next publish run should be clean.