### PR TITLE
refactor(validator): ProgressReporter thin orchestrator + OutputWatcher (ORO-907 PR2)

### DIFF
--- a/subnet/tests/validator/test_output_watcher.py
+++ b/subnet/tests/validator/test_output_watcher.py
@@ -1,0 +1,113 @@
+"""OutputWatcher: tail envelope stream, yield ProblemRecord."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.agent.sandbox_status import SandboxProblemStatus
+from validator.output_watcher import ErrorInfo, OutputWatcher, ProblemRecord
+
+
+def _write(path: Path, **fields):
+    env = {
+        "problem_id": fields["problem_id"],
+        "status": fields.get("status", "SUCCESS"),
+        "execution_time": fields.get("execution_time", 1.0),
+        "inference_failure_count": fields.get("inference_failure_count", 0),
+        "inference_total": fields.get("inference_total", 1),
+        "error": fields.get("error"),
+        "dialogue": fields.get(
+            "dialogue", [{"role": "u", "content": "x", "extra_info": {"step": 1}}]
+        ),
+    }
+    with open(path, "a") as f:
+        f.write(json.dumps(env) + "\n")
+
+
+@pytest.fixture
+def output_path(tmp_path) -> Path:
+    p = tmp_path / "output.jsonl"
+    p.touch()
+    return p
+
+
+class TestOutputWatcher:
+    def test_yields_records_in_append_order(self, output_path):
+        w = OutputWatcher(output_path)
+        _write(output_path, problem_id="p1", inference_total=4, execution_time=2.5)
+        _write(
+            output_path,
+            problem_id="p2",
+            status="FAILED",
+            dialogue=None,
+            error={"type": "RuntimeError", "message": "boom"},
+        )
+
+        records = list(w.read_new())
+
+        assert [r.problem_id for r in records] == ["p1", "p2"]
+        assert isinstance(records[0], ProblemRecord)
+        assert records[0].status is SandboxProblemStatus.SUCCESS
+        assert records[0].execution_time == 2.5
+        assert records[0].inference_total == 4
+        assert records[0].error is None
+        assert records[1].status is SandboxProblemStatus.FAILED
+        assert records[1].dialogue is None
+        assert isinstance(records[1].error, ErrorInfo)
+        assert records[1].error.type == "RuntimeError"
+        assert records[1].error.message == "boom"
+
+    def test_truncation_resets_position(self, output_path):
+        w = OutputWatcher(output_path)
+        # Two envelopes so the position advances well past the post-truncate
+        # length of one envelope, so truncation is visibly detected.
+        _write(output_path, problem_id="p1")
+        _write(output_path, problem_id="p2")
+        first = list(w.read_new())
+        assert [r.problem_id for r in first] == ["p1", "p2"]
+
+        # Truncate file (simulates sandbox restart writing fresh output).
+        output_path.write_text("")
+        _write(output_path, problem_id="p3")
+        records = list(w.read_new())
+        assert [r.problem_id for r in records] == ["p3"]
+
+    def test_skips_malformed_lines(self, output_path):
+        # Malformed first, valid second.
+        with open(output_path, "w") as f:
+            f.write("not json\n")
+        _write(output_path, problem_id="p1")
+        w = OutputWatcher(output_path)
+        records = list(w.read_new())
+        assert [r.problem_id for r in records] == ["p1"]
+
+    def test_skips_unknown_status(self, output_path):
+        # Unknown status — emit only the valid follow-up record.
+        env = {
+            "problem_id": "p1",
+            "status": "WAT",
+            "execution_time": 1.0,
+            "inference_failure_count": 0,
+            "inference_total": 1,
+            "error": None,
+            "dialogue": None,
+        }
+        with open(output_path, "a") as f:
+            f.write(json.dumps(env) + "\n")
+        _write(output_path, problem_id="p2", status="SUCCESS")
+
+        w = OutputWatcher(output_path)
+        records = list(w.read_new())
+        assert [r.problem_id for r in records] == ["p2"]
+
+    def test_returns_typed_status_enum(self, output_path):
+        _write(output_path, problem_id="p1", status="SUCCESS")
+        w = OutputWatcher(output_path)
+        records = list(w.read_new())
+        assert len(records) == 1
+        # Status MUST be the typed enum so callers can use `is` comparisons.
+        assert records[0].status is SandboxProblemStatus.SUCCESS
+        assert not isinstance(records[0].status, str) or isinstance(
+            records[0].status, SandboxProblemStatus
+        )

--- a/subnet/tests/validator/test_output_watcher.py
+++ b/subnet/tests/validator/test_output_watcher.py
@@ -108,6 +108,3 @@ class TestOutputWatcher:
         assert len(records) == 1
         # Status MUST be the typed enum so callers can use `is` comparisons.
         assert records[0].status is SandboxProblemStatus.SUCCESS
-        assert not isinstance(records[0].status, str) or isinstance(
-            records[0].status, SandboxProblemStatus
-        )

--- a/subnet/validator/output_watcher.py
+++ b/subnet/validator/output_watcher.py
@@ -82,8 +82,7 @@ class OutputWatcher:
                 new_lines = f.readlines()
                 self._file_position = f.tell()
         except OSError as e:
-            logging.warning(f"OutputWatcher: read failed: {e}")
-            self._file_position = 0
+            logging.warning(f"OutputWatcher: read failed, retry next poll: {e}")
             return
 
         for line in new_lines:
@@ -97,11 +96,16 @@ class OutputWatcher:
     @staticmethod
     def _parse(line: str) -> Optional[ProblemRecord]:
         try:
-            line = line.replace("\x00", "")
-            envelope = json.loads(line)
-        except json.JSONDecodeError as e:
+            return OutputWatcher._parse_unsafe(line)
+        except (json.JSONDecodeError, ValueError, TypeError) as e:
             logging.warning(f"Skipping malformed envelope line: {e}")
             return None
+
+    @staticmethod
+    def _parse_unsafe(line: str) -> Optional[ProblemRecord]:
+        # Sandbox kill mid-write can leave NUL bytes in the line.
+        line = line.replace("\x00", "")
+        envelope = json.loads(line)
         if not isinstance(envelope, dict):
             logging.warning(
                 f"Skipping non-dict envelope line: {type(envelope).__name__}"

--- a/subnet/validator/output_watcher.py
+++ b/subnet/validator/output_watcher.py
@@ -1,0 +1,145 @@
+"""Tail the sandbox envelope stream and yield typed records.
+
+Stateless wrt scoring/reasoning/backend reporting — those are the orchestrator's
+job. This class owns:
+  - file position tracking
+  - envelope JSON parsing
+  - truncation handling
+  - skipping malformed/unrecognized lines
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional
+
+from bittensor.utils.btlogging import logging
+
+from src.agent.sandbox_status import SandboxProblemStatus
+
+
+@dataclass
+class ErrorInfo:
+    """Structured error info parsed from the envelope's `error` field."""
+
+    type: str
+    message: str
+
+
+@dataclass
+class ProblemRecord:
+    """One per-problem outcome, parsed from a single envelope line."""
+
+    problem_id: str
+    status: SandboxProblemStatus
+    execution_time: float
+    inference_failure_count: int
+    inference_total: int
+    error: Optional[ErrorInfo]
+    dialogue: Optional[List[Dict[str, Any]]]
+
+
+class OutputWatcher:
+    """Tails a sandbox `output.jsonl` stream and yields parsed records.
+
+    Each call to :meth:`read_new` returns an iterator over envelopes appended
+    since the previous call. The watcher tolerates:
+
+    - Missing file (returns no records)
+    - File truncation (resets position to 0)
+    - Malformed JSON lines (logged and skipped)
+    - Unrecognized status values (logged and skipped)
+    """
+
+    def __init__(self, output_file: Path):
+        self.output_file = Path(output_file)
+        self._file_position = 0
+
+    def reset(self) -> None:
+        """Reset file position. Called when re-using the watcher across runs."""
+        self._file_position = 0
+
+    def read_new(self) -> Iterator[ProblemRecord]:
+        """Yield records appended since the last call. Generator."""
+        if not self.output_file.exists():
+            return
+
+        try:
+            file_size = self.output_file.stat().st_size
+        except OSError as e:
+            logging.warning(f"OutputWatcher: stat failed: {e}")
+            return
+
+        if file_size < self._file_position:
+            logging.info("OutputWatcher: file truncated, resetting position")
+            self._file_position = 0
+
+        try:
+            with open(self.output_file) as f:
+                f.seek(self._file_position)
+                new_lines = f.readlines()
+                self._file_position = f.tell()
+        except OSError as e:
+            logging.warning(f"OutputWatcher: read failed: {e}")
+            self._file_position = 0
+            return
+
+        for line in new_lines:
+            line = line.strip()
+            if not line:
+                continue
+            record = self._parse(line)
+            if record is not None:
+                yield record
+
+    @staticmethod
+    def _parse(line: str) -> Optional[ProblemRecord]:
+        try:
+            line = line.replace("\x00", "")
+            envelope = json.loads(line)
+        except json.JSONDecodeError as e:
+            logging.warning(f"Skipping malformed envelope line: {e}")
+            return None
+        if not isinstance(envelope, dict):
+            logging.warning(
+                f"Skipping non-dict envelope line: {type(envelope).__name__}"
+            )
+            return None
+
+        problem_id = envelope.get("problem_id")
+        raw_status = envelope.get("status")
+        if not problem_id or not raw_status:
+            logging.warning("Skipping envelope without problem_id or status")
+            return None
+
+        try:
+            status = SandboxProblemStatus(raw_status)
+        except ValueError:
+            logging.warning(
+                f"Skipping envelope with unrecognized status '{raw_status}'"
+            )
+            return None
+
+        error_obj = envelope.get("error")
+        error_info: Optional[ErrorInfo] = None
+        if isinstance(error_obj, dict):
+            error_info = ErrorInfo(
+                type=str(error_obj.get("type") or "UnknownError"),
+                message=str(error_obj.get("message") or ""),
+            )
+
+        dialogue = envelope.get("dialogue")
+        if not isinstance(dialogue, list):
+            dialogue = None
+
+        return ProblemRecord(
+            problem_id=str(problem_id),
+            status=status,
+            execution_time=float(envelope.get("execution_time") or 0.0),
+            inference_failure_count=int(envelope.get("inference_failure_count") or 0),
+            inference_total=int(envelope.get("inference_total") or 0),
+            error=error_info,
+            dialogue=dialogue,
+        )

