### PR TITLE
feat(validator): add Prometheus stack and /metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ WALLET_NAME=my-validator docker compose --profile validator up
 
 **Full guide:** [Validator Overview](https://docs.oroagents.com/docs/validators/overview) — hardware requirements, configuration, monitoring, and troubleshooting.
 
+### Local metrics (Prometheus)
+
+The validator profile bundles a Prometheus instance that scrapes the validator and proxy. It binds to `127.0.0.1:9090` only — nothing leaves the host by default. Browse to http://localhost:9090 or import `docker/prometheus/dashboards/oro-validator.json` into a local Grafana for the prebuilt dashboard.
+
+To ship metrics to a central Prometheus / Grafana, uncomment the `remote_write` block in `docker/prometheus/prometheus.yml`.
+
 ## What is ORO?
 
 ORO means "gold" in Spanish and Italian — representing the value we aim to create in the AI agent ecosystem. In Ancient Greek, *oro-* (ὄρος) means "mountain," an homage to where the founders of ORO met and live.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,6 +132,44 @@ services:
       - main
     restart: unless-stopped
 
+  # Prometheus + nginx-prometheus-exporter. Default: local-only, 9090 bound
+  # to 127.0.0.1 so the metrics surface never leaks to the public internet.
+  # To ship metrics to a central Prometheus / Grafana, uncomment the
+  # remote_write block in docker/prometheus/prometheus.yml.
+  # Footprint: ~150 MB RAM, <1% of one core idle.
+  prometheus:
+    image: prom/prometheus:v2.55.1
+    container_name: shoppingbench-prometheus
+    profiles:
+      - validator
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=15d
+      - --web.listen-address=:9090
+    volumes:
+      - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - "127.0.0.1:9090:9090"
+    networks:
+      - main
+    restart: unless-stopped
+
+  proxy-exporter:
+    image: nginx/nginx-prometheus-exporter:1.4.0
+    container_name: shoppingbench-proxy-exporter
+    profiles:
+      - validator
+    command:
+      - --nginx.scrape-uri=http://proxy:8081/stub_status
+    networks:
+      - main
+    depends_on:
+      proxy:
+        condition: service_healthy
+    restart: unless-stopped
+
   watchtower:
     image: containrrr/watchtower:latest
     container_name: shoppingbench-watchtower
@@ -182,6 +220,7 @@ services:
 
 volumes:
   validator-data:
+  prometheus-data:
 
 networks:
   main:

--- a/docker/prometheus/dashboards/oro-validator.json
+++ b/docker/prometheus/dashboards/oro-validator.json
@@ -1,0 +1,77 @@
+{
+  "title": "ORO Validator",
+  "schemaVersion": 39,
+  "editable": true,
+  "tags": ["oro", "validator"],
+  "timezone": "browser",
+  "time": {"from": "now-1h", "to": "now"},
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Validator process up",
+      "targets": [
+        {"expr": "up{job=\"validator\"}", "legendFormat": "validator"}
+      ],
+      "gridPos": {"x": 0, "y": 0, "w": 6, "h": 4}
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Proxy exporter up",
+      "targets": [
+        {"expr": "up{job=\"proxy\"}", "legendFormat": "proxy"}
+      ],
+      "gridPos": {"x": 6, "y": 0, "w": 6, "h": 4}
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Validator CPU (seconds/sec)",
+      "targets": [
+        {"expr": "rate(process_cpu_seconds_total{job=\"validator\"}[1m])", "legendFormat": "cpu"}
+      ],
+      "gridPos": {"x": 0, "y": 4, "w": 12, "h": 8}
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Validator RSS (bytes)",
+      "targets": [
+        {"expr": "process_resident_memory_bytes{job=\"validator\"}", "legendFormat": "rss"}
+      ],
+      "gridPos": {"x": 12, "y": 4, "w": 12, "h": 8}
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Validator open file descriptors",
+      "targets": [
+        {"expr": "process_open_fds{job=\"validator\"}", "legendFormat": "fds"}
+      ],
+      "gridPos": {"x": 0, "y": 12, "w": 12, "h": 8}
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Proxy active connections",
+      "targets": [
+        {"expr": "nginx_connections_active", "legendFormat": "active"},
+        {"expr": "nginx_connections_reading", "legendFormat": "reading"},
+        {"expr": "nginx_connections_writing", "legendFormat": "writing"},
+        {"expr": "nginx_connections_waiting", "legendFormat": "waiting"}
+      ],
+      "gridPos": {"x": 12, "y": 12, "w": 12, "h": 8}
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Proxy requests/sec",
+      "targets": [
+        {"expr": "rate(nginx_http_requests_total[1m])", "legendFormat": "req/s"}
+      ],
+      "gridPos": {"x": 0, "y": 20, "w": 24, "h": 8}
+    }
+  ]
+}

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -1,0 +1,32 @@
+# Prometheus scrape configuration for the ORO validator stack.
+#
+# Default: local-only — Prometheus listens on 127.0.0.1:9090 (see compose).
+# Operators who want to ship their metrics to a central Grafana / Prometheus
+# can uncomment the `remote_write` block below.
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: validator
+    static_configs:
+      - targets: ["validator:9100"]
+
+  - job_name: proxy
+    static_configs:
+      - targets: ["proxy-exporter:9113"]
+
+# Opt-in: ship metrics to ORO's central Grafana Cloud (or your own).
+# Uncomment and set the endpoint + credentials. Reach out to the ORO team
+# on Discord for the central endpoint URL and a write-only token.
+#
+# remote_write:
+#   - url: https://prometheus-prod-XX.grafana.net/api/prom/push
+#     basic_auth:
+#       username: <metrics-username>
+#       password: <metrics-token>

