### PR TITLE
feat: log per-attempt duration and outcome in proxy retries

### DIFF
--- a/src/agent/proxy_client.py
+++ b/src/agent/proxy_client.py
@@ -42,6 +42,7 @@ class RequestLog:
         if not self._log_file:
             return
         entry = {
+            "kind": "summary",
             "method": method,
             "path": path,
             "timestamp": int(time.time() * 1000),
@@ -71,6 +72,41 @@ class RequestLog:
                     ]
             else:
                 entry["response"] = response_body
+        self._write(entry)
+
+    def record_attempt(
+        self,
+        method: str,
+        path: str,
+        attempt: int,
+        duration_ms: float,
+        status_code: Optional[int] = None,
+        error_class: Optional[str] = None,
+    ) -> None:
+        """Record one HTTP attempt inside the retry loop.
+
+        Per-attempt entries are written to the same JSONL file with
+        ``kind="attempt"`` so consumers (the reasoning judge bucketing) can
+        filter them out of the per-call summary view. The point is to make
+        a hung request visible: a stuck call shows up as one attempt entry
+        whose ``duration_ms`` matches or exceeds the configured timeout.
+        """
+        if not self._log_file:
+            return
+        entry = {
+            "kind": "attempt",
+            "method": method,
+            "path": path,
+            "timestamp": int(time.time() * 1000),
+            "attempt": attempt,
+            "duration_ms": round(duration_ms, 1),
+            "status_code": status_code,
+        }
+        if error_class:
+            entry["error_class"] = error_class
+        self._write(entry)
+
+    def _write(self, entry: Dict) -> None:
         with self._lock:
             try:
                 with open(self._log_file, "a") as f:
@@ -190,7 +226,8 @@ class ProxyClient:
     def _make_request_with_retries(
         self,
         request_func: Callable[[], requests.Response],
-        operation_name: str = "request",
+        method: str,
+        path: str,
     ) -> Optional[requests.Response]:
         """
         Make an HTTP request with retry logic.
@@ -199,17 +236,33 @@ class ProxyClient:
         backoff (5s base) so transient capacity issues don't exhaust the normal
         retry budget.
 
+        Each attempt's wall-clock duration and outcome (status code or
+        exception class) is logged via ``RequestLog.record_attempt`` so a
+        hung HTTP call is visible as a single attempt with ``duration_ms``
+        at or beyond the configured timeout.
+
         Args:
             request_func: Function that makes the HTTP request and returns a Response
-            operation_name: Name of the operation for logging
+            method: HTTP method (e.g., "GET", "POST"), recorded per attempt
+            path: Request path (e.g., "/inference/chat"), recorded per attempt
 
         Returns:
             Response object if successful, None otherwise
         """
+        operation_name = f"{method} {path}"
         for i in range(self.max_retries):
+            attempt_t0 = time.monotonic()
+            status_code: Optional[int] = None
+            error_class: Optional[str] = None
             try:
                 response = request_func()
+                status_code = response.status_code
                 if response.status_code == 200:
+                    self.request_log.record_attempt(
+                        method, path, i,
+                        (time.monotonic() - attempt_t0) * 1000,
+                        status_code=status_code,
+                    )
                     return response
                 if response.status_code == 429:
                     logger.warning(
@@ -222,10 +275,18 @@ class ProxyClient:
                         f"retry {i + 1}/{self.max_retries}"
                     )
             except requests.RequestException as e:
+                error_class = type(e).__name__
                 logger.error(
                     f"{operation_name} error, retry {i + 1}/{self.max_retries}: {e}"
                 )
                 response = None
+
+            self.request_log.record_attempt(
+                method, path, i,
+                (time.monotonic() - attempt_t0) * 1000,
+                status_code=status_code,
+                error_class=error_class,
+            )
 
             if i < self.max_retries - 1:
                 is_rate_limited = response is not None and response.status_code == 429
@@ -244,7 +305,7 @@ class ProxyClient:
             return requests.get(url, timeout=self.timeout)
 
         t0 = time.monotonic()
-        response = self._make_request_with_retries(make_request, f"GET {path}")
+        response = self._make_request_with_retries(make_request, "GET", path)
         duration_ms = (time.monotonic() - t0) * 1000
         result = response.json() if response else None
 
@@ -274,7 +335,7 @@ class ProxyClient:
             return response
 
         t0 = time.monotonic()
