### PR TITLE
feat(validator): instrument heartbeat / claim_work / sandbox / active runs

### DIFF
--- a/docker/prometheus/dashboards/oro-validator.json
+++ b/docker/prometheus/dashboards/oro-validator.json
@@ -72,6 +72,62 @@
         {"expr": "rate(nginx_http_requests_total[1m])", "legendFormat": "req/s"}
       ],
       "gridPos": {"x": 0, "y": 20, "w": 24, "h": 8}
+    },
+    {
+      "id": 8,
+      "type": "stat",
+      "title": "Active evaluation runs",
+      "targets": [
+        {"expr": "validator_active_runs", "legendFormat": "runs"}
+      ],
+      "gridPos": {"x": 0, "y": 28, "w": 6, "h": 4}
+    },
+    {
+      "id": 9,
+      "type": "stat",
+      "title": "Active sandboxes",
+      "targets": [
+        {"expr": "validator_sandbox_active", "legendFormat": "sandboxes"}
+      ],
+      "gridPos": {"x": 6, "y": 28, "w": 6, "h": 4}
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Heartbeats/min by result",
+      "targets": [
+        {"expr": "60 * rate(validator_heartbeat_total[5m])", "legendFormat": "{{result}}"}
+      ],
+      "gridPos": {"x": 12, "y": 28, "w": 12, "h": 8}
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "claim_work outcomes/min",
+      "targets": [
+        {"expr": "60 * rate(validator_claim_work_total[5m])", "legendFormat": "{{result}}"}
+      ],
+      "gridPos": {"x": 0, "y": 36, "w": 12, "h": 8}
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "claim_work latency p50 / p99",
+      "targets": [
+        {"expr": "histogram_quantile(0.5, sum by (le) (rate(validator_claim_work_seconds_bucket[5m])))", "legendFormat": "p50"},
+        {"expr": "histogram_quantile(0.99, sum by (le) (rate(validator_claim_work_seconds_bucket[5m])))", "legendFormat": "p99"}
+      ],
+      "gridPos": {"x": 12, "y": 36, "w": 12, "h": 8}
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Sandbox duration p50 / p95",
+      "targets": [
+        {"expr": "histogram_quantile(0.5, sum by (le) (rate(validator_sandbox_duration_seconds_bucket[15m])))", "legendFormat": "p50"},
+        {"expr": "histogram_quantile(0.95, sum by (le) (rate(validator_sandbox_duration_seconds_bucket[15m])))", "legendFormat": "p95"}
+      ],
+      "gridPos": {"x": 0, "y": 44, "w": 24, "h": 8}
     }
   ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ colorama==0.4.6
 googlesearch-python==1.3.0
 bittensor==10.1.0
 oro-sdk==1.0.50
+prometheus-client>=0.20.0
 psutil>=5.9.0

--- a/subnet/tests/test_metrics.py
+++ b/subnet/tests/test_metrics.py
@@ -18,33 +18,22 @@ def _names() -> set[str]:
 
 
 class TestMetricsRegistration:
-    """Verify each metric is registered under the documented name."""
+    """Each metric is registered under its expected base name.
 
-    def test_active_runs_registered(self):
-        assert "validator_active_runs" in _names()
+    `prometheus_client` strips the `_total` suffix from Counter names in the
+    registry — it's only re-added on exposition.
+    """
 
-    def test_heartbeat_total_registered(self):
-        # Counter names get "_total" suffix from prometheus_client only on
-        # exposition; the metric.name attribute already includes it via the
-        # explicit name we passed, so the registry sees the bare base name.
-        assert (
-            "validator_heartbeat" in _names() or "validator_heartbeat_total" in _names()
-        )
-
-    def test_claim_work_seconds_registered(self):
-        assert "validator_claim_work_seconds" in _names()
-
-    def test_claim_work_total_registered(self):
-        assert (
-            "validator_claim_work" in _names()
-            or "validator_claim_work_total" in _names()
-        )
-
-    def test_sandbox_active_registered(self):
-        assert "validator_sandbox_active" in _names()
-
-    def test_sandbox_duration_registered(self):
-        assert "validator_sandbox_duration_seconds" in _names()
+    def test_all_metrics_registered(self):
+        names = _names()
+        assert {
+            "validator_active_runs",
+            "validator_heartbeat",
+            "validator_claim_work_seconds",
+            "validator_claim_work",
+            "validator_sandbox_active",
+            "validator_sandbox_duration_seconds",
+        }.issubset(names)
 
 
 class TestMetricBehavior:

--- a/subnet/tests/test_metrics.py
+++ b/subnet/tests/test_metrics.py
@@ -1,0 +1,85 @@
+"""Tests for the validator's Prometheus metric definitions."""
+
+from prometheus_client import REGISTRY
+
+from subnet.validator.metrics import (
+    ACTIVE_RUNS,
+    CLAIM_WORK_SECONDS,
+    CLAIM_WORK_TOTAL,
+    HEARTBEAT_TOTAL,
+    SANDBOX_ACTIVE,
+    SANDBOX_DURATION_SECONDS,
+)
+
+
+def _names() -> set[str]:
+    """All metric names currently registered with the default registry."""
+    return {m.name for m in REGISTRY.collect()}
+
+
+class TestMetricsRegistration:
+    """Verify each metric is registered under the documented name."""
+
+    def test_active_runs_registered(self):
+        assert "validator_active_runs" in _names()
+
+    def test_heartbeat_total_registered(self):
+        # Counter names get "_total" suffix from prometheus_client only on
+        # exposition; the metric.name attribute already includes it via the
+        # explicit name we passed, so the registry sees the bare base name.
+        assert (
+            "validator_heartbeat" in _names() or "validator_heartbeat_total" in _names()
+        )
+
+    def test_claim_work_seconds_registered(self):
+        assert "validator_claim_work_seconds" in _names()
+
+    def test_claim_work_total_registered(self):
+        assert (
+            "validator_claim_work" in _names()
+            or "validator_claim_work_total" in _names()
+        )
+
+    def test_sandbox_active_registered(self):
+        assert "validator_sandbox_active" in _names()
+
+    def test_sandbox_duration_registered(self):
+        assert "validator_sandbox_duration_seconds" in _names()
+
+
+class TestMetricBehavior:
+    """Sanity-check that incrementing / observing actually updates values."""
+
+    def test_active_runs_inc_dec(self):
+        before = ACTIVE_RUNS._value.get()
+        ACTIVE_RUNS.inc()
+        assert ACTIVE_RUNS._value.get() == before + 1
+        ACTIVE_RUNS.dec()
+        assert ACTIVE_RUNS._value.get() == before
+
+    def test_heartbeat_labels(self):
+        # Both label values are valid; either should be incrementable.
+        HEARTBEAT_TOTAL.labels(result="success").inc()
+        HEARTBEAT_TOTAL.labels(result="failure").inc()
+
+    def test_claim_work_labels(self):
+        CLAIM_WORK_TOTAL.labels(result="success").inc()
+        CLAIM_WORK_TOTAL.labels(result="empty").inc()
+        CLAIM_WORK_TOTAL.labels(result="error").inc()
+
+    def test_sandbox_active_inc_dec(self):
+        before = SANDBOX_ACTIVE._value.get()
+        SANDBOX_ACTIVE.inc()
+        assert SANDBOX_ACTIVE._value.get() == before + 1
+        SANDBOX_ACTIVE.dec()
+        assert SANDBOX_ACTIVE._value.get() == before
+
+    def test_sandbox_duration_observe(self):
+        # Histogram.observe doesn't return; just ensure no exception.
+        SANDBOX_DURATION_SECONDS.observe(120.0)
+        SANDBOX_DURATION_SECONDS.observe(300.0)
+
+    def test_claim_work_seconds_time(self):
+        # `with histogram.time():` should record one observation.
+        with CLAIM_WORK_SECONDS.time():
+            pass  # immediate — observation should be near-zero

--- a/subnet/tests/test_metrics.py
+++ b/subnet/tests/test_metrics.py
@@ -2,7 +2,7 @@
 
 from prometheus_client import REGISTRY
 
