### PR TITLE
hotfix: coerce null content from Chutes to avoid TypeError in judge retry

### DIFF
--- a/src/agent/reasoning_scorer.py
+++ b/src/agent/reasoning_scorer.py
@@ -404,7 +404,9 @@ def score_reasoning_quality(
             )
 
             if resp.status_code == 200:
-                content = resp.json()["choices"][0]["message"]["content"]
+                # Chutes sometimes returns {"choices":[{"message":{"content":null}}]}.
+                # Coerce to "" so downstream logging and parsing always see a str.
+                content = resp.json()["choices"][0]["message"]["content"] or ""
                 parsed = parse_judge_response(content)
                 if parsed["parsed"]:
                     logger.info(

--- a/subnet/tests/test_reasoning_scorer.py
+++ b/subnet/tests/test_reasoning_scorer.py
@@ -220,6 +220,27 @@ class TestScoreReasoningQuality:
 
     @patch("reasoning_scorer.time.sleep")
     @patch("reasoning_scorer.requests.post")
+    def test_handles_null_content_from_chutes(self, mock_post, _mock_sleep):
+        """Chutes sometimes returns {'choices':[{'message':{'content':null}}]}.
+        We must coerce to '' so the unparseable-200 retry path triggers
+        without crashing on content[:200]."""
+        mock_post.side_effect = [
+            # First judge returns 200 OK with content=null (the shape that crashed pre-hotfix)
+            MagicMock(status_code=200, json=lambda: {"choices": [{"message": {"content": None}}]}),
+            MagicMock(
+                status_code=200,
+                json=lambda: {
+                    "choices": [{"message": {"content": '{"reasoning_quality": 0.6, "explanation": "ok"}'}}]
+                },
+            ),
+        ]
+        result = score_reasoning_quality(REASONING_AGENT, api_key="test-key")
+        assert result["score"] == 0.6
+        assert result["inference_failed"] == 1
+        assert result["inference_total"] == 2
+
+    @patch("reasoning_scorer.time.sleep")
+    @patch("reasoning_scorer.requests.post")
     def test_returns_zero_when_all_retries_unparseable(self, mock_post, _mock_sleep):
         """If every rotated judge returns an unparseable 200, fall through
         to the max-retries exit path with score=0 and inference_failed


### PR DESCRIPTION
## Description

**Production hotfix.** v1.0.50 (PR #91) introduced a crash path when Chutes returns HTTP 200 with `content=null`.

The new unparseable-200 retry code reads:
```python
content = resp.json()["choices"][0]["message"]["content"]
```
`parse_judge_response(None)` is safe (it hits `if not response_text`). But the subsequent warning log does `content[:200]` unconditionally — which raises `TypeError: 'NoneType' object is not subscriptable` when `content` is actually `None`.

The TypeError is not caught by `score_reasoning_quality`'s try/except (which only handles `requests.exceptions.Timeout` and `RequestException`), so it propagates up and halts reasoning scoring for the problem. Hit during re-judge of Race #10 bug-signature trajectories.

## Changes Made

- Coerce `content` to `""` at read site. Single-character fix.
- Add `test_handles_null_content_from_chutes` regression test.

## Issue Link

- Follow-up to: #91
- Closes:

## Testing

### Manual Testing

Reproduced by running the re-judge script against a Race #10 trajectory — first Chutes response had `content=null`, crashed the scorer. With the fix applied locally, the same trajectory now correctly rotates to the next judge and returns a real score.

**Test Results:**
38 tests pass (1 new: null-content handling).

### Automated Testing

New test exercises the exact failure mode: first judge 200 with `content=null` → rotation → second judge 200 with valid JSON → real score returned.

**Test Command(s):**
```bash
PYTHONPATH=subnet python -m pytest subnet/tests/test_reasoning_scorer.py
```

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:** Inline comment at the coercion point explains the Chutes response shape we're guarding against.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

Needs immediate tag + promote to unblock production — current `:stable` (v1.0.50) is vulnerable to this crash any time Chutes returns null content, which happens sporadically on MiniMax.