### PR TITLE
feat: report per-problem execution time in progress updates

### DIFF
--- a/docker/validator/pyproject.toml
+++ b/docker/validator/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "async-substrate-interface==1.6.4",
     "bittensor==10.1.0",
     "bittensor-wallet==4.0.1",
-    "oro-sdk==1.0.36",
+    "oro-sdk==1.0.45",
     "requests==2.32.5",
     "sentence-transformers==5.3.0",
     "torch>=2.11.0,<3",

--- a/docker/validator/uv.lock
+++ b/docker/validator/uv.lock
@@ -279,6 +279,18 @@ wheels = [
 ]
 
 [[package]]
+name = "bittensor-auth"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bittensor-wallet" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/d0/c27114eebcf4f425b25682e4ff6ca0dc6fab5d9dc948a36a1474eef9b287/bittensor_auth-0.1.1.tar.gz", hash = "sha256:11dc1936098ea7201fbad3de7156aaa6154d243bb9db3ac9fccce964fe4bfddd", size = 1471152, upload-time = "2026-04-21T04:31:17.536Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/eb/67d16cf7fb491c21ca60e127da5c5420bc80a7a2b0706d4cc383adf410c6/bittensor_auth-0.1.1-py3-none-any.whl", hash = "sha256:0683ecd81be795d28b490d0a19ca6d6ccc0baff68ebdb03f5fb6e8c03740cbdd", size = 35169, upload-time = "2026-04-21T04:31:15.619Z" },
+]
+
+[[package]]
 name = "bittensor-drand"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1350,16 +1362,17 @@ wheels = [
 
 [[package]]
 name = "oro-sdk"
-version = "1.0.36"
+version = "1.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
+    { name = "bittensor-auth" },
     { name = "httpx" },
     { name = "python-dateutil" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/66/c8afa6743ae627c2390af66ba724669918a5e6d559311962e744ea0256c2/oro_sdk-1.0.36.tar.gz", hash = "sha256:f7c938f2abdfd2f2b469e740da382543f1de172ec7c7b2fe76edc6c91204d246", size = 106735, upload-time = "2026-04-14T19:30:10.971Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/41/1e7a75d1ebaff281085daf22b9eb35ef3492b7851f9a4ee42edf3b4b8a1c/oro_sdk-1.0.45.tar.gz", hash = "sha256:d2f7e86ab80b4967d0551625c8130635467cc4582623adc241b72d985b5b78ab", size = 107745, upload-time = "2026-04-24T21:10:15.108Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/27/dab87682271e1ee451e4da3b39f921f5735347d2d55319ad2402558c8605/oro_sdk-1.0.36-py3-none-any.whl", hash = "sha256:ee5501ce0212bfbe51a7213f79f85b0c1f3e80321638391f8da582b3e22a9a66", size = 265068, upload-time = "2026-04-14T19:30:09.335Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ac/004afa080c9cea9bf967caf68f4684a35e1a86f02e0d1b0c1431fce03c72/oro_sdk-1.0.45-py3-none-any.whl", hash = "sha256:295912b422e120a07a49ad112fb7954555afbc9699325f69c72e8e561ed6b231", size = 269240, upload-time = "2026-04-24T21:10:13.574Z" },
 ]
 
 [[package]]
@@ -1383,10 +1396,10 @@ requires-dist = [
     { name = "async-substrate-interface", specifier = "==1.6.4" },
     { name = "bittensor", specifier = "==10.1.0" },
     { name = "bittensor-wallet", specifier = "==4.0.1" },
-    { name = "oro-sdk", specifier = "==1.0.36" },
+    { name = "oro-sdk", specifier = "==1.0.45" },
     { name = "requests", specifier = "==2.32.5" },
     { name = "sentence-transformers", specifier = "==5.3.0" },
-    { name = "torch", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torch", specifier = ">=2.11.0,<3", index = "https://download.pytorch.org/whl/cpu" },
     { name = "ujson", specifier = "==5.12.0" },
 ]
 
@@ -2363,13 +2376,13 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:91209c7d8a2460b76e8ff5b28b7623da4ab1d27474b79e1de83e954871985afe" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d75eadcd97fe0dc7cd0eedc4d72152484c19cb2cfe46ce55766c8e129116425f" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:43b35116802c85fb88d99f4a396b8bd4472bfca1dd82e69499e5a4f9b8b4e252" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:442ec9dc78592564fdad69cf0beaa9da2f82ab810ccb4f13903869a90bf3f15d" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cc3a195701bba2239c313ee311487f80f8aaebe9e89b9073dddbcf2f93b5a0ba" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:072a0d6e4865e8b0dc0dbfe6ebed68fae235124222835ef03e5814d414d8c012" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:23ec7789017da9d95b6d543d790814785e6f30905c5443efa8257d1490d73f79" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:91209c7d8a2460b76e8ff5b28b7623da4ab1d27474b79e1de83e954871985afe", upload-time = "2026-03-23T15:16:50Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d75eadcd97fe0dc7cd0eedc4d72152484c19cb2cfe46ce55766c8e129116425f", upload-time = "2026-03-23T15:16:54Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:43b35116802c85fb88d99f4a396b8bd4472bfca1dd82e69499e5a4f9b8b4e252", upload-time = "2026-03-23T15:16:58Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:442ec9dc78592564fdad69cf0beaa9da2f82ab810ccb4f13903869a90bf3f15d", upload-time = "2026-03-23T15:17:02Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cc3a195701bba2239c313ee311487f80f8aaebe9e89b9073dddbcf2f93b5a0ba", upload-time = "2026-03-23T15:17:06Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:072a0d6e4865e8b0dc0dbfe6ebed68fae235124222835ef03e5814d414d8c012", upload-time = "2026-03-23T15:17:10Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:23ec7789017da9d95b6d543d790814785e6f30905c5443efa8257d1490d73f79", upload-time = "2026-03-23T15:17:14Z" },
 ]
 
 [[package]]