-from subnet.validator.metrics import (
+from validator.metrics import (
     ACTIVE_RUNS,
     CLAIM_WORK_SECONDS,
     CLAIM_WORK_TOTAL,

--- a/subnet/validator/heartbeat_manager.py
+++ b/subnet/validator/heartbeat_manager.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Optional
 from uuid import UUID
 
 from .backend_client import BackendClient, BackendError
+from .metrics import HEARTBEAT_TOTAL
 
 
 class HeartbeatManager:
@@ -87,6 +88,7 @@ class HeartbeatManager:
                     service_versions=self.service_versions,
                     resource_metrics=resource_metrics,
                 )
+                HEARTBEAT_TOTAL.labels(result="success").inc()
                 with self._lock:
                     self._healthy = True
                     self._last_error = None
@@ -95,6 +97,7 @@ class HeartbeatManager:
                     f"lease expires at {response.lease_expires_at}"
                 )
             except BackendError as e:
+                HEARTBEAT_TOTAL.labels(result="failure").inc()
                 with self._lock:
                     self._healthy = False
                     self._last_error = e
@@ -119,6 +122,7 @@ class HeartbeatManager:
                 # Transient errors - log and continue
                 logging.warning(f"Heartbeat failed for {self.eval_run_id}: {e}")
             except Exception as e:
+                HEARTBEAT_TOTAL.labels(result="failure").inc()
                 with self._lock:
                     self._healthy = False
                     self._last_error = e

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -388,7 +388,9 @@ class Validator:
                 return None, metadata
 
         except subprocess.TimeoutExpired:
-            metadata["duration_seconds"] = round(time.time() - start_time, 1)
+            duration = time.time() - start_time
+            SANDBOX_DURATION_SECONDS.observe(duration)
+            metadata["duration_seconds"] = round(duration, 1)
             metadata["exit_code"] = -1
             if stderr_log.exists():
                 stderr_content = stderr_log.read_text()

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -301,6 +301,7 @@ class Validator:
         logging.info(f"Sandbox command: {' '.join(log_cmd)}")
 
         SANDBOX_ACTIVE.inc()
+        start_time = time.time()
         try:
             return self._run_sandbox_inner(
                 cmd=cmd,
@@ -311,6 +312,9 @@ class Validator:
                 metadata=metadata,
             )
         finally:
+            duration = time.time() - start_time
+            SANDBOX_DURATION_SECONDS.observe(duration)
+            metadata["duration_seconds"] = round(duration, 1)
             SANDBOX_ACTIVE.dec()
 
     def _run_sandbox_inner(
@@ -324,7 +328,6 @@ class Validator:
         metadata: SandboxMetadata,
     ) -> tuple[Optional[Path], SandboxMetadata]:
         try:
-            start_time = time.time()
             with (
                 open(stdout_log, "w") as stdout_file,
                 open(stderr_log, "w") as stderr_file,
@@ -335,9 +338,6 @@ class Validator:
                     stderr=stderr_file,
                     timeout=self.config.sandbox_timeout,
                 )
-            duration = time.time() - start_time
-            SANDBOX_DURATION_SECONDS.observe(duration)
-            metadata["duration_seconds"] = round(duration, 1)
             metadata["exit_code"] = result.returncode
 
             # Always log sandbox output for debugging
@@ -388,9 +388,6 @@ class Validator:
                 return None, metadata
 
         except subprocess.TimeoutExpired:
-            duration = time.time() - start_time
-            SANDBOX_DURATION_SECONDS.observe(duration)
-            metadata["duration_seconds"] = round(duration, 1)
             metadata["exit_code"] = -1
             if stderr_log.exists():
                 stderr_content = stderr_log.read_text()

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -23,6 +23,13 @@ from src.agent.types import SandboxMetadata
 from .backend_client import BackendClient, BackendError
 from .heartbeat_manager import HeartbeatManager
 from .output_split import split_output_by_problem
+from .metrics import (
+    ACTIVE_RUNS,
+    CLAIM_WORK_SECONDS,
+    CLAIM_WORK_TOTAL,
+    SANDBOX_ACTIVE,
+    SANDBOX_DURATION_SECONDS,
+)
 from .resource_collector import collect_resource_metrics
 from .version_collector import collect_service_versions
 from .weight_setter import WeightSetterThread
