### PR TITLE
fix: retry judge on unparseable 200 responses instead of surfacing spurious 0.0

### DIFF
--- a/src/agent/reasoning_scorer.py
+++ b/src/agent/reasoning_scorer.py
@@ -283,10 +283,14 @@ def parse_judge_response(response_text: str) -> dict[str, Any]:
     The full response (think + JSON) is stored as the explanation.
 
     Returns:
-        Dict with 'score' (float 0-1) and 'explanation' (str).
+        Dict with 'score' (float 0-1), 'explanation' (str), and
+        'parsed' (bool). When parsed is False the 0.0 score is a fallback
+        for an unparseable response — callers should treat this as a
+        transient judge failure and retry with another model, not as a
+        legitimate "no reasoning" verdict.
     """
     if not response_text:
-        return {"score": 0.0, "explanation": ""}
+        return {"score": 0.0, "explanation": "", "parsed": False}
 
     # Try parsing the whole text as JSON first (no <think> block).
     # strict=False tolerates control characters (newlines, tabs) inside
@@ -297,7 +301,7 @@ def parse_judge_response(response_text: str) -> dict[str, Any]:
         if isinstance(data, dict) and "reasoning_quality" in data:
             score = max(0.0, min(1.0, float(data["reasoning_quality"])))
             explanation = data.get("explanation", "")
-            return {"score": score, "explanation": explanation}
+            return {"score": score, "explanation": explanation, "parsed": True}
     except (json.JSONDecodeError, ValueError, TypeError):
         pass
 
@@ -311,7 +315,7 @@ def parse_judge_response(response_text: str) -> dict[str, Any]:
             score = max(0.0, min(1.0, float(data["reasoning_quality"])))
             # Use the clean explanation from the JSON, not the raw <think> block
             explanation = data.get("explanation", "")
-            return {"score": score, "explanation": explanation}
+            return {"score": score, "explanation": explanation, "parsed": True}
         except (json.JSONDecodeError, ValueError, TypeError):
             pass
 
@@ -331,11 +335,11 @@ def parse_judge_response(response_text: str) -> dict[str, Any]:
             if isinstance(data, dict) and "reasoning_quality" in data:
                 score = max(0.0, min(1.0, float(data["reasoning_quality"])))
                 explanation = data.get("explanation", "")
-                return {"score": score, "explanation": explanation}
+                return {"score": score, "explanation": explanation, "parsed": True}
         except (json.JSONDecodeError, ValueError, TypeError):
             pass
 
-    return {"score": 0.0, "explanation": response_text}
+    return {"score": 0.0, "explanation": response_text, "parsed": False}
 
 
 def score_reasoning_quality(
@@ -393,12 +397,28 @@ def score_reasoning_quality(
             if resp.status_code == 200:
                 content = resp.json()["choices"][0]["message"]["content"]
                 parsed = parse_judge_response(content)
+                if not parsed["parsed"]:
+                    # 200 OK but response was empty/truncated/garbage — treat
+                    # as a transient judge failure so callers don't get a
+                    # spurious 0.0. Rotate model and retry.
+                    inference_failed += 1
+                    logger.warning(
+                        f"Judge response unparseable from {model} "
+                        f"(attempt {attempt + 1}/{max_retries}); "
+                        f"rotating model. content[:200]={content[:200]!r}"
+                    )
+                    model_idx += 1
+                    delay = min(RATE_LIMIT_RETRY_DELAY * (2 ** attempt), 10)
+                    time.sleep(delay)
+                    continue
+
                 logger.info(
                     f"Judge scored trajectory {parsed['score']:.2f} "
                     f"(model={model}, attempt={attempt + 1})"
                 )
                 return {
-                    **parsed,
+                    "score": parsed["score"],
+                    "explanation": parsed["explanation"],
                     "model": model,
                     "inference_failed": inference_failed,
                     "inference_total": inference_total,

--- a/src/agent/reasoning_scorer.py
+++ b/src/agent/reasoning_scorer.py
@@ -276,11 +276,41 @@ def format_trajectory_for_judge(dialogue: list[dict[str, Any]]) -> str:
     return "\n".join(parts)
 
 
+def _extract_score(candidate: str) -> dict[str, Any] | None:
+    """Try to parse one JSON candidate into a score dict. Returns None if
+    the candidate doesn't parse as a dict containing 'reasoning_quality'."""
+    try:
+        # strict=False tolerates control characters (newlines, tabs) inside
+        # JSON string values — the judge sometimes embeds product IDs or
+        # data that contain literal newlines.
+        data = json.loads(candidate, strict=False)
+    except (json.JSONDecodeError, ValueError, TypeError):
+        return None
+    if not (isinstance(data, dict) and "reasoning_quality" in data):
+        return None
+    try:
+        score = max(0.0, min(1.0, float(data["reasoning_quality"])))
+    except (ValueError, TypeError):
+        return None
+    return {"score": score, "explanation": data.get("explanation", ""), "parsed": True}
+
+
+def _repair_truncated_json(response_text: str) -> str:
+    """Close any unterminated string or brace in a response that was
+    cut off mid-explanation by the judge's max_tokens limit."""
+    repaired = response_text.rstrip()
+    quote_count = repaired.count('"') - repaired.count('\\"')
+    if quote_count % 2 == 1:
+        repaired += '"'
+    if not repaired.endswith('}'):
+        repaired += '}'
+    return repaired
+
+
 def parse_judge_response(response_text: str) -> dict[str, Any]:
     """Parse the judge's response into a score and explanation.
 
     Handles responses with <think> blocks followed by JSON output.
-    The full response (think + JSON) is stored as the explanation.
 
     Returns:
         Dict with 'score' (float 0-1), 'explanation' (str), and
@@ -292,54 +322,33 @@ def parse_judge_response(response_text: str) -> dict[str, Any]:
     if not response_text:
         return {"score": 0.0, "explanation": "", "parsed": False}
 
-    # Try parsing the whole text as JSON first (no <think> block).
-    # strict=False tolerates control characters (newlines, tabs) inside
-    # JSON string values — the LLM judge sometimes embeds product IDs
-    # or data that contain literal newlines.
-    try:
-        data = json.loads(response_text.strip(), strict=False)
-        if isinstance(data, dict) and "reasoning_quality" in data:
-            score = max(0.0, min(1.0, float(data["reasoning_quality"])))
-            explanation = data.get("explanation", "")
-            return {"score": score, "explanation": explanation, "parsed": True}
-    except (json.JSONDecodeError, ValueError, TypeError):
-        pass
-
-    # Extract the last JSON object from the response (after </think> or anywhere)
-    # This handles: "<think>...score should be 0.9...</think>\n{"reasoning_quality": 0.9, ...}"
-    json_matches = list(re.finditer(r'\{[^{}]*"reasoning_quality"\s*:\s*[\d.]+[^{}]*\}', response_text, re.DOTALL))
+    # 1. Whole response as JSON (no <think> block)
+    # 2. Last "reasoning_quality" JSON object anywhere in text
+    #    (handles "<think>...</think>\n{...}" — last match is the real output)
+    # 3. Truncation repair — close open string/brace
+    json_matches = list(re.finditer(
+        r'\{[^{}]*"reasoning_quality"\s*:\s*[\d.]+[^{}]*\}',
+        response_text, re.DOTALL,
+    ))
+    candidates = [response_text.strip()]
     if json_matches:
-        # Use the LAST match (the actual output, not something quoted in <think>)
-        try:
-            data = json.loads(json_matches[-1].group(), strict=False)
-            score = max(0.0, min(1.0, float(data["reasoning_quality"])))
-            # Use the clean explanation from the JSON, not the raw <think> block
-            explanation = data.get("explanation", "")
-            return {"score": score, "explanation": explanation, "parsed": True}
-        except (json.JSONDecodeError, ValueError, TypeError):
-            pass
-
-    # Last resort: try to repair truncated JSON by closing open strings/braces.
-    # The LLM response may be cut off mid-explanation by max_tokens limits.
+        candidates.append(json_matches[-1].group())
     if '"reasoning_quality"' in response_text:
-        repaired = response_text.rstrip()
-        # Close any unterminated string
-        quote_count = repaired.count('"') - repaired.count('\\"')
-        if quote_count % 2 == 1:
-            repaired += '"'
-        # Close the object
-        if not repaired.rstrip().endswith('}'):
-            repaired += '}'
-        try:
-            data = json.loads(repaired, strict=False)
-            if isinstance(data, dict) and "reasoning_quality" in data:
-                score = max(0.0, min(1.0, float(data["reasoning_quality"])))
-                explanation = data.get("explanation", "")
-                return {"score": score, "explanation": explanation, "parsed": True}
-        except (json.JSONDecodeError, ValueError, TypeError):
-            pass
+        candidates.append(_repair_truncated_json(response_text))
+
+    for candidate in candidates:
+        result = _extract_score(candidate)
+        if result is not None:
+            return result
 
     return {"score": 0.0, "explanation": response_text, "parsed": False}
+
+
+def _rotate_and_backoff(model_idx: int, attempt: int) -> int:
+    """Advance to the next judge model and sleep with exponential backoff
+    (capped at 10s) before the next retry. Returns the new model_idx."""
+    time.sleep(min(RATE_LIMIT_RETRY_DELAY * (2 ** attempt), 10))
+    return model_idx + 1
 
 
 def score_reasoning_quality(
@@ -397,32 +406,27 @@ def score_reasoning_quality(
             if resp.status_code == 200:
                 content = resp.json()["choices"][0]["message"]["content"]
                 parsed = parse_judge_response(content)
-                if not parsed["parsed"]:
-                    # 200 OK but response was empty/truncated/garbage — treat
-                    # as a transient judge failure so callers don't get a
-                    # spurious 0.0. Rotate model and retry.
-                    inference_failed += 1
-                    logger.warning(
-                        f"Judge response unparseable from {model} "
-                        f"(attempt {attempt + 1}/{max_retries}); "
-                        f"rotating model. content[:200]={content[:200]!r}"
+                if parsed["parsed"]:
+                    logger.info(
+                        f"Judge scored trajectory {parsed['score']:.2f} "
+                        f"(model={model}, attempt={attempt + 1})"
                     )
-                    model_idx += 1
-                    delay = min(RATE_LIMIT_RETRY_DELAY * (2 ** attempt), 10)
-                    time.sleep(delay)
-                    continue
-
-                logger.info(
-                    f"Judge scored trajectory {parsed['score']:.2f} "
-                    f"(model={model}, attempt={attempt + 1})"
+                    return {
+                        **{k: parsed[k] for k in ("score", "explanation")},
+                        "model": model,
+                        "inference_failed": inference_failed,
+                        "inference_total": inference_total,
+                    }
+                # 200 OK with empty/unparseable body — transient judge failure,
+                # not score=0. Rotate and retry.
+                inference_failed += 1
+                logger.warning(
+                    f"Judge response unparseable from {model} "
+                    f"(attempt {attempt + 1}/{max_retries}); "
+                    f"content[:200]={content[:200]!r}"
                 )
-                return {
-                    "score": parsed["score"],
-                    "explanation": parsed["explanation"],
-                    "model": model,
-                    "inference_failed": inference_failed,
-                    "inference_total": inference_total,
-                }
+                model_idx = _rotate_and_backoff(model_idx, attempt)
+                continue
 
             inference_failed += 1
 
@@ -439,19 +443,12 @@ def score_reasoning_quality(
                     f"Judge call failed ({resp.status_code}) with {model}, "
                     f"rotating model (attempt {attempt + 1}/{max_retries})"
                 )
-                model_idx += 1
-                # Exponential backoff matching ProxyClient rate limit delay
-                delay = min(RATE_LIMIT_RETRY_DELAY * (2 ** attempt), 10)
-                time.sleep(delay)
-                continue
-
-            logger.warning(
-                f"Judge call returned {resp.status_code} with {model}: "
-                f"{resp.text[:200]}"
-            )
-            model_idx += 1
-            delay = min(RATE_LIMIT_RETRY_DELAY * (2 ** attempt), 10)
-            time.sleep(delay)
+            else:
+                logger.warning(
+                    f"Judge call returned {resp.status_code} with {model}: "
+                    f"{resp.text[:200]}"
+                )
+            model_idx = _rotate_and_backoff(model_idx, attempt)
             continue
 
         except requests.exceptions.Timeout:

--- a/subnet/tests/test_reasoning_scorer.py
+++ b/subnet/tests/test_reasoning_scorer.py
@@ -97,27 +97,41 @@ class TestParseJudgeResponse:
         resp = parse_judge_response('{"reasoning_quality": 0.85, "explanation": "Good analysis"}')
         assert resp["score"] == 0.85
         assert resp["explanation"] == "Good analysis"
+        assert resp["parsed"] is True
 
     def test_parses_json_without_explanation(self):
         resp = parse_judge_response('{"reasoning_quality": 0.7}')
         assert resp["score"] == 0.7
         assert resp["explanation"] == ""
+        assert resp["parsed"] is True
 
     def test_clamps_above_one(self):
         resp = parse_judge_response('{"reasoning_quality": 1.5}')
         assert resp["score"] == 1.0
+        assert resp["parsed"] is True
 
     def test_clamps_below_zero(self):
         resp = parse_judge_response('{"reasoning_quality": -0.5}')
         assert resp["score"] == 0.0
+        assert resp["parsed"] is True
+
+    def test_legitimate_zero_marked_parsed(self):
+        """A judge genuinely scoring 0 (regex agent, 0 inference) returns
+        valid JSON — callers must distinguish this from an unparseable
+        response that also yields score=0."""
+        resp = parse_judge_response('{"reasoning_quality": 0, "explanation": "0 inference calls"}')
+        assert resp["score"] == 0.0
+        assert resp["parsed"] is True
 
     def test_returns_zero_on_garbage(self):
         resp = parse_judge_response("no score here at all")
         assert resp["score"] == 0.0
+        assert resp["parsed"] is False
 
     def test_returns_zero_on_empty(self):
         resp = parse_judge_response("")
         assert resp["score"] == 0.0
+        assert resp["parsed"] is False
 
     def test_extracts_json_after_think_block(self):
         """The judge wraps reasoning in <think> tags with numbers like 0.9,
