### PR TITLE
fix(validator): self-heal wedged BittensorAuthClient via circuit breaker (ORO-955)

### DIFF
--- a/subnet/tests/validator/test_backend_client.py
+++ b/subnet/tests/validator/test_backend_client.py
@@ -1,11 +1,13 @@
 """Tests for backend_client using oro-sdk."""
 
+import contextlib
 import sys
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 from uuid import UUID
 
+import httpx
 import pytest
 from bittensor_wallet import Keypair, Wallet
 
@@ -617,8 +619,6 @@ class TestBackendClientCircuitBreaker:
                     client.claim_work()
 
     def test_below_threshold_keeps_same_client(self, mock_wallet):
-        import httpx
-
         client = BackendClient("https://api.example.com", mock_wallet)
         original = client._auth_client
         self._drain(client, client._CIRCUIT_THRESHOLD - 1, httpx.TimeoutException("t"))
@@ -629,10 +629,8 @@ class TestBackendClientCircuitBreaker:
     @pytest.mark.parametrize(
         "exc",
         [
-            pytest.param(__import__("httpx").TimeoutException("t"), id="timeout"),
-            pytest.param(
-                __import__("httpx").ConnectError("refused"), id="connect-error"
-            ),
+            pytest.param(httpx.TimeoutException("t"), id="timeout"),
+            pytest.param(httpx.ConnectError("refused"), id="connect-error"),
         ],
     )
     def test_threshold_recreates_client(self, mock_wallet, exc):
@@ -646,21 +644,12 @@ class TestBackendClientCircuitBreaker:
     @pytest.mark.parametrize(
         "recovery_response",
         [
-            pytest.param(
-                _create_response(
-                    200,
-                    # ClaimWorkResponse is constructed lazily so the import only happens
-                    # if this branch runs — keeps the parametrize block readable.
-                    None,
-                ),
-                id="200-success",
-            ),
+            pytest.param(_create_response(200, None), id="200-success"),
             pytest.param(_create_response(500, None), id="500-server-error"),
         ],
     )
     def test_round_trip_resets_counter(self, mock_wallet, recovery_response):
         """Any HTTP response (200 or 5xx) round-trips and clears the counter."""
-        import httpx
         from oro_sdk.models.claim_work_response import ClaimWorkResponse
 
         if recovery_response.status_code == 200:
@@ -676,20 +665,18 @@ class TestBackendClientCircuitBreaker:
         self._drain(client, 2, httpx.TimeoutException("t"))
         assert client._consecutive_failures == 2
 