@@ -2391,34 +2404,34 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp310-cp310-linux_s390x.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp310-cp310-win_amd64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-linux_s390x.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-win_amd64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-linux_s390x.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-win_amd64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313-linux_s390x.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313-win_amd64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313t-linux_s390x.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313t-win_amd64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-linux_s390x.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-win_amd64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-linux_s390x.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-win_amd64.whl" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp310-cp310-linux_s390x.whl", upload-time = "2026-03-23T14:58:58Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp310-cp310-manylinux_2_28_aarch64.whl", upload-time = "2026-03-23T14:58:58Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl", upload-time = "2026-03-23T14:58:58Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp310-cp310-win_amd64.whl", upload-time = "2026-03-23T14:58:58Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-linux_s390x.whl", upload-time = "2026-03-23T14:58:58Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", upload-time = "2026-03-23T14:59:00Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl", upload-time = "2026-03-23T14:59:00Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-win_amd64.whl", upload-time = "2026-03-23T14:59:01Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-linux_s390x.whl", upload-time = "2026-03-23T14:59:01Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", upload-time = "2026-03-23T14:59:02Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", upload-time = "2026-03-23T14:59:03Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-win_amd64.whl", upload-time = "2026-03-23T14:59:04Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313-linux_s390x.whl", upload-time = "2026-03-23T14:59:04Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", upload-time = "2026-03-23T14:59:04Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", upload-time = "2026-03-23T14:59:05Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313-win_amd64.whl", upload-time = "2026-03-23T14:59:06Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313t-linux_s390x.whl", upload-time = "2026-03-23T14:59:07Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl", upload-time = "2026-03-23T14:59:07Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl", upload-time = "2026-03-23T14:59:07Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313t-win_amd64.whl", upload-time = "2026-03-23T14:59:09Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-linux_s390x.whl", upload-time = "2026-03-23T14:59:09Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", upload-time = "2026-03-23T14:59:10Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", upload-time = "2026-03-23T14:59:11Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-win_amd64.whl", upload-time = "2026-03-23T14:59:12Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-linux_s390x.whl", upload-time = "2026-03-23T14:59:12Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", upload-time = "2026-03-23T14:59:12Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", upload-time = "2026-03-23T14:59:13Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-win_amd64.whl", upload-time = "2026-03-23T14:59:15Z" },
 ]
 
 [[package]]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ duckduckgo_search==8.1.1
 colorama==0.4.6
 googlesearch-python==1.3.0
 bittensor==10.1.0
-oro-sdk==1.0.36
+oro-sdk==1.0.45

--- a/src/agent/sandbox_executor.py
+++ b/src/agent/sandbox_executor.py
@@ -332,6 +332,11 @@ def _format_single_result(result: ExecutionResult) -> Optional[str]:
         if result.problem_id and "problem_id" not in step.get("extra_info", {}):
             step.setdefault("extra_info", {})["problem_id"] = result.problem_id
 
+    # Stamp per-problem execution time onto the first step only — consumers
+    # (validator progress_reporter) read it from dialogue[0].extra_info.
+    if dialogue_steps:
+        dialogue_steps[0].setdefault("extra_info", {})["execution_time"] = result.execution_time
+
     # Distribute proxy calls across steps by timestamp approximation.
     # Calls before the first step go to step 0; calls between step N and N+1
     # go to step N.