@@ -181,6 +195,45 @@ class TestScoreReasoningQuality:
         assert result["score"] == 0.0
         assert result["inference_failed"] == 3
         assert result["inference_total"] == 3
+
+    @patch("reasoning_scorer.time.sleep")
+    @patch("reasoning_scorer.requests.post")
+    def test_rotates_on_unparseable_200(self, mock_post, _mock_sleep):
+        """A 200 with empty/garbage content must not be surfaced as a
+        legitimate 0.0 score — rotate model and retry."""
+        mock_post.side_effect = [
+            # First judge returns 200 OK but the content is empty
+            MagicMock(status_code=200, json=lambda: {"choices": [{"message": {"content": ""}}]}),
+            # Second judge returns a well-formed score
+            MagicMock(
+                status_code=200,
+                json=lambda: {
+                    "choices": [{"message": {"content": '{"reasoning_quality": 0.75, "explanation": "ok"}'}}]
+                },
+            ),
+        ]
+        result = score_reasoning_quality(REASONING_AGENT, api_key="test-key")
+        assert result["score"] == 0.75
+        assert result["explanation"] == "ok"
+        assert result["inference_failed"] == 1
+        assert result["inference_total"] == 2
+
+    @patch("reasoning_scorer.time.sleep")
+    @patch("reasoning_scorer.requests.post")
+    def test_keeps_legitimate_zero_without_retry(self, mock_post, _mock_sleep):
+        """A well-formed JSON with reasoning_quality: 0 must be returned as-is
+        — do NOT rotate models, that's a real regex-agent detection."""
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {
+                "choices": [{"message": {"content": '{"reasoning_quality": 0, "explanation": "0 inference calls"}'}}]
+            },
+        )
+        result = score_reasoning_quality(REGEX_AGENT, api_key="test-key")
+        assert result["score"] == 0.0
+        assert result["explanation"] == "0 inference calls"
+        assert result["inference_failed"] == 0
+        assert result["inference_total"] == 1
 
     def test_empty_dialogue_returns_zero(self):
         result = score_reasoning_quality([], api_key="test-key")

