### PR TITLE
feat(sandbox+validator): consolidate envelope IPC (ORO-907 PR1)

### DIFF
--- a/src/agent/sandbox_executor.py
+++ b/src/agent/sandbox_executor.py
@@ -316,62 +316,86 @@ def execute_single_problem(
         result_queue.close()
 
 
-def _format_single_result(result: ExecutionResult) -> Optional[str]:
-    """Format a single ExecutionResult as a JSONL line for dialogue output.
+def _classify_error_type(
+    error_message: Optional[str], status: SandboxProblemStatus
+) -> str:
+    """Best-effort error type classification from message + status.
 
-    Returns the JSON string (without trailing newline), or None if the
-    result should be skipped (failed, wrong format).
+    No traceback — sandbox stderr already captured in the logs bundle.
     """
-    if not result.success:
-        return None
+    if status == SandboxProblemStatus.TIMED_OUT:
+        return "TimeoutError"
+    if not error_message:
+        return "UnknownError"
+    # Cheap heuristic: error_message often starts with the exception class name
+    head = error_message.split(":", 1)[0].strip()
+    return head if head.isidentifier() else "RuntimeError"
 
-    if not isinstance(result.result, list):
-        return None
 
-    dialogue_steps = result.result
+def _format_single_result(result: ExecutionResult) -> str:
+    """Format an ExecutionResult as one JSONL envelope line.
 
-    for i, step in enumerate(dialogue_steps):
-        if "extra_info" not in step:
-            step["extra_info"] = {
-                "step": i + 1,
-                "query": result.query,
-                "timestamp": int(time.time() * 1000),
-            }
-        if "query" not in step.get("extra_info", {}):
-            step.setdefault("extra_info", {})["query"] = result.query
-        if result.problem_id and "problem_id" not in step.get("extra_info", {}):
-            step.setdefault("extra_info", {})["problem_id"] = result.problem_id
+    Always returns a non-empty line — failures emit with dialogue=null so the
+    validator's ProgressReporter sees every problem outcome through one channel.
+    """
+    dialogue: Optional[List[Dict]] = None
+    if result.success and isinstance(result.result, list):
+        dialogue = result.result
+        # Decorate dialogue steps as before — preserves backward compat for
+        # downstream consumers that look at extra_info.
+        for i, step in enumerate(dialogue):
+            step.setdefault("extra_info", {})
+            step["extra_info"].setdefault("step", i + 1)
+            step["extra_info"].setdefault("query", result.query)
+            step["extra_info"].setdefault("timestamp", int(time.time() * 1000))
+            if result.problem_id:
+                step["extra_info"].setdefault("problem_id", result.problem_id)
+        # Stamp per-problem execution time onto the first step only — consumers
+        # that look at dialogue[0].extra_info still find it there.
+        if dialogue:
+            dialogue[0]["extra_info"].setdefault("execution_time", result.execution_time)
+        # Distribute proxy calls across steps by timestamp approximation.
+        # Calls before the first step go to step 0; calls between step N and
+        # N+1 go to step N.
+        if result.proxy_calls and dialogue:
+            step_timestamps = [
+                s["extra_info"].get("timestamp", 0) for s in dialogue
+            ]
+            # Per-attempt entries (kind="attempt") are diagnostic only — keep
+            # them out of the trajectory the judge sees.
+            summary_calls = [
+                c for c in result.proxy_calls if c.get("kind") != "attempt"
+            ]
+            buckets: Dict[int, List[Dict]] = {}
+            for call in summary_calls:
+                call_ts = call.get("timestamp", 0)
+                target = 0
+                for i, st in enumerate(step_timestamps):
+                    if st <= call_ts:
+                        target = i
+                    else:
+                        break
+                buckets.setdefault(target, []).append(call)
+            for idx, calls in buckets.items():
+                dialogue[idx]["extra_info"]["proxy_calls"] = calls
 
-    # Stamp per-problem execution time onto the first step only — consumers
-    # (validator progress_reporter) read it from dialogue[0].extra_info.
-    if dialogue_steps:
-        dialogue_steps[0].setdefault("extra_info", {})["execution_time"] = result.execution_time
+    error_obj: Optional[Dict] = None
+    if not result.success and result.error:
+        error_obj = {
+            "type": _classify_error_type(result.error, result.status),
+            "message": result.error,
+        }
 
-    # Distribute proxy calls across steps by timestamp approximation.
-    # Calls before the first step go to step 0; calls between step N and N+1
-    # go to step N.
-    if result.proxy_calls and dialogue_steps:
-        step_timestamps = [
-            s.get("extra_info", {}).get("timestamp", 0) for s in dialogue_steps
-        ]
-        # Per-attempt entries (kind="attempt") are diagnostic only — keep
-        # them out of the trajectory the judge sees.
-        summary_calls = [c for c in result.proxy_calls if c.get("kind") != "attempt"]
-        # Bucket each call into the latest step whose timestamp <= call timestamp
-        buckets: Dict[int, List[Dict]] = {}
-        for call in summary_calls:
-            call_ts = call.get("timestamp", 0)
-            target = 0
-            for i, st in enumerate(step_timestamps):
-                if st <= call_ts:
-                    target = i
-                else:
-                    break
-            buckets.setdefault(target, []).append(call)
-        for idx, calls in buckets.items():
-            dialogue_steps[idx].setdefault("extra_info", {})["proxy_calls"] = calls
-
-    return json.dumps(dialogue_steps)
+    envelope = {
+        "problem_id": result.problem_id,
+        "status": result.status.value,
+        "execution_time": result.execution_time,
+        "inference_failure_count": result.inference_failure_count or 0,
+        "inference_total": result.inference_total or 0,
+        "error": error_obj,
+        "dialogue": dialogue,
+    }
+    return json.dumps(envelope)
 
 
 def execute_problems_parallel(
@@ -439,9 +463,8 @@ def execute_problems_parallel(
 
                     if fout is not None:
                         line = _format_single_result(result)
-                        if line is not None:
-                            fout.write(line + "\n")
-                            fout.flush()
+                        fout.write(line + "\n")
+                        fout.flush()
 
                 except FutureTimeoutError:
                     problem = future_to_problem[future]

--- a/src/agent/sandbox_executor.py
+++ b/src/agent/sandbox_executor.py
@@ -272,6 +272,7 @@ def execute_single_problem(
             inference_failure_count=inf_failures,
             inference_total=inf_total,
             proxy_calls=proxy_calls or None,
+            status=SandboxProblemStatus.TIMED_OUT,
         )
 
     try:
@@ -287,6 +288,7 @@ def execute_single_problem(
                     inference_failure_count=inf_failures,
                     inference_total=inf_total,
                     proxy_calls=proxy_calls or None,
+                    status=SandboxProblemStatus.SUCCESS,
                 )
             return ExecutionResult(
                 query=query,
@@ -297,6 +299,7 @@ def execute_single_problem(
                 inference_failure_count=inf_failures,
                 inference_total=inf_total,
                 proxy_calls=proxy_calls or None,
+                status=SandboxProblemStatus.FAILED,
             )
         return ExecutionResult(
             query=query,
@@ -307,6 +310,7 @@ def execute_single_problem(
             inference_failure_count=inf_failures,
             inference_total=inf_total,
             proxy_calls=proxy_calls or None,
+            status=SandboxProblemStatus.FAILED,
         )
     finally:
         result_queue.close()
@@ -442,6 +446,7 @@ def execute_problems_parallel(
                 except FutureTimeoutError:
                     problem = future_to_problem[future]
                     query = problem.get("query", "unknown")
+                    problem_id = problem.get("problem_id") or problem.get("id")
                     logger.error(
                         f"Future for problem '{query}' timed out during result retrieval"
                     )
@@ -451,11 +456,14 @@ def execute_problems_parallel(
                             success=False,
                             error="Future timeout during result retrieval",
                             execution_time=timeout_per_problem,
+                            problem_id=problem_id,
+                            status=SandboxProblemStatus.TIMED_OUT,
                         )
                     )
                 except Exception as e:
                     problem = future_to_problem[future]
                     query = problem.get("query", "unknown")
+                    problem_id = problem.get("problem_id") or problem.get("id")
                     logger.error(
                         f"Unexpected error retrieving result for '{query}': {e}"
                     )
@@ -465,6 +473,8 @@ def execute_problems_parallel(
                             success=False,
                             error=f"Unexpected error: {str(e)}",
                             execution_time=0.0,
+                            problem_id=problem_id,
+                            status=SandboxProblemStatus.FAILED,
                         )
                     )
     finally:

--- a/src/agent/sandbox_executor.py
+++ b/src/agent/sandbox_executor.py
@@ -13,7 +13,9 @@ from concurrent.futures import (
     as_completed,
 )
 from typing import Dict, List, Optional, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+from src.agent.sandbox_status import SandboxProblemStatus
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +33,10 @@ class ExecutionResult:
     inference_failure_count: int = 0
     inference_total: int = 0
     proxy_calls: Optional[List[Dict]] = None
+    # FAILED is the safe default — every successful exit path sets SUCCESS,
+    # every timeout path sets TIMED_OUT explicitly. Only the unexpected
+    # construction omits status.
+    status: SandboxProblemStatus = field(default=SandboxProblemStatus.FAILED)
 
 
 def load_problems(problem_file: str) -> List[Dict]:

--- a/src/agent/sandbox_executor.py
+++ b/src/agent/sandbox_executor.py
@@ -12,12 +12,20 @@ from concurrent.futures import (
     TimeoutError as FutureTimeoutError,
     as_completed,
 )
-from typing import Dict, List, Optional, Callable
+from typing import Any, Dict, List, Optional, Union, Callable
 from dataclasses import dataclass, field
 
 from src.agent.sandbox_status import SandboxProblemStatus
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ErrorInfo:
+    """Structured error captured at the exception site (preserves type name)."""
+
+    type: str
+    message: str
 
 
 @dataclass
@@ -27,15 +35,12 @@ class ExecutionResult:
     query: str
     success: bool
     result: Optional[Dict] = None
-    error: Optional[str] = None
+    error: Union[str, ErrorInfo, None] = None
     execution_time: float = 0.0
     problem_id: Optional[str] = None
     inference_failure_count: int = 0
     inference_total: int = 0
     proxy_calls: Optional[List[Dict]] = None
-    # FAILED is the safe default — every successful exit path sets SUCCESS,
-    # every timeout path sets TIMED_OUT explicitly. Only the unexpected
-    # construction omits status.
     status: SandboxProblemStatus = field(default=SandboxProblemStatus.FAILED)
 
 
@@ -205,7 +210,7 @@ def _run_in_process(
         result = agent_fn(problem)
         result_queue.put(("success", result))
     except Exception as e:
-        result_queue.put(("error", str(e)))
+        result_queue.put(("error", {"type": type(e).__name__, "message": str(e)}))
 
 
 def execute_single_problem(
@@ -290,10 +295,18 @@ def execute_single_problem(
                     proxy_calls=proxy_calls or None,
                     status=SandboxProblemStatus.SUCCESS,
                 )
+            error_payload: Union[str, ErrorInfo]
+            if isinstance(data, dict):
+                error_payload = ErrorInfo(
+                    type=str(data.get("type", "RuntimeError")),
+                    message=str(data.get("message", "")),
+                )
+            else:
+                error_payload = str(data)
             return ExecutionResult(
                 query=query,
                 success=False,
-                error=data,
+                error=error_payload,
                 execution_time=execution_time,
                 problem_id=problem_id,
                 inference_failure_count=inf_failures,
@@ -341,8 +354,6 @@ def _format_single_result(result: ExecutionResult) -> str:
     dialogue: Optional[List[Dict]] = None
     if result.success and isinstance(result.result, list):
         dialogue = result.result
-        # Decorate dialogue steps as before — preserves backward compat for
-        # downstream consumers that look at extra_info.
         for i, step in enumerate(dialogue):
             step.setdefault("extra_info", {})
             step["extra_info"].setdefault("step", i + 1)
@@ -379,19 +390,22 @@ def _format_single_result(result: ExecutionResult) -> str:
             for idx, calls in buckets.items():
                 dialogue[idx]["extra_info"]["proxy_calls"] = calls
 
-    error_obj: Optional[Dict] = None
-    if not result.success and result.error:
-        error_obj = {
-            "type": _classify_error_type(result.error, result.status),
-            "message": result.error,
-        }
+    error_obj: Optional[Dict[str, Any]] = None
+    if not result.success and result.error is not None:
+        if isinstance(result.error, ErrorInfo):
+            error_obj = {"type": result.error.type, "message": result.error.message}
+        else:
+            error_obj = {
+                "type": _classify_error_type(result.error, result.status),
+                "message": result.error,
+            }
 
     envelope = {
         "problem_id": result.problem_id,
         "status": result.status.value,
         "execution_time": result.execution_time,
-        "inference_failure_count": result.inference_failure_count or 0,
-        "inference_total": result.inference_total or 0,
+        "inference_failure_count": result.inference_failure_count,
+        "inference_total": result.inference_total,
         "error": error_obj,
         "dialogue": dialogue,
     }

--- a/src/agent/sandbox_status.py
+++ b/src/agent/sandbox_status.py
@@ -8,10 +8,10 @@ The CI guard test in tests/test_sandbox_envelope.py asserts this subset
 relation against a literal mirror of the Backend enum values.
 """
 
-from enum import StrEnum
+from enum import Enum
 
 
-class SandboxProblemStatus(StrEnum):
+class SandboxProblemStatus(str, Enum):
     SUCCESS = "SUCCESS"
     FAILED = "FAILED"
     TIMED_OUT = "TIMED_OUT"

--- a/src/agent/sandbox_status.py
+++ b/src/agent/sandbox_status.py
@@ -1,0 +1,17 @@
+"""Sandbox-side problem outcome status enum.
+
+Emitted in the per-problem envelope written to output.jsonl. Validator's
+ProgressReporter reads these values and forwards to Backend's ProblemStatus.
+
+Values must be a subset of Backend/app/models/schemas/common.py::ProblemStatus.
+The CI guard test in tests/test_sandbox_envelope.py asserts this subset
+relation against a literal mirror of the Backend enum values.
+"""
+
+from enum import StrEnum
+
+
+class SandboxProblemStatus(StrEnum):
+    SUCCESS = "SUCCESS"
+    FAILED = "FAILED"
+    TIMED_OUT = "TIMED_OUT"

--- a/subnet/tests/test_sandbox_executor.py
+++ b/subnet/tests/test_sandbox_executor.py
@@ -36,7 +36,8 @@ def test_timeout_kills_process():
 def test_agent_crash_returns_error():
     result = execute_single_problem({"query": "crash"}, timeout=10.0, agent_file=CRASH)
     assert not result.success
-    assert "agent crashed on purpose" in result.error
+    err_msg = result.error.message if hasattr(result.error, "message") else result.error
+    assert "agent crashed on purpose" in err_msg
 
 
 def test_missing_agent_file():

--- a/subnet/tests/validator/conftest.py
+++ b/subnet/tests/validator/conftest.py
@@ -1,6 +1,9 @@
 """Shared pytest fixtures for validator tests."""
 
+import logging as _stdlib_logging
+import sys
 import tempfile
+import types
 from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -10,6 +13,22 @@ import pytest
 from bittensor_wallet import Keypair, Wallet
 
 from oro_sdk.models import HeartbeatResponse, TopAgentResponse
+
+# Stub bittensor.utils.btlogging when the real module is unavailable so any
+# test importing progress_reporter (which imports btlogging at module import)
+# can collect. Real bittensor sometimes can't import in CI due to unrelated
+# env breakage in async_substrate_interface.
+if "bittensor.utils.btlogging" not in sys.modules:
+    try:
+        import bittensor.utils.btlogging  # noqa: F401
+    except Exception:
+        _btlogging = types.ModuleType("bittensor.utils.btlogging")
+        _btlogging.logging = _stdlib_logging.getLogger("bittensor")
+        sys.modules.setdefault("bittensor", types.ModuleType("bittensor"))
+        sys.modules.setdefault(
+            "bittensor.utils", types.ModuleType("bittensor.utils")
+        )
+        sys.modules["bittensor.utils.btlogging"] = _btlogging
 
 from validator.backend_client import BackendClient
 

--- a/subnet/tests/validator/test_progress_reporter_envelope.py
+++ b/subnet/tests/validator/test_progress_reporter_envelope.py
@@ -1,0 +1,189 @@
+"""Validator parses envelope format from ORO-907."""
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+# Stub `bittensor.utils.btlogging` before importing progress_reporter — the
+# installed bittensor package can't be imported in this env (unrelated env
+# breakage with async_substrate_interface), so we substitute a lightweight
+# logging facade.
+_btlogging = types.ModuleType("bittensor.utils.btlogging")
+import logging as _stdlib_logging
+
+_btlogging.logging = _stdlib_logging.getLogger("bittensor")
+sys.modules.setdefault("bittensor", types.ModuleType("bittensor"))
+sys.modules.setdefault("bittensor.utils", types.ModuleType("bittensor.utils"))
+sys.modules["bittensor.utils.btlogging"] = _btlogging
+
+# Add subnet to path so `validator.progress_reporter` resolves
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from oro_sdk.models import ProblemStatus
+
+from validator.progress_reporter import ProgressReporter
+
+
+def _write_envelope(path: Path, **fields):
+    envelope = {
+        "problem_id": fields.get("problem_id", "p1"),
+        "status": fields.get("status", "SUCCESS"),
+        "execution_time": fields.get("execution_time", 1.0),
+        "inference_failure_count": fields.get("inference_failure_count", 0),
+        "inference_total": fields.get("inference_total", 1),
+        "error": fields.get("error"),
+        "dialogue": fields.get(
+            "dialogue", [{"role": "u", "content": "x", "extra_info": {"step": 1}}]
+        ),
+    }
+    with open(path, "a") as f:
+        f.write(json.dumps(envelope) + "\n")
+
+
+# Fixed problem UUIDs the tests reuse — must be valid UUIDs because
+# _batch_report calls UUID(r.problem_id), but the in-memory _results
+# dict tolerates any string. Use valid UUIDs throughout for safety.
+_P1 = "11111111-1111-1111-1111-111111111111"
+_P2 = "22222222-2222-2222-2222-222222222222"
+_P3 = "33333333-3333-3333-3333-333333333333"
+
+
+@pytest.fixture
+def reporter(tmp_path) -> ProgressReporter:
+    out = tmp_path / "output.jsonl"
+    out.touch()
+    problems = [
+        {"problem_id": _P1, "query": "q1", "category": "product"},
+        {"problem_id": _P2, "query": "q2", "category": "product"},
+        {"problem_id": _P3, "query": "q3", "category": "product"},
+    ]
+    backend = MagicMock()
+    rep = ProgressReporter(
+        backend_client=backend,
+        eval_run_id=uuid4(),
+        output_file=out,
+        problems=problems,
+        workspace_dir=tmp_path,
+    )
+    # Disable scoring side effects — tests assert on dispatch/no-dispatch,
+    # not on what scoring computes. Replace scorers with a stub that always
+    # produces a clean SUCCESS so dispatched futures complete promptly.
+    rep._scorers = {}
+    return rep
+
+
+class TestEnvelopeParsing:
+    def test_success_envelope_dispatches_to_scoring(self, reporter, tmp_path):
+        _write_envelope(tmp_path / "output.jsonl", problem_id=_P1, status="SUCCESS")
+        reporter._read_and_dispatch()
+        assert _P1 in reporter._scoring_futures
+
+    def test_failure_envelope_records_without_scoring(self, reporter, tmp_path):
+        _write_envelope(
+            tmp_path / "output.jsonl",
+            problem_id=_P1,
+            status="FAILED",
+            dialogue=None,
+            error={"type": "RuntimeError", "message": "boom"},
+        )
+        reporter._read_and_dispatch()
+        assert _P1 not in reporter._scoring_futures
+        assert reporter._results[_P1].status == ProblemStatus.FAILED
+
+    def test_timeout_envelope_records_without_scoring(self, reporter, tmp_path):
+        _write_envelope(
+            tmp_path / "output.jsonl",
+            problem_id=_P1,
+            status="TIMED_OUT",
+            dialogue=None,
+            error={"type": "TimeoutError", "message": "..."},
+        )
+        reporter._read_and_dispatch()
+        assert _P1 not in reporter._scoring_futures
+        assert reporter._results[_P1].status == ProblemStatus.TIMED_OUT
+
+    def test_inference_counts_come_from_envelope(self, reporter, tmp_path):
+        _write_envelope(
+            tmp_path / "output.jsonl",
+            problem_id=_P1,
+            status="FAILED",
+            dialogue=None,
+            inference_failure_count=2,
+            inference_total=7,
+            error={"type": "RuntimeError", "message": "x"},
+        )
+        reporter._read_and_dispatch()
+        # Inference counts captured from envelope at dispatch time.
+        assert reporter._envelope_counts[_P1] == (2, 7)
+        # And materialized into the terminal result.
+        assert reporter._results[_P1].inference_failures == 2
+        assert reporter._results[_P1].inference_total == 7
+
+    def test_no_inference_stats_jsonl_read(self, reporter, tmp_path):
+        # Make sidecar unreadable to prove validator does not touch it.
+        sidecar = tmp_path / "inference_stats.jsonl"
+        sidecar.write_text("CORRUPT NOT JSON\n")
+        _write_envelope(
+            tmp_path / "output.jsonl",
+            problem_id=_P1,
+            status="FAILED",
+            dialogue=None,
+            inference_failure_count=0,
+            inference_total=1,
+            error={"type": "RuntimeError", "message": "x"},
+        )
+        # Should not raise. If validator reads sidecar, JSONDecodeError surfaces.
+        reporter._read_and_dispatch()
+        assert reporter._results[_P1].status == ProblemStatus.FAILED
+
+    def test_validator_no_longer_has_read_inference_stats(self, reporter):
+        """Sidecar reader is gone from validator side."""
+        assert not hasattr(reporter, "_read_inference_stats")
+
+    def test_execution_time_from_envelope(self, reporter, tmp_path):
+        _write_envelope(
+            tmp_path / "output.jsonl",
+            problem_id=_P1,
+            status="TIMED_OUT",
+            dialogue=None,
+            execution_time=42.0,
+            error={"type": "TimeoutError", "message": "..."},
+        )
+        reporter._read_and_dispatch()
+        assert reporter._results[_P1].execution_time == 42.0
+
+    def test_malformed_line_skipped(self, reporter, tmp_path):
+        out = tmp_path / "output.jsonl"
+        with open(out, "a") as f:
+            f.write("not json\n")
+        _write_envelope(out, problem_id=_P1, status="FAILED", dialogue=None,
+                        error={"type": "RuntimeError", "message": "x"})
+        reporter._read_and_dispatch()
+        assert reporter._results[_P1].status == ProblemStatus.FAILED
+
+
+class TestSweepNarrowing:
+    def test_sweep_skips_problems_already_in_envelope(self, reporter, tmp_path):
+        # p1 has FAILED envelope. Sweep at deadline must NOT overwrite to TIMED_OUT.
+        _write_envelope(
+            tmp_path / "output.jsonl",
+            problem_id=_P1,
+            status="FAILED",
+            dialogue=None,
+            error={"type": "RuntimeError", "message": "x"},
+        )
+        reporter._read_and_dispatch()
+        reporter._mark_remaining_timed_out()
+        assert reporter._results[_P1].status == ProblemStatus.FAILED
+
+    def test_sweep_marks_only_never_seen_problems(self, reporter):
+        # No envelope written. Sweep should mark all three TIMED_OUT.
+        reporter._mark_remaining_timed_out()
+        assert reporter._results[_P1].status == ProblemStatus.TIMED_OUT
+        assert reporter._results[_P2].status == ProblemStatus.TIMED_OUT
+        assert reporter._results[_P3].status == ProblemStatus.TIMED_OUT

--- a/subnet/tests/validator/test_progress_reporter_envelope.py
+++ b/subnet/tests/validator/test_progress_reporter_envelope.py
@@ -118,7 +118,8 @@ class TestEnvelopeParsing:
         )
         reporter._read_and_dispatch()
         # Inference counts captured from envelope at dispatch time.