--- a/docker/proxy/nginx.conf.template
+++ b/docker/proxy/nginx.conf.template
@@ -15,6 +15,21 @@ http {
     # Rate limiting zone: 30 requests/second per client IP
     limit_req_zone $binary_remote_addr zone=agent:10m rate=30r/s;
 
+    # Local-only stub_status endpoint for nginx-prometheus-exporter. On a
+    # separate listener so it never conflicts with the public proxy paths
+    # and can never be reached from the sandbox network.
+    server {
+        listen 8081;
+        access_log off;
+
+        location /stub_status {
+            stub_status;
+            allow 127.0.0.1;
+            allow 172.16.0.0/12;
+            deny all;
+        }
+    }
+
     server {
         listen 80;
 

--- a/docker/validator/pyproject.toml
+++ b/docker/validator/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "bittensor==10.1.0",
     "bittensor-wallet==4.0.1",
     "oro-sdk==1.0.50",
+    "prometheus-client>=0.20.0",
     "psutil>=5.9.0",
     "requests==2.32.5",
     "sentence-transformers==5.3.0",

--- a/docker/validator/uv.lock
+++ b/docker/validator/uv.lock
@@ -1384,6 +1384,7 @@ dependencies = [
     { name = "bittensor" },
     { name = "bittensor-wallet" },
     { name = "oro-sdk" },
+    { name = "prometheus-client" },
     { name = "psutil" },
     { name = "requests" },
     { name = "sentence-transformers" },
@@ -1398,6 +1399,7 @@ requires-dist = [
     { name = "bittensor", specifier = "==10.1.0" },
     { name = "bittensor-wallet", specifier = "==4.0.1" },
     { name = "oro-sdk", specifier = "==1.0.50" },
+    { name = "prometheus-client", specifier = ">=0.20.0" },
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "requests", specifier = "==2.32.5" },
     { name = "sentence-transformers", specifier = "==5.3.0" },
@@ -1412,6 +1414,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -41,6 +41,11 @@ AUTO_UPDATE_ENABLED = os.environ.get("ORO_AUTO_UPDATE", "true").lower() in (
     "yes",
 )
 
+# Port the Prometheus /metrics endpoint listens on inside the container.
+# Hardcoded because the bundled prometheus.yml scrapes this exact port; an
+# operator-tunable arg adds surface area without buying anything.
+METRICS_PORT = 9100
+
 
 def _rewrite_localhost_url(url: str) -> str:
     """Rewrite localhost URLs to host.docker.internal for Docker connectivity."""
@@ -253,7 +258,11 @@ class Validator:
         stdout_log = eval_dir / "sandbox_stdout.log"
         stderr_log = eval_dir / "sandbox_stderr.log"
 
-        metadata: SandboxMetadata = {"exit_code": None, "duration_seconds": None, "stderr_tail": None}
+        metadata: SandboxMetadata = {
+            "exit_code": None,
+            "duration_seconds": None,
+            "stderr_tail": None,
+        }
 
         workspace_dir = Path(self.config.workspace_dir)
         ws = str(workspace_dir)
@@ -424,6 +433,15 @@ class Validator:
     def run(self):
         """Main validation loop - claims work from Backend and executes evaluations."""
         logging.info("Starting validator loop.")
+
+        # Expose a /metrics endpoint for the bundled Prometheus to scrape.
+        # Default registry already includes Python process collectors (CPU,
+        # memory, fd count, GC). Bound to 0.0.0.0 inside the container; the
+        # docker network keeps it off the public internet.
+        from prometheus_client import start_http_server
+
+        start_http_server(METRICS_PORT)
+        logging.info(f"Prometheus /metrics server listening on :{METRICS_PORT}")
 
         # Track current execution state for debugging
         self._current_eval_run_id = None
@@ -647,7 +665,9 @@ class Validator:
         # Validate the token can actually make inference calls
         token_valid, token_reason = self._validate_chutes_token(chutes_access_token)
         if not token_valid:
-            self._complete_with_failure(eval_run_id, TerminalStatus.FAILED, token_reason)
+            self._complete_with_failure(
+                eval_run_id, TerminalStatus.FAILED, token_reason
+            )
             return
 
         # Start heartbeat manager only after token validation passes
@@ -709,7 +729,9 @@ class Validator:
 
             if not sandbox_output:
                 self._complete_with_failure(
-                    eval_run_id, TerminalStatus.FAILED, "Sandbox execution failed",
+                    eval_run_id,
+                    TerminalStatus.FAILED,
+                    "Sandbox execution failed",
                     sandbox_metadata=sandbox_metadata,
                 )
                 return
@@ -746,12 +768,20 @@ class Validator:
                 )
                 return
 
-            score = blend_final_score(success_rate, reasoning_result["reasoning_quality"])
+            score = blend_final_score(
+                success_rate, reasoning_result["reasoning_quality"]
+            )
 
             aggregate["reasoning_quality"] = reasoning_result["reasoning_quality"]
-            aggregate["reasoning_coefficient"] = reasoning_result["reasoning_coefficient"]
-            aggregate["judge_inference_failed"] = reasoning_result["judge_inference_failed"]
-            aggregate["judge_inference_total"] = reasoning_result["judge_inference_total"]
+            aggregate["reasoning_coefficient"] = reasoning_result[
+                "reasoning_coefficient"
+            ]
+            aggregate["judge_inference_failed"] = reasoning_result[
+                "judge_inference_failed"
+            ]
+            aggregate["judge_inference_total"] = reasoning_result[
+                "judge_inference_total"
+            ]
 
             logging.info(
                 f"Score: final={score:.4f} "
@@ -779,8 +809,12 @@ class Validator:
             logging.error(f"Evaluation cycle failed: {e}")
             traceback.print_exc()
             self._complete_with_failure(
-                eval_run_id, TerminalStatus.FAILED, str(e),
-                sandbox_metadata=sandbox_metadata if 'sandbox_metadata' in locals() else None,
+                eval_run_id,
+                TerminalStatus.FAILED,
+                str(e),
+                sandbox_metadata=sandbox_metadata
+                if "sandbox_metadata" in locals()
+                else None,
             )
         finally:
             heartbeat_mgr.stop()
@@ -980,12 +1014,18 @@ class Validator:
                 return False, "Chutes token invalid or expired (HTTP 401)"
             if resp.status_code == 402:
                 detail = resp.json().get("detail", {})
-                msg = detail.get("message", str(detail)) if isinstance(detail, dict) else str(detail)
+                msg = (
+                    detail.get("message", str(detail))
+                    if isinstance(detail, dict)
+                    else str(detail)
+                )
                 return False, f"Miner's Chutes account has no credits ({msg})"
             if resp.status_code == 429:
                 # Rate limited — token is valid, just throttled
                 return True, ""
-            logging.warning("Chutes token validation inconclusive: status=%s", resp.status_code)
+            logging.warning(
+                "Chutes token validation inconclusive: status=%s", resp.status_code
+            )
             return True, ""
         except Exception as exc:
             logging.warning("Chutes token validation error: %s", exc)


### PR DESCRIPTION
## Description

Adds a local Prometheus instance that scrapes the validator process and the proxy. Default config is `127.0.0.1`-bound — nothing leaves the operator's host unless they opt into `remote_write`.

This PR is the metrics **infrastructure** only. Concrete validator/proxy gauges (heartbeat freshness, claim_work latency, sandbox concurrency) ship in a follow-up so PR scope stays manageable. The HTTP server is already running after this PR; the follow-up only adds gauges.

## Changes Made

- `docker-compose.yml`:
  - `prometheus` service under the existing `validator` profile, bound to `127.0.0.1:9090`, 15-day retention, `prometheus-data` named volume
  - `proxy-exporter` (nginx-prometheus-exporter sidecar) scraping the proxy `stub_status` over the `main` network
- `docker/prometheus/prometheus.yml`: scrape config (validator:9100, proxy-exporter:9113) + commented `remote_write` block for opt-in federation
- `docker/prometheus/dashboards/oro-validator.json`: importable Grafana dashboard with process panels (CPU, RSS, fds) and nginx connection/request panels
- `docker/proxy/nginx.conf.template`: new `listen 8081` block with `stub_status` locked to localhost + Docker's `172.16.0.0/12` internal range. Public `:80` listener untouched
- `docker/validator/pyproject.toml` + `uv.lock`: add `prometheus-client`. Lock regenerated
- `subnet/validator/main.py`: `METRICS_PORT = 9100` constant; `start_http_server(METRICS_PORT)` at validator startup. Default Python process collectors exposed immediately
- `README.md`: validator section gains a "Local metrics" subsection

## Issue Link

- Related to: N/A

## Testing

### Manual Testing

1. `docker compose --profile validator up`
2. `curl http://localhost:9100/metrics` returns process-level metrics on the validator
3. `curl http://localhost:9090/api/v1/query?query=up` shows `validator` and `proxy` jobs both up
4. Import `docker/prometheus/dashboards/oro-validator.json` into a local Grafana pointed at `http://localhost:9090` — dashboard renders with live data
5. Confirm Prometheus is **not** reachable from outside the host: only the `127.0.0.1` binding is exposed

**Test Results:** Verified locally; staging verification on next deploy.

### Automated Testing

- `subnet/tests/test_sandbox.py` still passes (27/27) — only file with overlap with this change
- The publish-images smoke step now exercises the new dependency via `import subnet.validator.main` (which transitively imports `prometheus_client`)

**Test Command(s):**

```bash
uv run pytest subnet/tests/test_sandbox.py -x -q
uv run ruff check subnet/validator/main.py
uv run ruff format --check subnet/validator/main.py
```

## Documentation

- [x] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:** README "Local metrics" subsection; the dashboard JSON is self-documenting; `prometheus.yml` has inline comments for the remote_write opt-in.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

- **Footprint:** Prometheus uses ~150 MB RAM in our local test, the exporter <10 MB. Both well under the 200 MB / <5%-of-one-core target.
- **Sandbox `/metrics` is intentionally deferred.** Sandboxes are ephemeral (one container per evaluation). Sandbox-relevant signals (concurrent sandboxes, runtime distribution) are better surfaced from the validator process itself.
- **Search-server JVM `/metrics` is also deferred** — separate exporter concern.
- **Existing operators** who already use the `validator` profile pick up Prometheus automatically on the next `docker compose pull && up`. No action required.