--- a/subnet/validator/progress_reporter.py
+++ b/subnet/validator/progress_reporter.py
@@ -8,7 +8,6 @@ Architecture:
   - Aggregate score is computed on-demand from _results
 """
 
-import json
 import time
 import traceback
 import threading
@@ -30,6 +29,7 @@ from subnet.sandbox import attach_title_embeddings
 import requests
 
 from .backend_client import BackendClient, BackendError
+from .output_watcher import ErrorInfo, OutputWatcher
 
 
 @dataclass
@@ -105,7 +105,7 @@ class ProgressReporter:
         self._stop_event = threading.Event()
         self._hard_deadline: Optional[float] = None
         self._thread: Optional[threading.Thread] = None
-        self._file_position = 0
+        self._watcher = OutputWatcher(output_file)
         self._lock = threading.Lock()
 
         # Single source of truth for all problem results
@@ -186,7 +186,7 @@ class ProgressReporter:
         """Start the background monitoring loop."""
         self._stop_event.clear()
         self._hard_deadline = None
-        self._file_position = 0
+        self._watcher.reset()
         self._results = {}
         self._last_reported_count = 0
         self._last_report_time = 0.0
@@ -381,120 +381,57 @@ class ProgressReporter:
             time.sleep(self.poll_interval)
 
     def _read_and_dispatch(self) -> int:
-        """Read new envelope lines from output file.
+        """Read new records from the OutputWatcher and act on each.
 
-        SUCCESS envelopes are dispatched to the scoring pool; FAILED and
-        TIMED_OUT envelopes are recorded directly without scoring.
+        SUCCESS records are dispatched to the scoring pool; FAILED and
+        TIMED_OUT records are stored directly without scoring.
 
         Returns the number of newly dispatched (SUCCESS) problems.
         """
         newly_dispatched = 0