-        assert reporter._envelope_counts[_P1] == (2, 7)
+        meta = reporter._envelope_meta[_P1]
+        assert (meta.inference_failure_count, meta.inference_total) == (2, 7)
         # And materialized into the terminal result.
         assert reporter._results[_P1].inference_failures == 2
         assert reporter._results[_P1].inference_total == 7

--- a/subnet/tests/validator/test_progress_reporter_envelope.py
+++ b/subnet/tests/validator/test_progress_reporter_envelope.py
@@ -1,6 +1,7 @@
 """Validator parses envelope format from ORO-907."""
 
 import json
+import logging as _stdlib_logging
 import sys
 import types
 from pathlib import Path
@@ -14,8 +15,6 @@ import pytest
 # breakage with async_substrate_interface), so we substitute a lightweight
 # logging facade.
 _btlogging = types.ModuleType("bittensor.utils.btlogging")
-import logging as _stdlib_logging
-
 _btlogging.logging = _stdlib_logging.getLogger("bittensor")
 sys.modules.setdefault("bittensor", types.ModuleType("bittensor"))
 sys.modules.setdefault("bittensor.utils", types.ModuleType("bittensor.utils"))
@@ -24,9 +23,9 @@ sys.modules["bittensor.utils.btlogging"] = _btlogging
 # Add subnet to path so `validator.progress_reporter` resolves
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from oro_sdk.models import ProblemStatus
+from oro_sdk.models import ProblemStatus  # noqa: E402
 