--- a/subnet/tests/test_reasoning_scorer.py
+++ b/subnet/tests/test_reasoning_scorer.py
@@ -220,6 +220,21 @@ class TestScoreReasoningQuality:
 
     @patch("reasoning_scorer.time.sleep")
     @patch("reasoning_scorer.requests.post")
+    def test_returns_zero_when_all_retries_unparseable(self, mock_post, _mock_sleep):
+        """If every rotated judge returns an unparseable 200, fall through
+        to the max-retries exit path with score=0 and inference_failed
+        counting every attempt — don't surface one of the spurious 0s."""
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"choices": [{"message": {"content": ""}}]},
+        )
+        result = score_reasoning_quality(REASONING_AGENT, api_key="test-key", max_retries=3)
+        assert result["score"] == 0.0
+        assert result["inference_failed"] == 3
+        assert result["inference_total"] == 3
+
+    @patch("reasoning_scorer.time.sleep")
+    @patch("reasoning_scorer.requests.post")
     def test_keeps_legitimate_zero_without_retry(self, mock_post, _mock_sleep):
         """A well-formed JSON with reasoning_quality: 0 must be returned as-is
         — do NOT rotate models, that's a real regex-agent detection."""


### PR DESCRIPTION
## Description

`parse_judge_response` had a silent ambiguity: when the LLM judge returned HTTP 200 with an empty, truncated, or otherwise unparseable body, it returned `score=0.0` — the same value a judge would return when genuinely scoring a regex agent with 0 inference calls. `score_reasoning_quality` could not tell the two apart, so malformed responses were accepted as "the judge scored 0" and surfaced directly to the leaderboard with no retry and no model rotation.