-        try:
-            if not self.output_file.exists():
-                return 0
-
-            file_size = self.output_file.stat().st_size
-            if file_size < self._file_position:
-                logging.info("Output file truncated, resetting position")
-                self._file_position = 0
-
-            with open(self.output_file) as f:
-                f.seek(self._file_position)
-                new_lines = f.readlines()
-                self._file_position = f.tell()
-
-            for line in new_lines:
-                line = line.strip()
-                if not line:
+        for record in self._watcher.read_new():
+            with self._lock:
+                if (
+                    record.problem_id in self._results
+                    or record.problem_id in self._scoring_futures
+                ):
                     continue
+                self._envelope_meta[record.problem_id] = EnvelopeMeta(
+                    inference_failure_count=record.inference_failure_count,
+                    inference_total=record.inference_total,
+                    execution_time=record.execution_time,
+                )
 
-                envelope = self._parse_envelope(line)
-                if envelope is None:
-                    continue
+            if record.status is SandboxProblemStatus.SUCCESS:
+                future = self._scoring_executor.submit(
+                    self._score_problem,
+                    record.dialogue or [],
+                    record.problem_id,
+                )
+                self._scoring_futures[record.problem_id] = future
+                newly_dispatched += 1
+            else:
+                # FAILED / TIMED_OUT — record directly, no scoring dispatch.
+                terminal = self._build_terminal_result(
+                    problem_id=record.problem_id,
+                    status=record.status,
+                    error=record.error,
+                )
+                if terminal is not None:
+                    with self._lock:
+                        self._results[record.problem_id] = terminal
 