-from validator.progress_reporter import ProgressReporter
+from validator.progress_reporter import ProgressReporter  # noqa: E402
 
 
 def _write_envelope(path: Path, **fields):

--- a/subnet/tests/validator/test_progress_reporter_envelope.py
+++ b/subnet/tests/validator/test_progress_reporter_envelope.py
@@ -1,31 +1,15 @@
 """Validator parses envelope format from ORO-907."""
 
 import json
-import logging as _stdlib_logging
-import sys
-import types
 from pathlib import Path
 from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
 
-# Stub `bittensor.utils.btlogging` before importing progress_reporter — the
-# installed bittensor package can't be imported in this env (unrelated env
-# breakage with async_substrate_interface), so we substitute a lightweight
-# logging facade.
-_btlogging = types.ModuleType("bittensor.utils.btlogging")
-_btlogging.logging = _stdlib_logging.getLogger("bittensor")
-sys.modules.setdefault("bittensor", types.ModuleType("bittensor"))
-sys.modules.setdefault("bittensor.utils", types.ModuleType("bittensor.utils"))
-sys.modules["bittensor.utils.btlogging"] = _btlogging
+from oro_sdk.models import ProblemStatus
 
-# Add subnet to path so `validator.progress_reporter` resolves
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-
-from oro_sdk.models import ProblemStatus  # noqa: E402
-
-from validator.progress_reporter import ProgressReporter  # noqa: E402
+from validator.progress_reporter import ProgressReporter
 
 
 def _write_envelope(path: Path, **fields):