-        with patch(
-            "validator.backend_client.claim_work.sync_detailed",
-            return_value=recovery_response,
+        with (
+            patch(
+                "validator.backend_client.claim_work.sync_detailed",
+                return_value=recovery_response,
+            ),
+            contextlib.suppress(BackendError),
         ):
-            try:
-                client.claim_work()
-            except BackendError:
-                pass  # 5xx still counts as a round-trip
+            client.claim_work()
         assert client._consecutive_failures == 0
 
     def test_recreate_throttled_within_cooldown(self, mock_wallet):
         """Once recreated, the client doesn't recreate again for the cooldown window."""
-        import httpx
-
         client = BackendClient("https://api.example.com", mock_wallet)
         self._drain(client, client._CIRCUIT_THRESHOLD, httpx.TimeoutException("t"))
         first_client, first_at = client._auth_client, client._last_recreate_at

--- a/subnet/tests/validator/test_backend_client.py
+++ b/subnet/tests/validator/test_backend_client.py
@@ -600,3 +600,102 @@ class TestBackendErrorTypedErrors:
 
             assert not exc_info.value.is_error(LeaseExpiredError)
             assert not exc_info.value.is_lease_expired
+
+
+class TestBackendClientCircuitBreaker:
+    """Self-healing circuit breaker for the BittensorAuthClient pool (ORO-955)."""
+
+    @staticmethod
+    def _drain(client: BackendClient, n: int, exc: Exception) -> None:
+        """Run n failing claim_work calls, each raising the given exception."""
+        with patch(
+            "validator.backend_client.claim_work.sync_detailed",
+            side_effect=exc,
+        ):
+            for _ in range(n):
+                with pytest.raises(BackendError):
+                    client.claim_work()
+
+    def test_below_threshold_keeps_same_client(self, mock_wallet):
+        import httpx
+
+        client = BackendClient("https://api.example.com", mock_wallet)
+        original = client._auth_client
+        self._drain(client, client._CIRCUIT_THRESHOLD - 1, httpx.TimeoutException("t"))
+
+        assert client._consecutive_failures == client._CIRCUIT_THRESHOLD - 1
+        assert client._auth_client is original
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            pytest.param(__import__("httpx").TimeoutException("t"), id="timeout"),
+            pytest.param(
+                __import__("httpx").ConnectError("refused"), id="connect-error"
+            ),
+        ],
+    )
+    def test_threshold_recreates_client(self, mock_wallet, exc):
+        client = BackendClient("https://api.example.com", mock_wallet)
+        original = client._auth_client
+        self._drain(client, client._CIRCUIT_THRESHOLD, exc)
+
+        assert client._auth_client is not original
+        assert client._consecutive_failures == 0
+
+    @pytest.mark.parametrize(
+        "recovery_response",
+        [
+            pytest.param(
+                _create_response(
+                    200,
+                    # ClaimWorkResponse is constructed lazily so the import only happens
+                    # if this branch runs — keeps the parametrize block readable.
+                    None,
+                ),
+                id="200-success",
+            ),
+            pytest.param(_create_response(500, None), id="500-server-error"),
+        ],
+    )
+    def test_round_trip_resets_counter(self, mock_wallet, recovery_response):
+        """Any HTTP response (200 or 5xx) round-trips and clears the counter."""
+        import httpx
+        from oro_sdk.models.claim_work_response import ClaimWorkResponse
+
+        if recovery_response.status_code == 200:
+            recovery_response.parsed = ClaimWorkResponse(
+                eval_run_id=UUID("12345678-1234-1234-1234-123456789012"),
+                agent_version_id=UUID("11111111-1111-1111-1111-111111111111"),
+                suite_id=1,
+                lease_expires_at=datetime(2025, 1, 1, 0, 0, 0),
+                code_download_url="https://example.com/code.py",
+            )
+
+        client = BackendClient("https://api.example.com", mock_wallet)
+        self._drain(client, 2, httpx.TimeoutException("t"))
+        assert client._consecutive_failures == 2
+
+        with patch(
+            "validator.backend_client.claim_work.sync_detailed",
+            return_value=recovery_response,
+        ):
+            try:
+                client.claim_work()
+            except BackendError:
+                pass  # 5xx still counts as a round-trip
+        assert client._consecutive_failures == 0
+
+    def test_recreate_throttled_within_cooldown(self, mock_wallet):
+        """Once recreated, the client doesn't recreate again for the cooldown window."""
+        import httpx
+
+        client = BackendClient("https://api.example.com", mock_wallet)
+        self._drain(client, client._CIRCUIT_THRESHOLD, httpx.TimeoutException("t"))
+        first_client, first_at = client._auth_client, client._last_recreate_at
+
+        # More timeouts immediately after — should NOT recreate again.
+        self._drain(client, client._CIRCUIT_THRESHOLD, httpx.TimeoutException("t"))
+
+        assert client._auth_client is first_client
+        assert client._last_recreate_at == first_at

--- a/subnet/validator/backend_client.py
+++ b/subnet/validator/backend_client.py
@@ -10,6 +10,7 @@ Error Handling:
 """
 
 import logging
+import time
 from typing import Any, Callable, Optional
 from uuid import UUID
 
@@ -176,30 +177,56 @@ class BackendError(Exception):
 class BackendClient:
     """HTTP client for ORO Backend API using oro-sdk.
 