-                problem_id = envelope.get("problem_id")
-                status: SandboxProblemStatus = envelope["status"]
-                if not problem_id:
-                    continue
-                problem_id = str(problem_id)
-
-                with self._lock:
-                    if problem_id in self._results:
-                        continue
-                    if problem_id in self._scoring_futures:
-                        continue
-                    self._envelope_meta[problem_id] = EnvelopeMeta(
-                        inference_failure_count=int(
-                            envelope.get("inference_failure_count", 0)
-                        ),
-                        inference_total=int(envelope.get("inference_total", 0)),
-                        execution_time=float(envelope.get("execution_time", 0.0)),
-                    )
-
-                if status is SandboxProblemStatus.SUCCESS:
-                    dialogue = envelope.get("dialogue") or []
-                    future = self._scoring_executor.submit(
-                        self._score_problem, dialogue, problem_id
-                    )
-                    self._scoring_futures[problem_id] = future
-                    newly_dispatched += 1
-                else:
-                    # FAILED / TIMED_OUT — record directly, no scoring dispatch.
-                    terminal = self._build_terminal_result(
-                        problem_id=problem_id,
-                        status=status,
-                        error=envelope.get("error"),
-                    )
-                    if terminal is not None:
-                        with self._lock:
-                            self._results[problem_id] = terminal
-
-                if self._hard_deadline is not None and time.time() >= self._hard_deadline:
-                    break
-
-        except (OSError, IOError) as e:
-            logging.warning(f"Error reading output file: {e}")
-            self._file_position = 0
+            if self._hard_deadline is not None and time.time() >= self._hard_deadline:
+                break
 
         return newly_dispatched
