### PR TITLE
feat(sandbox): set CPU shares so validator preempts under contention (ORO-948)

### DIFF
--- a/subnet/sandbox.py
+++ b/subnet/sandbox.py
@@ -11,9 +11,7 @@ from typing import List, Optional, Tuple
 
 
 # Docker configuration — shared between test_runner and validator
-SANDBOX_IMAGE = os.environ.get(
-    "SANDBOX_IMAGE", "ghcr.io/oro-ai/oro/sandbox:latest"
-)
+SANDBOX_IMAGE = os.environ.get("SANDBOX_IMAGE", "ghcr.io/oro-ai/oro/sandbox:latest")
 SANDBOX_NETWORK = os.environ.get("SANDBOX_NETWORK", "sandbox-network")
 HOST_PROJECT_DIR = os.environ.get("HOST_PROJECT_DIR")
 
@@ -150,6 +148,11 @@ def build_sandbox_command(
         "256",
         "--ulimit",
         "nofile=1024:1024",
+        # CPU priority — validator + search-server (default cpu-shares=1024) preempt the
+        # sandbox under contention so heartbeats and the work-claim loop stay responsive.
+        # Sandbox still uses idle CPU; this only matters when the host is saturated.
+        "--cpu-shares",
+        "512",
         "--user",
         "1000:1000",
         # Security hardening — minimize container attack surface

--- a/subnet/tests/test_sandbox.py
+++ b/subnet/tests/test_sandbox.py
@@ -5,7 +5,12 @@ import os
 from unittest import mock
 
 
-from subnet.sandbox import host_path, load_problems, build_sandbox_command, attach_title_embeddings
+from subnet.sandbox import (
+    host_path,
+    load_problems,
+    build_sandbox_command,
+    attach_title_embeddings,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -188,6 +193,9 @@ class TestBuildSandboxCommand:
         # Non-root user
         user_idx = cmd.index("--user")
         assert cmd[user_idx + 1] == "1000:1000"
+        # CPU shares — sandbox at half the default so validator preempts under contention
+        shares_idx = cmd.index("--cpu-shares")
+        assert cmd[shares_idx + 1] == "512"
 
     def test_chutes_access_token_injected(self):
         cmd = build_sandbox_command(


### PR DESCRIPTION
## Description

Adds `--cpu-shares=512` to the sandbox `docker run`. Validator and search-server containers run at the default `cpu-shares=1024`, so under host CPU contention the validator process (heartbeats, work-claim loop) is scheduled ahead of the sandbox. On healthy / idle hosts the sandbox still uses all available CPU; this only matters when the host is saturated.

This is the smallest mechanical change motivated by the ORO-948 investigation. It pairs with a docs update in Frontend that documents the recommended host spec and the rationale for the cpu-shares contract.

## Changes Made

- `subnet/sandbox.py`: insert `--cpu-shares 512` into the `docker run` command alongside the existing memory/PID/ulimit caps; comment explains why.
- `subnet/tests/test_sandbox.py`: assert `--cpu-shares 512` is present in the resource-limits test.

## Issue Link

- Related to: ORO-948
- Related to: ORO-904 (timeout-mode hang investigation), ORO-949 (per-problem timeout bump)

## Testing

### Manual Testing
None required at the host level — the change is a single Docker flag. Verified locally that `build_sandbox_command()` produces a command containing `--cpu-shares 512` immediately after the PID limit and before the user/security flags.

**Test Results:**
27/27 tests pass in `subnet/tests/test_sandbox.py` after adding the new assertion.

### Automated Testing
Existing unit tests cover `build_sandbox_command` flag composition.

**Test Command(s):**
```bash
uv run pytest subnet/tests/test_sandbox.py -x -q
```

## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
Hardware-spec doc updated separately in ORO-AI/Frontend (`content/docs/validators/overview.mdx`) — that PR documents the new recommended floor (8 cores, dedicated host) and explains how the cpu-shares contract behaves under contention.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

Why `--cpu-shares` not `--cpus`: a hard cap (`--cpus=N`) would slow the sandbox on every host, including ours, making the timeout problem worse. Shares are relative weights — sandbox still takes idle CPU, only loses priority when the host is fighting for it. That matches what we want: preserve validator responsiveness on under-provisioned hosts without penalising healthy operators.

Investigation context posted on ORO-948 (race 13/14 cross-validator analysis): tao.bot's median problem-execution time runs ~11% slower than ORO Official on identical agent+problem pairs, and inference-failure rates rule out upstream Chutes as the primary cause — the bottleneck is on validator hosts.