--- a/subnet/tests/validator/test_sandbox_executor_format.py
+++ b/subnet/tests/validator/test_sandbox_executor_format.py
@@ -1,0 +1,40 @@
+"""Unit tests for _format_single_result output JSONL shape."""
+
+import json
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+# Allow `src.agent` imports from the repo root
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from src.agent.sandbox_executor import ExecutionResult, _format_single_result
+
+
+def _make_result(success: bool, dialogue: Optional[List], execution_time: float) -> ExecutionResult:
+    return ExecutionResult(
+        query="find a laptop",
+        success=success,
+        result=dialogue,
+        execution_time=execution_time,
+        problem_id="11111111-1111-1111-1111-111111111111",
+    )
+
+
+class TestFormatSingleResultExecutionTime:
+    def test_execution_time_stamped_on_first_step(self):
+        dialogue = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "ok"}]
+        line = _format_single_result(_make_result(success=True, dialogue=dialogue, execution_time=4.25))
+        assert line is not None
+        steps = json.loads(line)
+        assert steps[0]["extra_info"]["execution_time"] == 4.25
+
+    def test_execution_time_not_duplicated_on_later_steps(self):
+        dialogue = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "ok"}]
+        line = _format_single_result(_make_result(success=True, dialogue=dialogue, execution_time=4.25))
+        steps = json.loads(line)
+        assert "execution_time" not in steps[1].get("extra_info", {})
+
+    def test_failure_still_returns_none(self):
+        line = _format_single_result(_make_result(success=False, dialogue=None, execution_time=1.0))
+        assert line is None

--- a/subnet/validator/progress_reporter.py
+++ b/subnet/validator/progress_reporter.py
@@ -47,6 +47,7 @@ class ProblemResult:
     reasoning_model: str = ""
     reasoning_inf_failed: int = 0
     reasoning_inf_total: int = 0
+    execution_time: float | None = None
 
 
 # Default number of concurrent scoring workers
@@ -455,6 +456,7 @@ class ProgressReporter:
                 return
 
             extra_info = (dialogue[0].get("extra_info") or {}) if dialogue else {}
+            execution_time = extra_info.get("execution_time")
             query = problem.get("query") or extra_info.get("query")
             category = problem.get("category", "product").lower()
 
@@ -486,6 +488,7 @@ class ProgressReporter:
                 score_dict=score_dict if isinstance(score_dict, dict) else {},
                 inference_failures=inf_failures,
                 inference_total=inf_total,
+                execution_time=execution_time,
                 **reasoning,
             )
             with self._lock:
@@ -605,6 +608,7 @@ class ProgressReporter:
                 score_components_summary=scs,
                 inference_failure_count=r.inference_failures if r.inference_total > 0 else None,
                 inference_total=r.inference_total if r.inference_total > 0 else None,
+                execution_time=r.execution_time,
             )
             updates.append(update)
 


### PR DESCRIPTION
## Description

Surfaces the sandbox's per-problem `execution_time` (seconds, float) on each heartbeat progress update, so consumers can see how long each problem took. The sandbox already measures the value into `ExecutionResult.execution_time`; this PR plumbs it through the existing dialogue → progress-reporter → backend channel.

## Changes Made

- `chore: bump oro-sdk to 1.0.45` — picks up the new optional `execution_time` field on `ProblemProgressUpdate`.
- `feat: include execution_time in sandbox dialogue extra_info` — the parent process stamps `execution_time` onto `dialogue_steps[0].extra_info` in `_format_single_result`, alongside the existing `step` / `query` / `timestamp` / `problem_id` / `proxy_calls` metadata.
- `feat: report per-problem execution_time in progress updates` — `ProgressReporter._score_problem` reads the value off `extra_info[0]` into a new `ProblemResult.execution_time` field, and `_batch_report` forwards it to the backend.

No new sidecar files. No new IPC channels. The progress reporter learns about execution time through the same JSONL output it already tails for dialogues.

`execution_time` is currently null for hard timeouts and sandbox crashes (those problems don't emit a dialogue line today). Restructuring the sandbox output to cover those cases is tracked separately and intentionally out of scope here.

## Issue Link

- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing
N/A — covered by automated tests below. Smoke test on staging deferred until the auto-promoted image lands.

**Test Results:**
N/A

### Automated Testing
- New unit test: `subnet/tests/validator/test_sandbox_executor_format.py` covers the success path (execution_time stamped on first step only) and the failure path (still returns None).
- Existing validator unit tests continue to pass; the new `ProblemResult.execution_time` field defaults to `None` so `_mark_remaining_timed_out` and other paths that don't populate it remain unchanged.

**Test Command(s):**
```bash
uv run --project docker/validator --with pytest pytest tests/ subnet/tests/ --ignore=tests/integration -q
# 259 passed
uv run --project docker/validator --with ruff ruff check src/agent/sandbox_executor.py subnet/validator/progress_reporter.py subnet/tests/validator/test_sandbox_executor_format.py
# All checks passed!
```


## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
Inline comment on the new stamp in `_format_single_result` explains where the value is consumed.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

The dependent SDK change (`oro-sdk==1.0.45`) is already published and merged. This PR is the consumer side of that schema addition.