-    This class wraps the oro-sdk and returns SDK types directly.
-    All validator endpoints require authentication via the BittensorAuthClient
-    which signs requests using the wallet's hotkey.
+    The httpx pool can wedge after a Backend rollover or stale TLS session
+    (see ORO-955); recovery is to drop the pool and re-create the auth
+    client. _call_api counts consecutive transient failures and recreates
+    after _CIRCUIT_THRESHOLD in a row, throttled to once per minute.
     """
+
+    _CIRCUIT_THRESHOLD = 3
+    _RECREATE_COOLDOWN_S = 60
 
     def __init__(self, base_url: str, wallet: Wallet, timeout: int = 30):
         self.base_url = base_url.rstrip("/")
         self.wallet = wallet
         self.timeout = timeout
-
-        # Create authenticated client for validator endpoints
-        self._auth_client = BittensorAuthClient(
-            base_url=self.base_url,
-            wallet=wallet,
-            timeout=httpx.Timeout(timeout),
-            raise_on_unexpected_status=False,
-        )
-
-        # Create public client for unauthenticated endpoints
+        self._consecutive_failures = 0
+        self._last_recreate_at: float = 0.0
+        self._auth_client = self._build_auth_client()
         self._public_client = Client(
             base_url=self.base_url,
             timeout=httpx.Timeout(timeout),
             raise_on_unexpected_status=False,
         )
+
+    def _build_auth_client(self) -> BittensorAuthClient:
+        return BittensorAuthClient(
+            base_url=self.base_url,
+            wallet=self.wallet,
+            timeout=httpx.Timeout(self.timeout),
+            raise_on_unexpected_status=False,
+        )
+
+    def _record_failure(self) -> None:
+        """Track a transient failure and recreate the auth client if the circuit trips."""
+        self._consecutive_failures += 1
+        now = time.monotonic()
+        if (
+            self._consecutive_failures < self._CIRCUIT_THRESHOLD
+            or now - self._last_recreate_at < self._RECREATE_COOLDOWN_S
+        ):
+            return
+        logging.warning(
+            "BackendClient: %d consecutive transient failures; recreating auth client",
+            self._consecutive_failures,
+        )
+        try:
+            self._auth_client.get_httpx_client().close()
+        except Exception as exc:
+            logging.warning("Old auth client failed to close cleanly: %s", exc)
+        self._auth_client = self._build_auth_client()
+        self._last_recreate_at = now
+        self._consecutive_failures = 0
 
     def _handle_response(
         self,
@@ -279,13 +306,24 @@ class BackendClient:
         Raises:
             BackendError: For any API error (transient or permanent).
         """
+        # Public-client failures don't trip the circuit breaker — only the
+        # auth client's pool wedges in the way ORO-955 describes.
+        is_auth_call = kwargs.get("client") is self._auth_client
+
         try:
             response = api_func(**kwargs)
+            # Any HTTP response means the pool is healthy — reset before
+            # _handle_response so a 4xx/5xx still clears the counter.
+            if is_auth_call:
+                self._consecutive_failures = 0
             return self._handle_response(response, operation, allow_204)
-
         except httpx.TimeoutException:
+            if is_auth_call:
+                self._record_failure()
             raise BackendError(f"{operation}: Request timed out")
         except httpx.ConnectError as e:
+            if is_auth_call:
+                self._record_failure()
             raise BackendError(f"{operation}: Connection error: {e}")
         except sdk_errors.UnexpectedStatus as e:
             body = ""
@@ -303,7 +341,8 @@ class BackendClient:
             logging.exception(
                 "%s: SDK response parsing failed (%s). Check for proxy/WAF "
                 "interference or SDK/Backend version mismatch.",
-                operation, type(e).__name__,
+                operation,
+                type(e).__name__,
             )
             raise BackendError(
                 f"{operation}: Response parsing failed ({type(e).__name__}: {e}). "
@@ -566,8 +605,11 @@ class BackendClient:
         )
         problems = []
         for p in response.problems:
-            metadata = p.metadata.to_dict() if p.metadata and not isinstance(p.metadata, Unset) else {}
+            metadata = (
+                p.metadata.to_dict()
+                if p.metadata and not isinstance(p.metadata, Unset)
+                else {}
+            )
             metadata["problem_id"] = str(p.problem_id)
             problems.append(metadata)
         return problems
-


### PR DESCRIPTION
## Description

Recurrence #3 of the wedged-auth-client stall today (2026-04-30) on the ORO production validator. Same shape as ORO-618 (March) and the Kraken stall (ORO-955 itself):