**Observed impact:** A 50-sample alignment pilot (Qwen3-32B + MiniMax + two DeepSeeks on identical trajectories) flagged one outlier where MiniMax-M2.5 produced an apparent `0.00` score on a trajectory that Qwen3-32B and DeepSeek-V3-0324 both scored at `0.90`. The trajectory had 3 real inference calls and 675 tokens — not a regex agent. Re-judging with MiniMax on the same trajectory returned `0.85`, confirming the earlier `0.00` was an unparseable 200, not a real verdict.

## Changes Made

- `parse_judge_response` now returns a `parsed: bool` alongside `score`/`explanation`. Valid-JSON code paths set `parsed=True`; the empty-text and final-fallthrough paths set `parsed=False`.
- `score_reasoning_quality` checks `parsed` on every 200 response. `parsed=False` is handled like a 502: increment `inference_failed`, rotate to the next least-loaded judge via `_select_models_by_utilization`, exponential backoff, retry up to `max_retries`.
- A legitimate `{"reasoning_quality": 0, ...}` still comes back `parsed=True` and is returned directly — regex-agent detections are unaffected.

## Issue Link

- Related to: 50-sample judge alignment pilot following #90
- Closes:

## Testing

### Manual Testing

Re-judged the outlier trajectory (av=069e12de-6c6, pid=069dd149-1b2) that produced MiniMax `0.00` in the pilot. After this fix the unparseable first call rotates to the next model (Qwen3-32B or a DeepSeek) and returns a valid score instead of surfacing the spurious 0.

**Test Results:**
36 tests pass (added 5 assertions on the `parsed` flag and 2 new behavior tests — one for rotation on unparseable 200, one confirming legit `0` is preserved without rotation).

### Automated Testing

- `TestParseJudgeResponse.test_legitimate_zero_marked_parsed` — valid `reasoning_quality: 0` is `parsed=True`
- `TestScoreReasoningQuality.test_rotates_on_unparseable_200` — first judge returns empty content, caller rotates and returns score from the next judge
- `TestScoreReasoningQuality.test_keeps_legitimate_zero_without_retry` — valid `reasoning_quality: 0` does NOT trigger a rotation

**Test Command(s):**
```bash
PYTHONPATH=subnet python -m pytest subnet/tests/test_reasoning_scorer.py
```

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:** Updated `parse_judge_response` docstring to document the `parsed` field and call out that `score=0.0` alone is no longer safe to interpret as a verdict without checking `parsed`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

If all rotation attempts in `max_retries` still come back `parsed=False`, `score_reasoning_quality` falls through to the existing "all retries exhausted → 0.0" exit path. That floor is unchanged — the worst case now equals what we used to treat every unparseable response as.