-        response = self._make_request_with_retries(make_request, f"POST {path}")
+        response = self._make_request_with_retries(make_request, "POST", path)
         duration_ms = (time.monotonic() - t0) * 1000
 
         if "/inference/" in path:

--- a/src/agent/sandbox_executor.py
+++ b/src/agent/sandbox_executor.py
@@ -344,9 +344,12 @@ def _format_single_result(result: ExecutionResult) -> Optional[str]:
         step_timestamps = [
             s.get("extra_info", {}).get("timestamp", 0) for s in dialogue_steps
         ]
+        # Per-attempt entries (kind="attempt") are diagnostic only — keep
+        # them out of the trajectory the judge sees.
+        summary_calls = [c for c in result.proxy_calls if c.get("kind") != "attempt"]
         # Bucket each call into the latest step whose timestamp <= call timestamp
         buckets: Dict[int, List[Dict]] = {}
-        for call in result.proxy_calls:
+        for call in summary_calls:
             call_ts = call.get("timestamp", 0)
             target = 0
             for i, st in enumerate(step_timestamps):

--- a/tests/test_proxy_client.py
+++ b/tests/test_proxy_client.py
@@ -1,0 +1,129 @@
+"""Tests for ProxyClient — covers per-attempt request logging."""
+
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+import requests
+
+from src.agent.proxy_client import ProxyClient, RequestLog
+
+
+def _read_jsonl(path) -> list[dict]:
+    with open(path) as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+@pytest.fixture
+def log_path(tmp_path):
+    return str(tmp_path / "request_log.jsonl")
+
+
+@pytest.fixture
+def client(log_path, monkeypatch):
+    monkeypatch.setenv("REQUEST_LOG_FILE", log_path)
+    return ProxyClient(proxy_url="http://proxy:80", max_retries=3, retry_delay=0)
+
+
+def _ok_response(payload=None):
+    r = MagicMock(spec=requests.Response)
+    r.status_code = 200
+    r.json.return_value = payload or {"ok": True}
+    return r
+
+
+def _status_response(code: int):
+    r = MagicMock(spec=requests.Response)
+    r.status_code = code
+    r.json.return_value = {}
+    return r
+
+
+def test_post_logs_one_attempt_on_success(client, log_path):
+    with patch("src.agent.proxy_client.requests.post", return_value=_ok_response()):
+        client.post("/inference/chat", json_data={"messages": []})
+
+    entries = _read_jsonl(log_path)
+    attempts = [e for e in entries if e["kind"] == "attempt"]
+    summaries = [e for e in entries if e["kind"] == "summary"]
+
+    assert len(attempts) == 1
+    assert attempts[0]["attempt"] == 0
+    assert attempts[0]["status_code"] == 200
+    assert attempts[0]["method"] == "POST"
+    assert attempts[0]["path"] == "/inference/chat"
+    assert "error_class" not in attempts[0]
+    assert len(summaries) == 1
+
+
+def test_post_logs_attempt_per_retry_on_5xx(client, log_path):
+    responses = [_status_response(503), _status_response(503), _ok_response()]
+    with patch("src.agent.proxy_client.requests.post", side_effect=responses), \
+         patch("src.agent.proxy_client.time.sleep"):
+        client.post("/inference/chat", json_data={"messages": []})
+
+    attempts = [e for e in _read_jsonl(log_path) if e["kind"] == "attempt"]
+    assert [a["attempt"] for a in attempts] == [0, 1, 2]
+    assert [a["status_code"] for a in attempts] == [503, 503, 200]
+
+
+def test_post_records_error_class_on_timeout(client, log_path):
+    """A hung HTTP call surfaces as an attempt with error_class=ReadTimeout."""
+    with patch(
+        "src.agent.proxy_client.requests.post",
+        side_effect=requests.exceptions.ReadTimeout("read timed out"),
+    ), patch("src.agent.proxy_client.time.sleep"):
+        result = client.post("/inference/chat", json_data={"messages": []})
+
+    assert result is None
+    attempts = [e for e in _read_jsonl(log_path) if e["kind"] == "attempt"]
+    assert len(attempts) == 3
+    for a in attempts:
+        assert a["status_code"] is None
+        assert a["error_class"] == "ReadTimeout"
+        assert "duration_ms" in a
+
+
+def test_attempt_duration_ms_present_per_call(client, log_path):
+    """Each attempt entry carries its own duration_ms (not a cumulative roll-up)."""
+    with patch(
+        "src.agent.proxy_client.requests.post",
+        side_effect=[_status_response(503), _ok_response()],
+    ), patch("src.agent.proxy_client.time.sleep"):
+        client.post("/search/find_product")
+
+    attempts = [e for e in _read_jsonl(log_path) if e["kind"] == "attempt"]
+    assert len(attempts) == 2
+    for a in attempts:
+        assert isinstance(a["duration_ms"], (int, float))
+        assert a["duration_ms"] >= 0
+
+
+def test_get_logs_attempts_too(client, log_path):
+    with patch("src.agent.proxy_client.requests.get", return_value=_ok_response()):
+        client.get("/search/find_product", params={"q": "shoes"})
+
+    attempts = [e for e in _read_jsonl(log_path) if e["kind"] == "attempt"]
+    assert len(attempts) == 1
+    assert attempts[0]["method"] == "GET"
+    assert attempts[0]["path"] == "/search/find_product"
+
+
+def test_summary_entry_still_written(client, log_path):
+    """Existing per-call summary entry is preserved (judge consumes it)."""
+    with patch("src.agent.proxy_client.requests.post", return_value=_ok_response()):
+        client.post("/search/find_product")
+
+    summaries = [e for e in _read_jsonl(log_path) if e["kind"] == "summary"]
+    assert len(summaries) == 1
+    assert summaries[0]["path"] == "/search/find_product"
+    assert summaries[0]["status_code"] == 200
+
+
+def test_request_log_disabled_when_no_file(monkeypatch):
+    """No env var -> attempts and summaries are silently skipped."""
+    monkeypatch.delenv("REQUEST_LOG_FILE", raising=False)
+    rl = RequestLog(None)
+    rl.record_attempt("POST", "/inference/chat", 0, 100.0, status_code=200)
+    rl.record("POST", "/inference/chat", duration_ms=100.0, status_code=200)
+    # No assertions on file content — call must just not raise.