- Validator's httpx connection pool gets into a bad state — typically after a Backend ECS task rolls or a TLS session goes stale.
- Every subsequent `claim_work` raises `httpx.TimeoutException` without ever reaching the Backend.
- Validator stays wedged until container restart.

The 30s `keepalive_expiry` in oro-sdk's SigningTransport doesn't catch this — once the pool is sour, no recovery path exists short of a fresh process. ORO-618's per-connection retry fix evidently doesn't go far enough.

This PR adds a self-healing circuit breaker at the `BackendClient` level: track consecutive transient failures, swap in a fresh `BittensorAuthClient` after the threshold, throttle recreation so a real Backend outage doesn't spin in a recreate loop. Same approach, higher level — recover the entire socket pool, not just one connection.

## Changes Made

- `subnet/validator/backend_client.py`:
  - New `_build_auth_client()` helper to centralize auth-client construction.
  - New `_maybe_recreate_auth_client()` that swaps in a fresh `BittensorAuthClient` once `_CIRCUIT_THRESHOLD` (3) consecutive transient failures have piled up. Closes the old client (best-effort) so its socket pool + TLS sessions get dropped. Throttles recreation to once per `_MIN_RECREATE_INTERVAL_SECONDS` (60).
  - `_call_api`:
    - Resets `_consecutive_failures` to 0 as soon as `api_func()` returns (any HTTP status — 2xx/4xx/5xx all mean the pool is healthy, the request reached Backend).
    - Increments `_consecutive_failures` and may trigger recreation on `httpx.TimeoutException` and `httpx.ConnectError`.
    - Only auth-client calls participate in the circuit breaker; public-client failures don't affect the validator's work loop and have their own retry semantics.
  - Added a self-healing docstring to `BackendClient` explaining the mechanism.
- `subnet/tests/validator/test_backend_client.py`:
  - New `TestBackendClientCircuitBreaker` class with 6 tests:
    - `test_single_timeout_does_not_recreate` — one transient failure keeps the same auth client.
    - `test_threshold_consecutive_timeouts_recreate_client` — hitting threshold swaps in a fresh client.
    - `test_success_resets_failure_counter` — a successful round-trip clears accumulated failures.
    - `test_server_error_resets_failure_counter` — 5xx round-trips also reset (connection works, server errored).
    - `test_recreate_throttled_within_min_interval` — 60s cooldown prevents recreate loop.
    - `test_connect_error_counts_toward_circuit` — `httpx.ConnectError` is a wedge symptom too.

## Issue Link

- Closes: ORO-955

## Testing

### Manual Testing

Local pytest of new + existing backend_client tests.

**Test Results:**

```
$ uv run pytest subnet/tests/validator/test_backend_client.py
30 passed, 1 failed
```

The single pre-existing failure (`test_claim_work_with_resource_metrics`) is unrelated — it fails identically on `main` due to an SDK schema change for `cpu_pct`/`ram_pct` keys on `HeartbeatRequest`. Tracked separately.

All 6 new circuit-breaker tests pass.

### Automated Testing

CI runs the same suite plus lint + format.

**Test Command(s):**
```bash
uv run pytest subnet/tests/validator/test_backend_client.py
uv run ruff check subnet/validator/backend_client.py subnet/tests/validator/test_backend_client.py
uv run ruff format --check subnet/validator/backend_client.py subnet/tests/validator/test_backend_client.py
```

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**

`BackendClient` class docstring now describes the self-healing mechanism + when it fires.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

**Followups deliberately not in this PR** (filed in ORO-955 comment as belt-and-suspenders, none of them solve the wedge on their own):

- Lower `keepalive_expiry` 30s→10s in `oro-sdk SigningTransport` — narrower window for stale state to live in the pool.
- Set TCP keepalive socket options (`TCP_KEEPIDLE=60, TCP_KEEPINTVL=15, TCP_KEEPCNT=3`) on the httpx transport. Need to verify httpx enables `SO_KEEPALIVE` first.
- Per-request log line with connection age + reuse count for diagnostics.
- `/debug/httpx-pool` endpoint dumping pool state on demand.
- CloudWatch metric for circuit-breaker fires so we can detect the wedge in the wild before lease expiry.

This PR is the structural fix; those are diagnostics + defense in depth that should land separately.