### PR TITLE
chore(validator): bump default poll-interval from 30s to 60s

### DIFF
--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -112,8 +112,8 @@ class Validator:
         parser.add_argument(
             "--poll-interval",
             type=int,
-            default=int(os.environ.get("ORO_POLL_INTERVAL", "30")),
-            help="Seconds between work claim attempts when no work (env: ORO_POLL_INTERVAL)",
+            default=int(os.environ.get("ORO_POLL_INTERVAL", "60")),
+            help="Seconds between work claim attempts when no work (env: ORO_POLL_INTERVAL, default: 60)",
         )
         parser.add_argument(
             "--heartbeat-interval",


### PR DESCRIPTION
## Description

Doubles the default no-work poll interval (`--poll-interval`) from 30s to 60s in `subnet/validator/main.py`.

Operators running multiple instances behind one hotkey (e.g. ORO's production fleet of 5) were generating high baseline `/v1/validator/work/claim` noise. The backend's dedup logic keys off hotkey, so only one of the 5 instances can actually claim any given item — the other 4 just generate empty polls. Halving the per-instance poll rate substantially reduces that noise without meaningfully delaying work pickup (60s is still well below typical race work-item lifetime).

Operators who want the old cadence can set `ORO_POLL_INTERVAL=30` in their `.env`.

## Changes Made

- `subnet/validator/main.py`: change argparse default for `--poll-interval` from 30 to 60. Updated the help string to reflect the new default.

## Issue Link

- Followup to PagerDuty incident on 2026-04-29 (`oro-production-work-claim-failures`). Companion Backend PR fixes the underlying metric so it ignores dedup-blocked polls; this PR reduces empty-poll volume regardless.

## Testing

### Manual Testing

`--poll-interval` is read once at validator startup in `Validator.__init__` via argparse. No state machinery; only effect is the `time.sleep(self.config.poll_interval)` between empty-claim retries (`subnet/validator/main.py:466`).

**Test Results:**

```bash
$ python -m subnet.validator.main --help | grep -A2 poll-interval
  --poll-interval POLL_INTERVAL
                        Seconds between work claim attempts when no work
                        (env: ORO_POLL_INTERVAL, default: 60)
```

### Automated Testing

**Test Command(s):**
```bash
uv run pytest subnet/tests/validator/ -v
```

Existing tests pin `poll_interval` explicitly in fixtures (e.g., `poll_interval=0.05` in `tests/validator/test_progress_reporter.py`), so they're unaffected by the default change.

## Documentation

- [ ] README updated
- [x] Code comments added/updated (help-string default annotation)
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

After this ships and Watchtower updates the prod validator images, the production fleet will automatically pick up the new default. External operators get the same default but can override with `ORO_POLL_INTERVAL=<seconds>` in their `.env` if they need faster polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)