--- a/subnet/tests/validator/test_sandbox_executor_format.py
+++ b/subnet/tests/validator/test_sandbox_executor_format.py
@@ -1,4 +1,4 @@
-"""Unit tests for _format_single_result output JSONL shape."""
+"""Unit tests for _format_single_result envelope output (ORO-907)."""
 
 import json
 import sys
@@ -9,32 +9,63 @@ from typing import List, Optional
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from src.agent.sandbox_executor import ExecutionResult, _format_single_result
+from src.agent.sandbox_status import SandboxProblemStatus
 
 
-def _make_result(success: bool, dialogue: Optional[List], execution_time: float) -> ExecutionResult:
+def _make_result(
+    success: bool,
+    dialogue: Optional[List],
+    execution_time: float,
+    status: SandboxProblemStatus = SandboxProblemStatus.SUCCESS,
+    error: Optional[str] = None,
+) -> ExecutionResult:
     return ExecutionResult(
         query="find a laptop",
         success=success,
         result=dialogue,
+        error=error,
         execution_time=execution_time,
         problem_id="11111111-1111-1111-1111-111111111111",
+        status=status,
     )
 
 
 class TestFormatSingleResultExecutionTime:
-    def test_execution_time_stamped_on_first_step(self):
-        dialogue = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "ok"}]
-        line = _format_single_result(_make_result(success=True, dialogue=dialogue, execution_time=4.25))
-        assert line is not None
-        steps = json.loads(line)
+    def test_execution_time_stamped_on_first_dialogue_step(self):
+        dialogue = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        line = _format_single_result(
+            _make_result(success=True, dialogue=dialogue, execution_time=4.25)
+        )
+        envelope = json.loads(line)
+        steps = envelope["dialogue"]
         assert steps[0]["extra_info"]["execution_time"] == 4.25
 
     def test_execution_time_not_duplicated_on_later_steps(self):
-        dialogue = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "ok"}]
-        line = _format_single_result(_make_result(success=True, dialogue=dialogue, execution_time=4.25))
-        steps = json.loads(line)
+        dialogue = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "ok"},
+        ]
+        line = _format_single_result(
+            _make_result(success=True, dialogue=dialogue, execution_time=4.25)
+        )
+        envelope = json.loads(line)
+        steps = envelope["dialogue"]
         assert "execution_time" not in steps[1].get("extra_info", {})
 
-    def test_failure_still_returns_none(self):
-        line = _format_single_result(_make_result(success=False, dialogue=None, execution_time=1.0))
-        assert line is None
+    def test_failure_emits_envelope_with_null_dialogue(self):
+        line = _format_single_result(
+            _make_result(
+                success=False,
+                dialogue=None,
+                execution_time=1.0,
+                status=SandboxProblemStatus.FAILED,
+                error="boom",
+            )
+        )
+        envelope = json.loads(line)
+        assert isinstance(envelope, dict)
+        assert envelope["status"] == "FAILED"
+        assert envelope["dialogue"] is None

--- a/subnet/validator/progress_reporter.py
+++ b/subnet/validator/progress_reporter.py
@@ -33,6 +33,19 @@ from .backend_client import BackendClient, BackendError
 
 
 @dataclass
+class EnvelopeMeta:
+    """Per-problem metadata captured from the sandbox envelope line.
+
+    Held under ``ProgressReporter._lock`` and read by both dispatch (terminal
+    branch) and the scoring worker thread.
+    """
+
+    inference_failure_count: int
+    inference_total: int
+    execution_time: float
+
+
+@dataclass
 class ProblemResult:
     """Single source of truth for one problem's scoring outcome."""
 
@@ -100,10 +113,7 @@ class ProgressReporter:
         self._total_problems = len(problems)
         self._scorers: Dict[str, Any] = {}
 
-        # Sandbox-supplied per-problem metadata captured from envelope lines.
-        # Replaces the validator-side read of inference_stats.jsonl.
-        self._envelope_counts: Dict[str, tuple[int, int]] = {}
-        self._envelope_execution_time: Dict[str, float] = {}
+        self._envelope_meta: Dict[str, EnvelopeMeta] = {}
 
         # Circuit breaker for reasoning judge — stop after N consecutive
         # total failures to avoid retry storms on bad tokens/infra issues.