### PR DESCRIPTION
## Description

Adds per-attempt entries to the proxy request log so hung HTTP calls inside the retry loop become visible. The existing summary entry already recorded the wall-clock duration of an entire `get()`/`post()` call, but a single 300s entry was indistinguishable from "1 truly hung call" vs "many timeouts that exhausted the retry budget" vs "stuck in backoff sleeps". Per-attempt entries make hangs unambiguous: a stuck call shows up as one attempt whose `duration_ms` matches or exceeds the configured timeout, optionally with `error_class=ReadTimeout`.

## Changes Made

- `RequestLog`: existing `record(...)` entries now carry `kind="summary"`; new `record_attempt(method, path, attempt, duration_ms, status_code, error_class)` writes `kind="attempt"` rows to the same JSONL file.
- `ProxyClient._make_request_with_retries`: now takes `method` and `path` (instead of a single `operation_name` string) and times each `request_func()` call independently, emitting one attempt entry per try with status code or exception class.
- `sandbox_executor.py`: filters `kind="attempt"` entries out before bucketing proxy calls into dialogue steps, so the reasoning judge keeps seeing only the per-call summaries it has been seeing all along.
- New tests in `tests/test_proxy_client.py` covering the success path, retries on 5xx, exception capture (ReadTimeout), GET path, and the no-log-file case.

## Issue Link

- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing
Inspected the JSONL output by patching `requests.post` to raise `ReadTimeout` and confirmed the file contains 3 `kind="attempt"` rows with `error_class="ReadTimeout"` plus 1 `kind="summary"` row.

**Test Results:**
- 7 new tests pass
- 46 existing unit tests pass
- No changes to the schema of existing summary entries beyond the new `kind` field

### Automated Testing
**Test Command(s):**
```bash
uv run --python 3.11 pytest tests/ -x -q --ignore=tests/integration
```

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
Inline docstrings on `RequestLog.record_attempt` and `_make_request_with_retries` explain the diagnostic intent of per-attempt logging.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

- No behavior change for callers — this is purely additive logging. The existing summary entry retains the same shape (with one new `kind` field).
- Per-attempt entries are filtered out of the trajectory presented to the reasoning judge, so they cannot influence scoring or be used as a side channel by agents.