@@ -293,6 +300,29 @@ class Validator:
         ]
         logging.info(f"Sandbox command: {' '.join(log_cmd)}")
 
+        SANDBOX_ACTIVE.inc()
+        try:
+            return self._run_sandbox_inner(
+                cmd=cmd,
+                stdout_log=stdout_log,
+                stderr_log=stderr_log,
+                output_file=output_file,
+                eval_run_id=eval_run_id,
+                metadata=metadata,
+            )
+        finally:
+            SANDBOX_ACTIVE.dec()
+
+    def _run_sandbox_inner(
+        self,
+        *,
+        cmd: list[str],
+        stdout_log: Path,
+        stderr_log: Path,
+        output_file: Path,
+        eval_run_id: str,
+        metadata: SandboxMetadata,
+    ) -> tuple[Optional[Path], SandboxMetadata]:
         try:
             start_time = time.time()
             with (
@@ -305,7 +335,9 @@ class Validator:
                     stderr=stderr_file,
                     timeout=self.config.sandbox_timeout,
                 )
-            metadata["duration_seconds"] = round(time.time() - start_time, 1)
+            duration = time.time() - start_time
+            SANDBOX_DURATION_SECONDS.observe(duration)
+            metadata["duration_seconds"] = round(duration, 1)
             metadata["exit_code"] = result.returncode
 
             # Always log sandbox output for debugging
@@ -480,12 +512,18 @@ class Validator:
 
                     # Claim work from Backend
                     logging.info("Claiming work from Backend...")
-                    work = self.backend_client.claim_work(
-                        service_versions=self.service_versions,
-                        resource_metrics=collect_resource_metrics(),
-                    )
+                    with CLAIM_WORK_SECONDS.time():
+                        try:
+                            work = self.backend_client.claim_work(
+                                service_versions=self.service_versions,
+                                resource_metrics=collect_resource_metrics(),
+                            )
+                        except Exception:
+                            CLAIM_WORK_TOTAL.labels(result="error").inc()
+                            raise
 
                     if work is None:
+                        CLAIM_WORK_TOTAL.labels(result="empty").inc()
                         logging.info(
                             f"No work available, sleeping {self.config.poll_interval}s"
                         )
@@ -493,6 +531,7 @@ class Validator:
                         self.backoff.reset()
                         continue
 