@@ -411,21 +421,17 @@ class ProgressReporter:
                 problem_id = str(problem_id)
 
                 with self._lock:
-                    already_scored = problem_id in self._results
-                already_dispatched = problem_id in self._scoring_futures
-
-                if already_scored or already_dispatched:
-                    continue
-
-                # Capture sandbox-supplied counts for this problem (replaces
-                # validator-side inference_stats.jsonl read).
-                self._envelope_counts[problem_id] = (
-                    int(envelope.get("inference_failure_count") or 0),
-                    int(envelope.get("inference_total") or 0),
-                )
-                self._envelope_execution_time[problem_id] = float(
-                    envelope.get("execution_time") or 0.0
-                )
+                    if problem_id in self._results:
+                        continue
+                    if problem_id in self._scoring_futures:
+                        continue
+                    self._envelope_meta[problem_id] = EnvelopeMeta(
+                        inference_failure_count=int(
+                            envelope.get("inference_failure_count") or 0
+                        ),
+                        inference_total=int(envelope.get("inference_total") or 0),
+                        execution_time=float(envelope.get("execution_time") or 0.0),
+                    )
 
                 if status is SandboxProblemStatus.SUCCESS:
                     dialogue = envelope.get("dialogue") or []
@@ -499,8 +505,11 @@ class ProgressReporter:
             return None
         category = problem.get("category", "product").lower()
         problem_status = ProblemStatus(status.value)
-        inf_fail, inf_total = self._envelope_counts.get(problem_id, (0, 0))
-        exec_time = self._envelope_execution_time.get(problem_id, 0.0)
+        with self._lock:
+            meta = self._envelope_meta.get(problem_id)
+        inf_fail = meta.inference_failure_count if meta else 0
+        inf_total = meta.inference_total if meta else 0
+        exec_time = meta.execution_time if meta else 0.0
         if error:
             err_msg = error.get("message") if isinstance(error, dict) else None
             if err_msg:
@@ -545,11 +554,11 @@ class ProgressReporter:
                 return
 
             extra_info = (dialogue[0].get("extra_info") or {}) if dialogue else {}
-            # Prefer envelope-supplied execution_time; fall back to extra_info
-            # for trajectories built before envelope rollout.
-            execution_time = self._envelope_execution_time.get(
-                str(problem_id)
-            ) or extra_info.get("execution_time")
+            with self._lock:
+                meta = self._envelope_meta.get(str(problem_id))
+            execution_time = (
+                meta.execution_time if meta is not None else extra_info.get("execution_time")
+            )
             query = problem.get("query") or extra_info.get("query")
             category = problem.get("category", "product").lower()
 
@@ -569,9 +578,8 @@ class ProgressReporter:
             is_successful = is_problem_successful(score_dict, category)
             score = 1.0 if is_successful else 0.0
             status = ProblemStatus.SUCCESS if is_successful else ProblemStatus.FAILED
-            inf_failures, inf_total = self._envelope_counts.get(
-                str(problem_id), (0, 0)
-            )
+            inf_failures = meta.inference_failure_count if meta else 0
+            inf_total = meta.inference_total if meta else 0
 
             reasoning = self._run_reasoning_judge(dialogue, problem_id)
 

--- a/subnet/validator/progress_reporter.py
+++ b/subnet/validator/progress_reporter.py
@@ -23,6 +23,7 @@ from oro_sdk.models import ProblemProgressUpdate, ProblemStatus
 from bittensor.utils.btlogging import logging
 
 from src.agent.problem_scorer import ProblemScorer, clear_product_cache
+from src.agent.sandbox_status import SandboxProblemStatus
 from src.agent.scoring import is_problem_successful, compute_aggregate, reasoning_coefficient
 from src.agent.types import ScoreDict
 from subnet.sandbox import attach_title_embeddings
@@ -404,8 +405,8 @@ class ProgressReporter:
                     continue
 
                 problem_id = envelope.get("problem_id")
-                status = envelope.get("status")
-                if not problem_id or not status:
+                status: SandboxProblemStatus = envelope["status"]
+                if not problem_id:
                     continue
                 problem_id = str(problem_id)
 
@@ -426,7 +427,7 @@ class ProgressReporter:
                     envelope.get("execution_time") or 0.0
                 )
 
-                if status == "SUCCESS":
+                if status is SandboxProblemStatus.SUCCESS:
                     dialogue = envelope.get("dialogue") or []
                     future = self._scoring_executor.submit(
                         self._score_problem, dialogue, problem_id
@@ -454,7 +455,12 @@ class ProgressReporter:
         return newly_dispatched
 
     def _parse_envelope(self, line: str) -> Optional[Dict[str, Any]]:
-        """Parse one envelope line. Returns None for malformed input."""
+        """Parse one envelope line. Returns None for malformed input.
+
+        Coerces ``status`` to ``SandboxProblemStatus`` once at the boundary;
+        unrecognized values cause the line to be skipped entirely so callers
+        can rely on `envelope["status"]` being a typed enum.
+        """
         try:
             line = line.replace("\x00", "")
             envelope = json.loads(line)
@@ -466,13 +472,24 @@ class ProgressReporter:
                 f"Skipping non-dict envelope line: {type(envelope).__name__}"
             )
             return None
+        raw_status = envelope.get("status")
+        if not raw_status:
+            logging.warning("Skipping envelope without status field")
+            return None
+        try:
+            envelope["status"] = SandboxProblemStatus(raw_status)
+        except ValueError:
+            logging.warning(
+                f"Skipping envelope with unrecognized status '{raw_status}'"
+            )
+            return None
         return envelope
 
     def _build_terminal_result(
         self,
         *,
         problem_id: str,
-        status: str,
+        status: SandboxProblemStatus,
         error: Optional[Dict[str, Any]],
     ) -> Optional["ProblemResult"]:
         """Build a non-success ProblemResult from envelope-only data."""
@@ -481,14 +498,7 @@ class ProgressReporter:
             logging.warning(f"Unknown problem_id in terminal envelope: {problem_id}")
             return None
         category = problem.get("category", "product").lower()
-        try:
-            problem_status = ProblemStatus(status)
-        except ValueError:
-            logging.warning(
-                f"Unknown envelope status '{status}' for {problem_id}, "
-                "treating as FAILED"
-            )
-            problem_status = ProblemStatus.FAILED
+        problem_status = ProblemStatus(status.value)
         inf_fail, inf_total = self._envelope_counts.get(problem_id, (0, 0))
         exec_time = self._envelope_execution_time.get(problem_id, 0.0)
         if error:

--- a/subnet/validator/progress_reporter.py
+++ b/subnet/validator/progress_reporter.py
@@ -383,10 +383,8 @@ class ProgressReporter:
     def _read_and_dispatch(self) -> int:
         """Read new envelope lines from output file.
 
-        SUCCESS envelopes are dispatched to the scoring pool. FAILED and
-        TIMED_OUT envelopes are recorded directly without scoring (no dialogue
-        to score). Per-problem inference counts and execution_time come from
-        the envelope itself — no sidecar reads on the validator side.
+        SUCCESS envelopes are dispatched to the scoring pool; FAILED and
+        TIMED_OUT envelopes are recorded directly without scoring.
 
         Returns the number of newly dispatched (SUCCESS) problems.
         """
@@ -427,10 +425,10 @@ class ProgressReporter:
                         continue
                     self._envelope_meta[problem_id] = EnvelopeMeta(
                         inference_failure_count=int(
-                            envelope.get("inference_failure_count") or 0
+                            envelope.get("inference_failure_count", 0)
                         ),
-                        inference_total=int(envelope.get("inference_total") or 0),
-                        execution_time=float(envelope.get("execution_time") or 0.0),
+                        inference_total=int(envelope.get("inference_total", 0)),
+                        execution_time=float(envelope.get("execution_time", 0.0)),
                     )
 
                 if status is SandboxProblemStatus.SUCCESS:
@@ -536,11 +534,7 @@ class ProgressReporter:
                 logging.error(f"Scoring worker failed for {pid}: {exc}")
 
     def _score_problem(self, dialogue: list, problem_id: str) -> None:
-        """Score a single problem end-to-end. Runs in a worker thread.
-
-        Receives the parsed dialogue (list of step dicts) directly from the
-        envelope, instead of reparsing a JSONL line.
-        """
+        """Score a single problem end-to-end. Runs in a worker thread."""
         if not self._scorers:
             return
 
@@ -724,11 +718,8 @@ class ProgressReporter:
     def _mark_remaining_timed_out(self) -> None:
         """Mark all unscored problems as TIMED_OUT in local results.
 
-        After ORO-907 the envelope path records FAILED/TIMED_OUT results
-        directly when their envelopes arrive. This sweep therefore only
-        reaches problems that genuinely never produced an envelope — typically
-        a sandbox death before write, a never-started problem, or a partial
-        run cut off by hard deadline.
+        Only reaches problems that never produced an envelope (sandbox death
+        before write, never-started, or partial run cut off by hard deadline).
         """
         with self._lock:
             scored_ids = set(self._results.keys())

--- a/subnet/validator/progress_reporter.py
+++ b/subnet/validator/progress_reporter.py
@@ -99,6 +99,11 @@ class ProgressReporter:
         self._total_problems = len(problems)
         self._scorers: Dict[str, Any] = {}
 
+        # Sandbox-supplied per-problem metadata captured from envelope lines.
+        # Replaces the validator-side read of inference_stats.jsonl.
+        self._envelope_counts: Dict[str, tuple[int, int]] = {}
+        self._envelope_execution_time: Dict[str, float] = {}
+
         # Circuit breaker for reasoning judge — stop after N consecutive
         # total failures to avoid retry storms on bad tokens/infra issues.
         self._consecutive_judge_failures = 0
@@ -365,9 +370,14 @@ class ProgressReporter:
             time.sleep(self.poll_interval)
 
     def _read_and_dispatch(self) -> int:
-        """Read new lines from output file and dispatch scoring to thread pool.
+        """Read new envelope lines from output file.
 
