### PR TITLE
fix: register agent module in sys.modules before exec_module

### DIFF
--- a/src/agent/sandbox_executor.py
+++ b/src/agent/sandbox_executor.py
@@ -5,6 +5,7 @@ import json
 import logging
 import multiprocessing
 import os
+import sys
 import time
 from concurrent.futures import (
     ThreadPoolExecutor,
@@ -103,7 +104,14 @@ def load_agent_from_file(file_path: str) -> Callable:
         raise ImportError(f"Could not create module spec from file: {file_path}")
 
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    # Register before exec so dataclass + PEP 563 annotations can resolve
+    # string types via sys.modules[cls.__module__] during class definition.
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
 
     if not hasattr(module, "agent_main"):
         raise ImportError(f"Module {file_path} does not define 'agent_main' function")

--- a/subnet/tests/fixtures/frozen_dataclass_agent.py
+++ b/subnet/tests/fixtures/frozen_dataclass_agent.py
@@ -1,0 +1,24 @@
+"""Test fixture: agent that uses `from __future__ import annotations`
+combined with `@dataclass(frozen=True)`.
+
+This pattern requires the loader to register the module in sys.modules
+before exec_module so Python's dataclass machinery can resolve string
+annotations via sys.modules[cls.__module__].
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class _Tunables:
+    answer: str = "hello-frozen"
+    threshold: float = 9.0
+
+
+_T = _Tunables()
+
+
+def agent_main(problem):
+    return {"answer": _T.answer, "query": problem.get("query", "")}

--- a/subnet/tests/test_sandbox_executor.py
+++ b/subnet/tests/test_sandbox_executor.py
@@ -12,6 +12,7 @@ FIXTURES = Path(__file__).parent / "fixtures"
 FAST = str(FIXTURES / "fast_agent.py")
 SLOW = str(FIXTURES / "slow_agent.py")
 CRASH = str(FIXTURES / "crashing_agent.py")
+FROZEN_DC = str(FIXTURES / "frozen_dataclass_agent.py")
 
 
 def test_successful_execution():
@@ -43,6 +44,17 @@ def test_missing_agent_file():
         {"query": "x"}, timeout=10.0, agent_file="/tmp/no_such_agent.py"
     )
     assert not result.success
+
+
+def test_frozen_dataclass_with_pep563_annotations():
+    """Agents using `from __future__ import annotations` + @dataclass rely on
+    the loaded module being present in sys.modules — dataclasses._is_type
+    reads sys.modules[cls.__module__] to resolve string-form annotations."""
+    result = execute_single_problem(
+        {"query": "anything", "id": "p-frozen"}, timeout=10.0, agent_file=FROZEN_DC
+    )
+    assert result.success
+    assert result.result["answer"] == "hello-frozen"
 
 
 class TestReadInferenceStats:


### PR DESCRIPTION
## Summary

Fixes a sandbox loader bug that breaks any agent using `from __future__ import annotations` together with `@dataclass`.

## The bug

`src/agent/sandbox_executor.py::load_agent_from_file` creates the agent module from an `importlib.util` spec but skips the `sys.modules` registration step. When the agent uses the (perfectly valid) combination of PEP 563 lazy annotations and dataclass:

```python
from __future__ import annotations
from dataclasses import dataclass

@dataclass(frozen=True)
class MyConfig:
    threshold: float = 9.0
```

Python 3.10's `dataclasses._is_type()` tries to resolve string annotations via `sys.modules[cls.__module__].__dict__`. Since we never registered the module, that returns `None`, and the class definition crashes with:

```
AttributeError: 'NoneType' object has no attribute '__dict__'
```

Result: the agent fails to import, `agent_main` never exists, and every problem fails in ~0.18s.

## The fix

One-line fix plus cleanup on failure:

```python
module = importlib.util.module_from_spec(spec)
sys.modules[module_name] = module
try:
    spec.loader.exec_module(module)
except Exception:
    sys.modules.pop(module_name, None)
    raise
```

This matches the documented pattern at https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly.

## Regression test

Added `subnet/tests/fixtures/frozen_dataclass_agent.py` (a minimal agent that uses the broken pattern) and `test_frozen_dataclass_with_pep563_annotations` to lock the behavior in. Verified:
- **Without the fix**: test fails in 0.09s with the exact `NoneType` error
- **With the fix**: test passes; all 11 tests in the file green
- `ruff check` clean

## Risk

Very low. Agents are loaded in per-problem child processes via `multiprocessing.Process`, so `sys.modules` registrations are isolated to that child's lifetime. No sandbox-escape implications (the agent already has full `sys.modules` access). Agents that don't use PEP 563 + `@dataclass` see zero behavior change — they never hit the `_is_type` code path that needs the lookup.