### PR TITLE
fix: skip zero-active-instance models when routing judge calls

### DIFF
--- a/src/agent/reasoning_scorer.py
+++ b/src/agent/reasoning_scorer.py
@@ -44,23 +44,59 @@ CHUTES_UTILIZATION_TIMEOUT = 5
 def _select_models_by_utilization() -> list[str]:
     """Query Chutes utilization API and return JUDGE_MODELS sorted by load.
 
+    Models reported with zero active instances are excluded. Chutes can
+    descale a model to 0 when idle; the utilization API then reports
+    utilization_current=0.0 (no traffic → no load), which would otherwise
+    make the ascending sort prefer it. Every call routed to a 0-instance
+    model fails, and those failures count toward the judge-infra-failure
+    threshold in the validator.
+
     Returns models sorted by utilization_current (ascending = least loaded
-    first). Falls back to the static JUDGE_MODELS list on any failure.
+    first), excluding any with active_instance_count == 0. Falls back to
+    the static JUDGE_MODELS list on any API failure, or if filtering would
+    leave no models.
     """
     try:
         resp = requests.get(CHUTES_UTILIZATION_URL, timeout=CHUTES_UTILIZATION_TIMEOUT)
         if resp.status_code != 200:
             return list(JUDGE_MODELS)
 
-        util_by_name = {
-            e["name"]: e.get("utilization_current", 1.0) for e in resp.json()
-        }
-        result = sorted(JUDGE_MODELS, key=lambda m: util_by_name.get(m, 1.0))
+        entries_by_name = {e["name"]: e for e in resp.json()}
 
-        logger.info(
-            "Judge model order by utilization: "
-            + ", ".join(f"{m}({util_by_name.get(m, -1):.0%})" for m in result)
+        def is_available(m: str) -> bool:
+            e = entries_by_name.get(m)
+            if e is None:
+                # Not reported by the utilization API — be permissive.
+                return True
+            count = e.get("active_instance_count")
+            if count is None:
+                # Field not present on this entry — be permissive.
+                return True
+            return count > 0
+
+        available = [m for m in JUDGE_MODELS if is_available(m)]
+        if not available:
+            logger.warning(
+                "All judge models report zero active instances on Chutes; "
+                "falling back to static model list"
+            )
+            return list(JUDGE_MODELS)
+
+        result = sorted(
+            available,
+            key=lambda m: entries_by_name.get(m, {}).get("utilization_current", 1.0),
         )
+
+        log_parts = [
+            f"{m}({entries_by_name.get(m, {}).get('utilization_current', -1):.0%})"
+            for m in result
+        ]
+        msg = "Judge model order by utilization: " + ", ".join(log_parts)
+        skipped = [m for m in JUDGE_MODELS if m not in available]
+        if skipped:
+            msg += f" | skipped (0 instances): {', '.join(skipped)}"
+        logger.info(msg)
+
         return result
     except Exception as e:
         logger.warning(f"Failed to fetch Chutes utilization, using static model list: {e}")

--- a/subnet/tests/test_reasoning_scorer.py
+++ b/subnet/tests/test_reasoning_scorer.py
@@ -320,6 +320,45 @@ class TestSelectModelsByUtilization:
             result = _select_models_by_utilization()
         assert result == JUDGE_MODELS
 
+    def test_zero_active_instances_excluded(self):
+        # A model at 0% utilization would otherwise sort first — but if it's
+        # reporting active_instance_count == 0 (Chutes descaled it) every call
+        # fails. It must be filtered out of the returned order.
+        descaled, *healthy = JUDGE_MODELS
+        entries = [
+            {"name": descaled, "utilization_current": 0.0, "active_instance_count": 0},
+        ] + [
+            {"name": m, "utilization_current": 0.5, "active_instance_count": 4}
+            for m in healthy
+        ]
+        with patch("reasoning_scorer.requests.get", return_value=self._mock_response(entries)):
+            result = _select_models_by_utilization()
+        assert descaled not in result
+        assert set(result) == set(healthy)
+
+    def test_all_zero_active_instances_falls_back_to_static(self):
+        # If every judge model is descaled, prefer the static list over
+        # returning an empty order (calls will still fail, but the validator
+        # behavior stays predictable).
+        entries = [
+            {"name": m, "utilization_current": 0.0, "active_instance_count": 0}
+            for m in JUDGE_MODELS
+        ]
+        with patch("reasoning_scorer.requests.get", return_value=self._mock_response(entries)):
+            result = _select_models_by_utilization()
+        assert result == list(JUDGE_MODELS)
+
+    def test_missing_active_instance_count_field_treated_as_available(self):
+        # Older/partial Chutes responses that omit active_instance_count must
+        # not cause models to be silently dropped.
+        entries = [
+            {"name": m, "utilization_current": 0.1 * i}
+            for i, m in enumerate(JUDGE_MODELS)
+        ]
+        with patch("reasoning_scorer.requests.get", return_value=self._mock_response(entries)):
+            result = _select_models_by_utilization()
+        assert set(result) == set(JUDGE_MODELS)
+
 
 class TestFormatProxyCall:
     def test_search_with_params(self):


### PR DESCRIPTION
## Summary

Chutes descales idle judge models to zero instances. When that happens, the utilization API reports `utilization_current=0.0` (no traffic → no load), and our ascending sort in `_select_models_by_utilization` picks the descaled model *first*. Every call routed to it fails, and those failures count toward the judge-infrastructure-failure threshold in the validator.

Observed during Race 11 (2026-04-24):

- MiniMax successful judge calls on the ORO validator dropped from 126/hr at 19:00 UTC to **0/hr at 20:00 UTC** — Chutes silently descaled mid-race.
- In that same hour the ORO validator logged **296 `Judge call failed`**, **129 `Judge call timed out`**, and **12 `Reasoning judge infrastructure`** run classifications. Race 9 and Race 10 showed none.
- MiniMax's utilization entry shows `instance_count: 0`, `active_instance_count: 0`, `action_taken: "scale_up_candidate"` — so it *is* the canary we can read.

## The fix

`_select_models_by_utilization` now filters out any entry with `active_instance_count == 0` before the ascending sort. It logs which models were skipped in the existing `Judge model order by utilization:` line so the routing decision stays visible.

Conservative choices:
- Models **missing from the API entirely** are kept (not all models are always returned) — permissive fallback.
- Models whose entry is **present but missing the `active_instance_count` field** are kept — permissive fallback for partial Chutes responses.
- If filtering would leave **zero models**, fall back to the full static `JUDGE_MODELS` list (calls will still fail, but behavior stays predictable and callers see their existing retry/rotation path).

## Testing

- All 4 existing `TestSelectModelsByUtilization` tests still pass (sort order, missing-model default, API error, non-200 fallback).
- 3 new tests added:
  - `test_zero_active_instances_excluded` — directly reproduces Race 11. Without the fix it fails with the descaled model still first in the returned order; with the fix it passes.
  - `test_all_zero_active_instances_falls_back_to_static` — every model descaled, we return the static list rather than an empty routing order.
  - `test_missing_active_instance_count_field_treated_as_available` — older/partial Chutes responses don't silently drop models.
- `ruff check` clean.

## Risk

Very low. The only case in which behavior changes from the current code is when a judge model is actively reporting `active_instance_count: 0` on the Chutes utilization API, which is exactly the case we're fixing. Every other code path (missing entry, missing field, API error, all-healthy) behaves identically to before.