-        Returns the number of newly dispatched problems.
+        SUCCESS envelopes are dispatched to the scoring pool. FAILED and
+        TIMED_OUT envelopes are recorded directly without scoring (no dialogue
+        to score). Per-problem inference counts and execution_time come from
+        the envelope itself — no sidecar reads on the validator side.
+
+        Returns the number of newly dispatched (SUCCESS) problems.
         """
         newly_dispatched = 0
         try:
@@ -389,10 +399,15 @@ class ProgressReporter:
                 if not line:
                     continue
 
-                # Parse just enough to get problem_id and check for duplicates
-                problem_id = self._extract_problem_id(line)
-                if not problem_id:
+                envelope = self._parse_envelope(line)
+                if envelope is None:
                     continue
+
+                problem_id = envelope.get("problem_id")
+                status = envelope.get("status")
+                if not problem_id or not status:
+                    continue
+                problem_id = str(problem_id)
 
                 with self._lock:
                     already_scored = problem_id in self._results
@@ -401,10 +416,33 @@ class ProgressReporter:
                 if already_scored or already_dispatched:
                     continue
 
-                # Dispatch to thread pool
-                future = self._scoring_executor.submit(self._score_problem, line, problem_id)
-                self._scoring_futures[problem_id] = future
-                newly_dispatched += 1
+                # Capture sandbox-supplied counts for this problem (replaces
+                # validator-side inference_stats.jsonl read).
+                self._envelope_counts[problem_id] = (
+                    int(envelope.get("inference_failure_count") or 0),
+                    int(envelope.get("inference_total") or 0),
+                )
+                self._envelope_execution_time[problem_id] = float(
+                    envelope.get("execution_time") or 0.0
+                )
+
+                if status == "SUCCESS":
+                    dialogue = envelope.get("dialogue") or []
+                    future = self._scoring_executor.submit(
+                        self._score_problem, dialogue, problem_id
+                    )
+                    self._scoring_futures[problem_id] = future
+                    newly_dispatched += 1
+                else:
+                    # FAILED / TIMED_OUT — record directly, no scoring dispatch.
+                    terminal = self._build_terminal_result(
+                        problem_id=problem_id,
+                        status=status,
+                        error=envelope.get("error"),
+                    )
+                    if terminal is not None:
+                        with self._lock:
+                            self._results[problem_id] = terminal
 
                 if self._hard_deadline is not None and time.time() >= self._hard_deadline:
                     break
@@ -412,22 +450,62 @@ class ProgressReporter:
         except (OSError, IOError) as e:
             logging.warning(f"Error reading output file: {e}")
             self._file_position = 0
-        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
-            logging.warning(f"Error processing output: {e}")
 
         return newly_dispatched
 
-    def _extract_problem_id(self, line: str) -> Optional[str]:
-        """Extract problem_id from an output line without full scoring."""
+    def _parse_envelope(self, line: str) -> Optional[Dict[str, Any]]:
+        """Parse one envelope line. Returns None for malformed input."""
         try:
             line = line.replace("\x00", "")
-            dialogue = json.loads(line)
-            if not isinstance(dialogue, list) or not dialogue:
-                return None
-            extra_info = (dialogue[0].get("extra_info") or {}) if dialogue else {}
-            return extra_info.get("problem_id")
-        except (json.JSONDecodeError, KeyError, TypeError):
+            envelope = json.loads(line)
+        except json.JSONDecodeError as e:
+            logging.warning(f"Skipping malformed envelope line: {e}")
             return None
+        if not isinstance(envelope, dict):
+            logging.warning(
+                f"Skipping non-dict envelope line: {type(envelope).__name__}"
+            )
+            return None
+        return envelope
+
+    def _build_terminal_result(
+        self,
+        *,
+        problem_id: str,
+        status: str,
+        error: Optional[Dict[str, Any]],
+    ) -> Optional["ProblemResult"]:
+        """Build a non-success ProblemResult from envelope-only data."""
+        problem = self._id_to_problem.get(problem_id)
+        if not problem:
+            logging.warning(f"Unknown problem_id in terminal envelope: {problem_id}")
+            return None
+        category = problem.get("category", "product").lower()
+        try:
+            problem_status = ProblemStatus(status)
+        except ValueError:
+            logging.warning(
+                f"Unknown envelope status '{status}' for {problem_id}, "
+                "treating as FAILED"
+            )
+            problem_status = ProblemStatus.FAILED
+        inf_fail, inf_total = self._envelope_counts.get(problem_id, (0, 0))
+        exec_time = self._envelope_execution_time.get(problem_id, 0.0)
+        if error:
+            err_msg = error.get("message") if isinstance(error, dict) else None
+            if err_msg:
+                logging.info(
+                    f"Recording terminal {status} for {problem_id}: {err_msg[:80]}"
+                )
+        return ProblemResult(
+            problem_id=problem_id,
+            category=category,
+            status=problem_status,
+            score=0.0,
+            inference_failures=inf_fail,
+            inference_total=inf_total,
+            execution_time=exec_time,
+        )
 
     def _collect_completed_futures(self) -> None:
         """Check for completed scoring futures and update last_activity_at."""
@@ -438,25 +516,30 @@ class ProgressReporter:
             if exc:
                 logging.error(f"Scoring worker failed for {pid}: {exc}")
 
-    def _score_problem(self, line: str, problem_id: str) -> None:
-        """Score a single problem end-to-end. Runs in a worker thread."""
+    def _score_problem(self, dialogue: list, problem_id: str) -> None:
+        """Score a single problem end-to-end. Runs in a worker thread.
+
+        Receives the parsed dialogue (list of step dicts) directly from the
+        envelope, instead of reparsing a JSONL line.
+        """
         if not self._scorers:
             return
 
-        line = line.replace("\x00", "")
+        if not isinstance(dialogue, list) or not dialogue:
+            return
 
         try:
-            dialogue = json.loads(line)
-            if not isinstance(dialogue, list) or not dialogue:
-                return
-
             problem = self._id_to_problem.get(str(problem_id))
             if not problem:
                 logging.warning(f"Unknown problem_id: {problem_id}")
                 return
 
             extra_info = (dialogue[0].get("extra_info") or {}) if dialogue else {}
-            execution_time = extra_info.get("execution_time")
+            # Prefer envelope-supplied execution_time; fall back to extra_info
+            # for trajectories built before envelope rollout.
+            execution_time = self._envelope_execution_time.get(
+                str(problem_id)
+            ) or extra_info.get("execution_time")
             query = problem.get("query") or extra_info.get("query")
             category = problem.get("category", "product").lower()
 
@@ -476,7 +559,9 @@ class ProgressReporter:
             is_successful = is_problem_successful(score_dict, category)
             score = 1.0 if is_successful else 0.0
             status = ProblemStatus.SUCCESS if is_successful else ProblemStatus.FAILED
-            inf_failures, inf_total = self._read_inference_stats(problem_id)
+            inf_failures, inf_total = self._envelope_counts.get(
+                str(problem_id), (0, 0)
+            )
 
             reasoning = self._run_reasoning_judge(dialogue, problem_id)
 
@@ -500,8 +585,6 @@ class ProgressReporter:
                 f"{score:.4f} (query: {query[:50]}...)"
             )
 
-        except json.JSONDecodeError:
-            logging.warning(f"Failed to parse line: {line[:100]}...")
         except Exception as e:
             logging.error(f"Error scoring problem {problem_id}: {e}")
             traceback.print_exc()
@@ -621,7 +704,14 @@ class ProgressReporter:
             logging.warning(f"Batch report failed ({len(updates)} problems): {e}")
 
     def _mark_remaining_timed_out(self) -> None:
-        """Mark all unscored problems as TIMED_OUT in local results."""
+        """Mark all unscored problems as TIMED_OUT in local results.
+
+        After ORO-907 the envelope path records FAILED/TIMED_OUT results
+        directly when their envelopes arrive. This sweep therefore only
+        reaches problems that genuinely never produced an envelope — typically
+        a sandbox death before write, a never-started problem, or a partial
+        run cut off by hard deadline.
+        """
         with self._lock:
             scored_ids = set(self._results.keys())
 
@@ -638,21 +728,3 @@ class ProgressReporter:
                     status=ProblemStatus.TIMED_OUT,
                     score=0.0,
                 )
-
-    def _read_inference_stats(self, problem_id: str) -> tuple[int, int]:
-        """Read inference stats from the shared JSONL sidecar file."""
-        stats_path = self.output_file.parent / "inference_stats.jsonl"
-        last_failed, last_total = 0, 0
-        try:
-            with open(stats_path) as f:
-                for line in f:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    entry = json.loads(line)
-                    if str(entry.get("problem_id")) == str(problem_id):
-                        last_failed = entry.get("inference_failed", 0)
-                        last_total = entry.get("inference_total", 0)
-        except (FileNotFoundError, json.JSONDecodeError, OSError):
-            pass
-        return last_failed, last_total

--- a/tests/test_sandbox_envelope.py
+++ b/tests/test_sandbox_envelope.py
@@ -4,7 +4,7 @@ import json
 from unittest.mock import MagicMock, patch
 
 from src.agent import sandbox_executor
-from src.agent.sandbox_executor import ExecutionResult, _format_single_result
+from src.agent.sandbox_executor import ErrorInfo, ExecutionResult, _format_single_result
 from src.agent.sandbox_status import SandboxProblemStatus
 
 
@@ -132,6 +132,40 @@ class TestFormatSingleResultEnvelope:
         assert env["dialogue"] is None
         assert env["error"]["message"] == "boom"
         assert env["error"]["type"]  # non-empty
+
+    def test_failure_envelope_uses_structured_error_type_from_source(self):
+        """When error is captured at the exception site as ErrorInfo, the
+        type is the actual exception class name, not a regex on the message."""
+        result = ExecutionResult(
+            query="q",
+            success=False,
+            error=ErrorInfo(type="ValueError", message="random text without colon"),
+            execution_time=0.5,
+            problem_id="p_struct",
+            status=SandboxProblemStatus.FAILED,
+        )
+        env = _parse(_format_single_result(result))
+        assert env["error"]["type"] == "ValueError"
+        assert env["error"]["message"] == "random text without colon"
+
+    def test_run_in_process_captures_exception_type_at_source(self, tmp_path):
+        """Child process side: exception type name is on the queue as a dict."""
+        import multiprocessing as mp
+
+        agent_file = tmp_path / "raising_agent.py"
+        agent_file.write_text(
+            "def agent_main(problem):\n"
+            "    raise KeyError('missing-key')\n"
+        )
+        q: mp.Queue = mp.Queue()
+        sandbox_executor._run_in_process(
+            {"query": "q", "problem_id": "x"}, str(agent_file), q
+        )
+        kind, data = q.get(timeout=2)
+        assert kind == "error"
+        assert isinstance(data, dict)
+        assert data["type"] == "KeyError"
+        assert "missing-key" in data["message"]
 
     def test_timeout_envelope_marks_status_and_records_partial_counts(self):
         result = ExecutionResult(

--- a/tests/test_sandbox_envelope.py
+++ b/tests/test_sandbox_envelope.py
@@ -1,5 +1,8 @@
 """Envelope format tests for ORO-907 sandbox->validator IPC."""
 
+from unittest.mock import MagicMock, patch
+
+from src.agent import sandbox_executor
 from src.agent.sandbox_executor import ExecutionResult
 from src.agent.sandbox_status import SandboxProblemStatus
 
@@ -46,3 +49,39 @@ class TestExecutionResultStatus:
             status=SandboxProblemStatus.TIMED_OUT,
         )
         assert r.status == SandboxProblemStatus.TIMED_OUT
+
+
+class TestExecuteSingleProblemStatus:
+    def test_timed_out_when_process_alive_after_join(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("SANDBOX_OUTPUT_FILE", str(tmp_path / "output.jsonl"))
+
+        # Stub Process to simulate timeout: is_alive() True after join.
+        mock_proc = MagicMock()
+        mock_proc.is_alive.return_value = True
+        mock_proc.pid = 1
+        mock_proc.exitcode = None
+        with patch.object(
+            sandbox_executor.multiprocessing, "Process", return_value=mock_proc
+        ):
+            result = sandbox_executor.execute_single_problem(
+                {"query": "q", "problem_id": "p1"}, timeout=0.01
+            )
+        assert result.status == SandboxProblemStatus.TIMED_OUT
+        assert result.success is False
+
+    def test_failed_status_when_no_result_in_queue(self, tmp_path, monkeypatch):
+        """Process exits cleanly but queue is empty -> FAILED."""
+        monkeypatch.setenv("SANDBOX_OUTPUT_FILE", str(tmp_path / "output.jsonl"))
+
+        mock_proc = MagicMock()
+        mock_proc.is_alive.return_value = False
+        mock_proc.pid = 2
+        mock_proc.exitcode = 1
+        with patch.object(
+            sandbox_executor.multiprocessing, "Process", return_value=mock_proc
+        ):
+            result = sandbox_executor.execute_single_problem(
+                {"query": "q", "problem_id": "p2"}, timeout=0.01
+            )
+        assert result.status == SandboxProblemStatus.FAILED
+        assert result.success is False

--- a/tests/test_sandbox_envelope.py
+++ b/tests/test_sandbox_envelope.py
@@ -1,9 +1,10 @@
 """Envelope format tests for ORO-907 sandbox->validator IPC."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 from src.agent import sandbox_executor