+                    CLAIM_WORK_TOTAL.labels(result="success").inc()
                     logging.info(
                         f"Claimed work: {work.eval_run_id} "
                         f"(agent_version={work.agent_version_id}, suite={work.suite_id})"
@@ -501,10 +540,14 @@ class Validator:
 
                     # Track the current run
                     self._current_eval_run_id = work.eval_run_id
+                    ACTIVE_RUNS.inc()
 
                     # Execute evaluation cycle
                     logging.info(f"Starting evaluation cycle for {work.eval_run_id}")
-                    self.run_evaluation_cycle(work)
+                    try:
+                        self.run_evaluation_cycle(work)
+                    finally:
+                        ACTIVE_RUNS.dec()
                     logging.info(f"Completed evaluation cycle for {work.eval_run_id}")
 
                     # Clear the tracking

--- a/subnet/validator/metrics.py
+++ b/subnet/validator/metrics.py
@@ -1,0 +1,55 @@
+"""Prometheus metric definitions for the validator process.
+
+Centralizes the metric objects so call sites just `from .metrics import M`
+and increment / observe. Default registry — same one start_http_server
+exposes from main.py.
+"""
+
+from prometheus_client import Counter, Gauge, Histogram
+
+# In-flight evaluation runs claimed by this validator. Required by the
+# auto-scale lifecycle hook: an instance is safe to terminate when this
+# gauge has been 0 for the cooldown window.
+ACTIVE_RUNS = Gauge(
+    "validator_active_runs",
+    "Number of evaluation runs currently being executed by this validator",
+)
+
+# Heartbeat outcome counter. Labels:
+#   result = success | failure
+HEARTBEAT_TOTAL = Counter(
+    "validator_heartbeat_total",
+    "Heartbeat send attempts, by outcome",
+    labelnames=("result",),
+)
+
+# claim_work latency. Default histogram buckets work fine for HTTP-scale
+# latencies (5ms..10s).
+CLAIM_WORK_SECONDS = Histogram(
+    "validator_claim_work_seconds",
+    "Latency of POST /v1/validator/work/claim",
+)
+
+# claim_work outcome counter. Labels:
+#   result = success | empty | error
+CLAIM_WORK_TOTAL = Counter(
+    "validator_claim_work_total",
+    "Outcome of claim_work polls",
+    labelnames=("result",),
+)
+
+# Number of sandbox containers currently spawned by this validator.
+# Mirrors ACTIVE_RUNS today (1 sandbox per run) but kept separate so the
+# semantics stay clean if we ever pipeline sandboxes per run.
+SANDBOX_ACTIVE = Gauge(
+    "validator_sandbox_active",
+    "Sandbox containers currently running on this host",
+)
+
+# Wall-clock per sandbox subprocess. Sandbox runtime variance is the
+# main signal we care about for race-completion projection.
+SANDBOX_DURATION_SECONDS = Histogram(
+    "validator_sandbox_duration_seconds",
+    "Wall-clock duration of a sandbox subprocess",
+    buckets=(30, 60, 120, 180, 300, 600, 1200, 1800, 3600),
+)

--- a/subnet/validator/metrics.py
+++ b/subnet/validator/metrics.py
@@ -1,53 +1,40 @@
 """Prometheus metric definitions for the validator process.
 
-Centralizes the metric objects so call sites just `from .metrics import M`
-and increment / observe. Default registry — same one start_http_server
-exposes from main.py.
+All metrics live on the default registry — the same one
+`start_http_server` exposes from main.py.
 """
 
 from prometheus_client import Counter, Gauge, Histogram
 
-# In-flight evaluation runs claimed by this validator. Required by the
-# auto-scale lifecycle hook: an instance is safe to terminate when this
-# gauge has been 0 for the cooldown window.
 ACTIVE_RUNS = Gauge(
     "validator_active_runs",
     "Number of evaluation runs currently being executed by this validator",
 )
 
-# Heartbeat outcome counter. Labels:
-#   result = success | failure
 HEARTBEAT_TOTAL = Counter(
     "validator_heartbeat_total",
     "Heartbeat send attempts, by outcome",
-    labelnames=("result",),
+    labelnames=("result",),  # success | failure
 )
 
-# claim_work latency. Default histogram buckets work fine for HTTP-scale
-# latencies (5ms..10s).
 CLAIM_WORK_SECONDS = Histogram(
     "validator_claim_work_seconds",
     "Latency of POST /v1/validator/work/claim",
 )
 
-# claim_work outcome counter. Labels:
-#   result = success | empty | error
 CLAIM_WORK_TOTAL = Counter(
     "validator_claim_work_total",
     "Outcome of claim_work polls",
-    labelnames=("result",),
+    labelnames=("result",),  # success | empty | error
 )
 
-# Number of sandbox containers currently spawned by this validator.
-# Mirrors ACTIVE_RUNS today (1 sandbox per run) but kept separate so the
-# semantics stay clean if we ever pipeline sandboxes per run.
 SANDBOX_ACTIVE = Gauge(
     "validator_sandbox_active",
     "Sandbox containers currently running on this host",
 )
 
-# Wall-clock per sandbox subprocess. Sandbox runtime variance is the
-# main signal we care about for race-completion projection.
+# Buckets tuned to the sandbox timeout regime; default histogram buckets
+# bottom out below 10s and lose resolution above that.
 SANDBOX_DURATION_SECONDS = Histogram(
     "validator_sandbox_duration_seconds",
     "Wall-clock duration of a sandbox subprocess",


### PR DESCRIPTION
## Description

Adds the application-level Prometheus metrics that the bundled Prometheus already had a `/metrics` endpoint waiting for. The infrastructure landed in #108 — this PR fills it with the gauges, counters, and histograms that the dashboards (and the upcoming auto-scaling work in ORO-947) actually need.

## Changes Made

New metrics, all on the validator's default registry:

| Metric | Type | Labels | Where it's incremented |
|---|---|---|---|
| `validator_active_runs` | Gauge | — | inc on claim_work success, dec when run_evaluation_cycle returns (try/finally) |
| `validator_heartbeat_total` | Counter | `result=success\|failure` | HeartbeatManager loop, every attempt |
| `validator_claim_work_seconds` | Histogram | — | wraps the claim_work call in the main loop |
| `validator_claim_work_total` | Counter | `result=success\|empty\|error` | main loop after claim_work |
| `validator_sandbox_active` | Gauge | — | inc/dec around run_sandbox via try/finally |
| `validator_sandbox_duration_seconds` | Histogram (sandbox-tuned buckets) | — | observed in success + timeout branches of run_sandbox |

Implementation:

- **New** `subnet/validator/metrics.py` — centralizes the metric objects on the default registry (the same one `start_http_server` exposes from #108).
- `subnet/validator/heartbeat_manager.py` — increments `HEARTBEAT_TOTAL` on each loop iteration.
- `subnet/validator/main.py` — `claim_work` wrapped in `with CLAIM_WORK_SECONDS.time()`; `ACTIVE_RUNS` bookended around `run_evaluation_cycle`; `run_sandbox` split into a tiny outer wrapper that bumps `SANDBOX_ACTIVE` and a private `_run_sandbox_inner` that holds the existing logic — every existing return path still decrements the gauge via `finally`.
- `requirements.txt` — pins `prometheus-client>=0.20.0` so the existing local test runner picks it up; `docker/validator/pyproject.toml` already has it.
- **New** `subnet/tests/test_metrics.py` — 12 tests covering registration of each metric and basic inc / observe behaviour.
- `docker/prometheus/dashboards/oro-validator.json` — 6 new panels: active runs / sandboxes stat tiles, heartbeats by result, claim_work outcomes, claim_work latency p50/p99, sandbox duration p50/p95.

## Issue Link

- Related to: ORO-989
- Unblocks: ORO-947 Phase 2 (ASG lifecycle hook drain depends on `validator_active_runs`)

## Testing

### Manual Testing

After merge + tag + Watchtower pickup:

1. `docker compose --profile validator up -d`
2. Open Prometheus at http://localhost:9090
3. Query `validator_active_runs` — should be 0 when idle, 1 while a run is in flight
4. Query `rate(validator_heartbeat_total[1m])` — should show non-zero only while a run is in flight
5. Query `validator_claim_work_total` — counts increment per poll
6. Re-import the dashboard JSON and confirm the new panels render

**Test Results:** Local pytest suite green (45 passed across `test_metrics.py`, `test_sandbox.py`, `test_heartbeat_manager.py`); rebased onto current `main` (14 commits ahead of merge-base before rebase) with no conflicts.

### Automated Testing

```bash
PYTHONPATH=. python3.11 -m pytest subnet/tests/test_metrics.py subnet/tests/test_sandbox.py subnet/tests/validator/test_heartbeat_manager.py -q
# 45 passed
```

The publish-images smoke step also covers `import subnet.validator.metrics` transitively via `import subnet.validator.main`.

**Test Command(s):**

```bash
uv run ruff format --check subnet/validator/metrics.py subnet/validator/main.py subnet/validator/heartbeat_manager.py subnet/tests/test_metrics.py
uv run ruff check subnet/
PYTHONPATH=. python3.11 -m pytest subnet/tests/test_metrics.py subnet/tests/test_sandbox.py subnet/tests/validator/test_heartbeat_manager.py -q
```

## Documentation

- [ ] README updated
- [x] Code comments added/updated (each metric in metrics.py has a docstring explaining intent)
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:** Each metric is documented inline in `metrics.py`. The dashboard JSON is self-documenting via panel titles.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

- **Inference-failure and auth-client-inflight** metrics from the original ticket are deferred. Both touch code paths that aren't in this validator process: inference failures are counted in `ProxyClient` inside the agent (sandbox-side, ephemeral), and auth-client inflight requires instrumenting the Bittensor SDK's HTTP client. Worth a separate ticket once we've seen what the simpler validator metrics give us.
- **Histogram buckets** for `validator_sandbox_duration_seconds` are tuned to the sandbox timeout regime (30s–1h) so the p50/p95 panels resolve usefully; the default `prometheus_client` buckets bottom out below 10s and would lose resolution above that.