### PR TITLE
ci(publish): smoke-test proxy image renders nginx config

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -130,6 +130,12 @@ jobs:
           name: digest-sandbox-linux-amd64
           path: /tmp/digests/sandbox
 
+      - name: Download proxy digest (amd64)
+        uses: actions/download-artifact@v4
+        with:
+          name: digest-proxy-linux-amd64
+          path: /tmp/digests/proxy
+
       # Override ENTRYPOINT so argv runs our import check instead of booting
       # a live validator. Validator deps live in a uv-managed venv, so we
       # enter through `uv run` rather than the system python.
@@ -144,6 +150,33 @@ jobs:
           digest=$(ls /tmp/digests/sandbox | head -1)
           docker run --rm --entrypoint python ${{ env.IMAGE_PREFIX }}/sandbox@sha256:$digest \
             -c "import src.agent.agent_interface; print('Sandbox module OK')"
+
+      # Boot the proxy with the same env vars that docker-compose.yml exports
+      # to a real validator deploy. If a new ${VAR} is added to
+      # nginx.conf.template without either (a) a default in the proxy
+      # Dockerfile CMD or (b) a corresponding entry in docker-compose.yml,
+      # envsubst writes empty, nginx fails with `[emerg] invalid number of
+      # arguments`, and the container exits — failing this step before the
+      # tag is published. Without this guard, v1.0.56 shipped that exact
+      # regression to staging.
+      - name: Smoke test proxy image
+        run: |
+          digest=$(ls /tmp/digests/proxy | head -1)
+          docker run -d --name proxy-smoke \
+            -e SEARCH_SERVER_URL=search-server \
+            -e SEARCH_SERVER_PORT=5632 \
+            -e CHUTES_HOST=llm.chutes.ai \
+            ${{ env.IMAGE_PREFIX }}/proxy@sha256:$digest
+          sleep 5
+          state=$(docker inspect -f '{{.State.Status}}' proxy-smoke)
+          if [ "$state" != "running" ]; then
+            echo "::error::Proxy state is '$state' (expected 'running') — nginx config likely failed to render"
+            docker logs proxy-smoke 2>&1 || true
+            docker rm -f proxy-smoke 2>/dev/null || true
+            exit 1
+          fi
+          echo "Proxy nginx config rendered and started cleanly"
+          docker rm -f proxy-smoke
 
   merge:
     needs: [determine-tag, smoke-test]


### PR DESCRIPTION
## Description

Adds a smoke-test step in `.github/workflows/publish-images.yml` that boots the freshly-built proxy image (with the same env vars `docker-compose.yml` exports) and asserts the container reaches `running`. The step runs before the `merge` job tags `:latest` / `:vN`, so a misconfigured proxy image cannot reach any operator.

## Why this guard

v1.0.56 shipped a regression: a new `${BACKEND_URL}` / `${BACKEND_HOST}` was added to `nginx.conf.template`, but neither the proxy `Dockerfile` CMD nor `docker-compose.yml` provided a value. `envsubst` wrote empty strings, nginx crashed with:

```
[emerg] 1#1: invalid number of arguments in "proxy_set_header" directive in /etc/nginx/nginx.conf:79
```

The proxy crashlooped on staging for hours. Every miner inference call hit a dead proxy and timed out at 300s — looking exactly like the ORO-904 hang signature. v1.0.57 (#101) added shell defaults in the proxy CMD as a hotfix.

This smoke step would have failed v1.0.56's publish workflow before the broken image ever got tagged as `latest`.

## Changes Made

- `.github/workflows/publish-images.yml`: download `digest-proxy-linux-amd64` artifact and run a smoke step that boots the image with the compose-defaulted env vars and checks `docker inspect` state is `running` after 5s.

## Issue Link

- Related to: ORO-948
- Related to: ORO-904 (the hang signature this regression masqueraded as)

## Testing

### Manual Testing
Reproduced the smoke logic locally against `ghcr.io/oro-ai/oro/proxy:latest` (v1.0.58):

```bash
docker run -d --name proxy-smoke-verify \
  -e SEARCH_SERVER_URL=search-server \
  -e SEARCH_SERVER_PORT=5632 \
  -e CHUTES_HOST=llm.chutes.ai \
  ghcr.io/oro-ai/oro/proxy:latest
sleep 5
docker inspect -f '{{.State.Status}}' proxy-smoke-verify
# → running
```

Also verified that without the env vars (mimicking the v1.0.56 break), the same image exits within 5s with the `[emerg]` error — so the guard correctly detects the failure mode.

**Test Results:**
- v1.0.58 (current latest, has CMD defaults): smoke passes
- Bare image with no env: container exits → smoke would fail the publish

### Automated Testing
The new step itself runs in CI on the next tag push.

**Test Command(s):**
```bash
docker run -d --name proxy-smoke <image> -e SEARCH_SERVER_URL=... -e SEARCH_SERVER_PORT=... -e CHUTES_HOST=...
sleep 5
docker inspect -f '{{.State.Status}}' proxy-smoke   # expect "running"
```

## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
None — comment in the workflow step explains the rationale and references the v1.0.56 incident.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

The env vars passed to the smoke test mirror what `docker-compose.yml` already defaults. If a future PR adds a new `${VAR}` to `nginx.conf.template`, the author has two safe paths:

1. Add the var to `docker-compose.yml` AND mirror it in this smoke step's `-e` flags
2. Add a CMD-level default in `docker/proxy/Dockerfile`

Either keeps the smoke green. If the author does neither, the publish workflow fails before tagging.