-from src.agent.sandbox_executor import ExecutionResult
+from src.agent.sandbox_executor import ExecutionResult, _format_single_result
 from src.agent.sandbox_status import SandboxProblemStatus
 
 
@@ -85,3 +86,66 @@ class TestExecuteSingleProblemStatus:
             )
         assert result.status == SandboxProblemStatus.FAILED
         assert result.success is False
+
+
+def _parse(line: str) -> dict:
+    obj = json.loads(line)
+    assert isinstance(obj, dict), f"Envelope must be a dict, got {type(obj)}"
+    return obj
+
+
+class TestFormatSingleResultEnvelope:
+    def test_success_envelope(self):
+        result = ExecutionResult(
+            query="q",
+            success=True,
+            result=[{"role": "user", "content": "hi", "extra_info": {"step": 1}}],
+            execution_time=2.5,
+            problem_id="p1",
+            inference_failure_count=0,
+            inference_total=4,
+            status=SandboxProblemStatus.SUCCESS,
+        )
+        env = _parse(_format_single_result(result))
+        assert env["problem_id"] == "p1"
+        assert env["status"] == "SUCCESS"
+        assert env["execution_time"] == 2.5
+        assert env["inference_failure_count"] == 0
+        assert env["inference_total"] == 4
+        assert env["error"] is None
+        assert isinstance(env["dialogue"], list) and len(env["dialogue"]) == 1
+
+    def test_failure_envelope_emits_with_null_dialogue(self):
+        result = ExecutionResult(
+            query="q",
+            success=False,
+            error="boom",
+            execution_time=0.5,
+            problem_id="p2",
+            inference_failure_count=1,
+            inference_total=2,
+            status=SandboxProblemStatus.FAILED,
+        )
+        env = _parse(_format_single_result(result))
+        assert env["problem_id"] == "p2"
+        assert env["status"] == "FAILED"
+        assert env["dialogue"] is None
+        assert env["error"]["message"] == "boom"
+        assert env["error"]["type"]  # non-empty
+
+    def test_timeout_envelope_marks_status_and_records_partial_counts(self):
+        result = ExecutionResult(
+            query="q",
+            success=False,
+            error="Execution exceeded timeout of 300s",
+            execution_time=300.0,
+            problem_id="p3",
+            inference_failure_count=0,
+            inference_total=3,
+            status=SandboxProblemStatus.TIMED_OUT,
+        )
+        env = _parse(_format_single_result(result))
+        assert env["status"] == "TIMED_OUT"
+        assert env["dialogue"] is None
+        assert env["inference_total"] == 3
+        assert env["error"]["type"] == "TimeoutError"

--- a/tests/test_sandbox_envelope.py
+++ b/tests/test_sandbox_envelope.py
@@ -1,0 +1,25 @@
+"""Envelope format tests for ORO-907 sandbox->validator IPC."""
+
+from src.agent.sandbox_status import SandboxProblemStatus
+
+
+# Mirrors Backend/app/models/schemas/common.py::ProblemStatus.
+# Sandbox cannot import from Backend repo. CI guard catches drift.
+BACKEND_PROBLEM_STATUS_VALUES = frozenset(
+    {"PENDING", "RUNNING", "SUCCESS", "FAILED", "SKIPPED", "TIMED_OUT"}
+)
+
+
+class TestSandboxProblemStatus:
+    def test_values_subset_of_backend(self):
+        sandbox_values = {s.value for s in SandboxProblemStatus}
+        assert sandbox_values <= BACKEND_PROBLEM_STATUS_VALUES, (
+            f"SandboxProblemStatus has values not in Backend ProblemStatus: "
+            f"{sandbox_values - BACKEND_PROBLEM_STATUS_VALUES}. "
+            f"Update Backend/app/models/schemas/common.py::ProblemStatus or "
+            f"narrow sandbox emissions."
+        )
+
+    def test_required_values_present(self):
+        values = {s.value for s in SandboxProblemStatus}
+        assert {"SUCCESS", "FAILED", "TIMED_OUT"} <= values

--- a/tests/test_sandbox_envelope.py
+++ b/tests/test_sandbox_envelope.py
@@ -1,5 +1,6 @@
 """Envelope format tests for ORO-907 sandbox->validator IPC."""
 
+from src.agent.sandbox_executor import ExecutionResult
 from src.agent.sandbox_status import SandboxProblemStatus
 
 
@@ -23,3 +24,25 @@ class TestSandboxProblemStatus:
     def test_required_values_present(self):
         values = {s.value for s in SandboxProblemStatus}
         assert {"SUCCESS", "FAILED", "TIMED_OUT"} <= values
+
+
+class TestExecutionResultStatus:
+    def test_default_status_is_failed(self):
+        # Constructed without status -> FAILED (safe default).
+        r = ExecutionResult(query="q", success=False, error="x")
+        assert r.status == SandboxProblemStatus.FAILED
+
+    def test_success_status_when_explicitly_set(self):
+        r = ExecutionResult(
+            query="q", success=True, result=[], status=SandboxProblemStatus.SUCCESS
+        )
+        assert r.status == SandboxProblemStatus.SUCCESS
+
+    def test_timed_out_status_when_explicitly_set(self):
+        r = ExecutionResult(
+            query="q",
+            success=False,
+            error="t",
+            status=SandboxProblemStatus.TIMED_OUT,
+        )
+        assert r.status == SandboxProblemStatus.TIMED_OUT


### PR DESCRIPTION
## Description

PR1 of the ORO-907 stack. Consolidates per-problem sandbox→validator IPC into a single envelope stream in `output.jsonl`. Validator no longer reads `inference_stats.jsonl`. Failures and timeouts are now visible to the validator instead of inferred from absence at a deadline sweep.

Sidecars (`inference_stats.jsonl`, `request_log_*.jsonl`) remain as sandbox-internal child→parent IPC — only the validator-facing reads are removed.

## Changes Made

- Add `SandboxProblemStatus` StrEnum (`SUCCESS / FAILED / TIMED_OUT`) with subset-guard test against Backend `ProblemStatus`
- Extend `ExecutionResult` with `status` field and structured `ErrorInfo` (`type`, `message`); set on every exit path of `execute_single_problem`
- Capture exception type at source in `_run_in_process` (no string-regex heuristics)
- Rewrite `_format_single_result` to emit a flat envelope `{problem_id, status, execution_time, inference_failure_count, inference_total, error, dialogue}` for every outcome
- `ProgressReporter._read_and_dispatch` parses envelope, coerces status to `SandboxProblemStatus` once at the boundary
- Drop validator-side `_read_inference_stats`; envelope carries inference counts
- Failures/timeouts recorded directly via `_build_terminal_result`, no scoring dispatch
- Single `EnvelopeMeta` dataclass replaces parallel dicts; writes/reads under existing lock
- `_mark_remaining_timed_out` continues to handle the genuinely-never-started case (sandbox death before envelope write)

## Issue Link

- Closes part 1 of: ORO-907

## Testing

### Manual Testing

Local validator + sandbox against staging suite — confirm `output.jsonl` lines are envelopes; confirm Backend `/progress` updates contain entries for failed/timed-out problems. To follow on staging once merged.

**Test Results:** 274 passed (baseline 272 + 2 new for exception-type accuracy).

### Automated Testing

**Test Command(s):**
```bash
.venv/bin/pytest tests/ subnet/tests/ -v \
  --ignore=subnet/tests/validator/test_auto_update.py \
  --ignore=subnet/tests/validator/test_weight_setter.py \
  --ignore=tests/integration/test_sandbox_isolation.py
```

(Ignored files have pre-existing import / docker-environment failures unrelated to this PR.)

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [x] Other documentation updated (please specify): N/A — internal IPC refactor

**Documentation Changes:**

N/A

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

PR2 (extract `OutputWatcher`, thin `ProgressReporter`, fold ORO-836) stacks on top of this — opens after merge. sn-internal training-data extractors are unaffected (they read S3 trajectory artifacts, not `output.jsonl`).