### PR TITLE
ci: gate image tag push on smoke test passing (ORO-894)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -105,8 +105,48 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  smoke-test:
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download validator digest (amd64)
+        uses: actions/download-artifact@v4
+        with:
+          name: digest-validator-linux-amd64
+          path: /tmp/digests/validator
+
+      - name: Download sandbox digest (amd64)
+        uses: actions/download-artifact@v4
+        with:
+          name: digest-sandbox-linux-amd64
+          path: /tmp/digests/sandbox
+
+      # Override ENTRYPOINT so argv runs our import check instead of booting
+      # a live validator. Validator deps live in a uv-managed venv, so we
+      # enter through `uv run` rather than the system python.
+      - name: Smoke test validator image
+        run: |
+          digest=$(ls /tmp/digests/validator | head -1)
+          docker run --rm --entrypoint uv ${{ env.IMAGE_PREFIX }}/validator@sha256:$digest \
+            run python -c "import subnet.validator.main; print('Validator module OK')"
+
+      - name: Smoke test sandbox image
+        run: |
+          digest=$(ls /tmp/digests/sandbox | head -1)
+          docker run --rm --entrypoint python ${{ env.IMAGE_PREFIX }}/sandbox@sha256:$digest \
+            -c "import src.agent.agent_interface; print('Sandbox module OK')"
+
   merge:
-    needs: [determine-tag, build]
+    needs: [determine-tag, smoke-test]
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -137,29 +177,3 @@ jobs:
             -t ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:${{ needs.determine-tag.outputs.tag }} \
             -t ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:latest \
             $(printf '${{ env.IMAGE_PREFIX }}/${{ matrix.image }}@sha256:%s ' $(ls /tmp/digests/))
-
-  smoke-test:
-    needs: [determine-tag, merge]
-    runs-on: ubuntu-latest
-    permissions:
-      packages: read
-    steps:
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Override ENTRYPOINT so argv runs our import check instead of booting
-      # a live validator. Validator deps live in a uv-managed venv, so we
-      # enter through `uv run` rather than the system python.
-      - name: Smoke test validator image
-        run: |
-          docker run --rm --entrypoint uv ${{ env.IMAGE_PREFIX }}/validator:${{ needs.determine-tag.outputs.tag }} \
-            run python -c "import subnet.validator.main; print('Validator module OK')"
-
-      - name: Smoke test sandbox image
-        run: |
-          docker run --rm --entrypoint python ${{ env.IMAGE_PREFIX }}/sandbox:${{ needs.determine-tag.outputs.tag }} \
-            -c "import src.agent.agent_interface; print('Sandbox module OK')"


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does. Include the motivation and context if relevant. -->

Restructures `publish-images.yml` so the smoke test runs **before** any `:tag` or `:latest` manifest is pushed to GHCR. Previously, `merge` ran before `smoke-test`, meaning all four publish runs for v1.0.44–v1.0.47 pushed broken images to `:latest` before the canary fired.

New job order: `build` → `smoke-test` (by digest) → `merge`

## Changes Made

<!-- List the key changes made in this PR: -->
- Moved `smoke-test` job to depend on `build` instead of `merge`
- Smoke test now pulls the `linux/amd64` per-digest artifact and runs against `image@sha256:<digest>` — no tag needed
- `merge` job now depends on `smoke-test` instead of `build`, so tags are never pushed if smoke fails
- Per-digest blobs still upload during `build` (addressable by digest only, no human-visible tags)

## Issue Link

<!-- Link to the related issue(s). Use "Closes #issue_number" or "Fixes #issue_number" if this PR resolves an issue: -->
- Related to: #86, #87, #88
- Closes: ORO-894

## Testing

### Manual Testing
<!-- Describe the manual testing steps you performed: -->

To verify: trigger the workflow with a broken import (e.g., remove a dep so `from subnet.validator.main import Validator` fails). Smoke test should fail and `:tag`/`:latest` should not advance.

**Test Results:**
N/A — workflow change only, no runtime code modified.

### Automated Testing
<!-- Describe any automated tests that were run like unit tests, integration tests, scripts, etc.: -->

N/A

**Test Command(s):**
```bash
# No automated tests applicable to workflow-only changes
```

## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
N/A

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

The smoke test runs on `ubuntu-latest` (linux/amd64), so it tests the amd64 digest. The arm64 image is tested indirectly — if the amd64 build passes smoke, both platforms' digests go into the merged manifest.