-
-    def _parse_envelope(self, line: str) -> Optional[Dict[str, Any]]:
-        """Parse one envelope line. Returns None for malformed input.
-
-        Coerces ``status`` to ``SandboxProblemStatus`` once at the boundary;
-        unrecognized values cause the line to be skipped entirely so callers
-        can rely on `envelope["status"]` being a typed enum.
-        """
-        try:
-            line = line.replace("\x00", "")
-            envelope = json.loads(line)
-        except json.JSONDecodeError as e:
-            logging.warning(f"Skipping malformed envelope line: {e}")
-            return None
-        if not isinstance(envelope, dict):
-            logging.warning(
-                f"Skipping non-dict envelope line: {type(envelope).__name__}"
-            )
-            return None
-        raw_status = envelope.get("status")
-        if not raw_status:
-            logging.warning("Skipping envelope without status field")
-            return None
-        try:
-            envelope["status"] = SandboxProblemStatus(raw_status)
-        except ValueError:
-            logging.warning(
-                f"Skipping envelope with unrecognized status '{raw_status}'"
-            )
-            return None
-        return envelope
 
     def _build_terminal_result(
         self,
         *,
         problem_id: str,
         status: SandboxProblemStatus,
-        error: Optional[Dict[str, Any]],
+        error: Optional[ErrorInfo],
     ) -> Optional["ProblemResult"]:
         """Build a non-success ProblemResult from envelope-only data."""
         problem = self._id_to_problem.get(problem_id)
@@ -508,12 +445,10 @@ class ProgressReporter:
         inf_fail = meta.inference_failure_count if meta else 0
         inf_total = meta.inference_total if meta else 0
         exec_time = meta.execution_time if meta else 0.0
-        if error:
-            err_msg = error.get("message") if isinstance(error, dict) else None
-            if err_msg:
-                logging.info(
-                    f"Recording terminal {status} for {problem_id}: {err_msg[:80]}"
-                )
+        if error and error.message:
+            logging.info(
+                f"Recording terminal {status} for {problem_id}: {error.message[:80]}"
+            )
         return ProblemResult(
             problem_id=problem_id,
             category=category,


### PR DESCRIPTION
## Description

PR2 of the ORO-907 stack. Folds in ORO-836. Pure structural refactor — no behavior change beyond what PR1 already shipped.

## Changes Made

- New `subnet/validator/output_watcher.py` (~145 LoC): tails `output.jsonl`, parses envelopes, yields typed `ProblemRecord`. Owns file-position tracking, truncation handling, malformed/unknown-status skipping. No scoring/reasoning/backend reporting.
- `ProgressReporter` delegates to `OutputWatcher`: `_file_position`, inline JSON parsing, and `_parse_envelope` are gone. The class is now a wiring orchestrator (watcher → scorer → reasoning judge → backend reporter).
- `_build_terminal_result` now accepts `ErrorInfo | None` (typed dataclass) instead of dict.
- External API of `ProgressReporter` unchanged — no callsite changes in `subnet/validator/main.py`.

## Issue Link

- Closes: ORO-907
- Closes: ORO-836

## Testing

### Manual Testing

PR1 already shipped envelope IPC. PR2 is structural — same fixtures pass, same behavior.

**Test Results:** 279 passed (274 baseline + 5 new for `OutputWatcher`).

### Automated Testing

**Test Command(s):**
```bash
.venv/bin/pytest tests/ subnet/tests/ -v \
  --ignore=subnet/tests/validator/test_auto_update.py \
  --ignore=subnet/tests/validator/test_weight_setter.py \
  --ignore=tests/integration/test_sandbox_isolation.py
```

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [x] Other documentation updated (please specify): N/A — internal refactor

**Documentation Changes:**

N/A

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

Stacks on PR1 #98 (already merged). Diff over main = PR2-only changes.