### PR TITLE
fix(judge): blacklist judge model after unparseable response, no backoff

### DIFF
--- a/src/agent/reasoning_scorer.py
+++ b/src/agent/reasoning_scorer.py
@@ -614,10 +614,24 @@ def score_reasoning_quality(
     headers = {"Authorization": f"Bearer {api_key}"}
 
     models = _select_models_by_utilization()
+    # Models that returned an unparseable 200 in this eval. Skipped on
+    # subsequent rotation steps so a single broken model (e.g. Chutes
+    # serving empty `content` for one TEE variant while reporting healthy
+    # active_instance_count) doesn't burn the full retry budget.
+    bad_models: set[str] = set()
     model_idx = 0
     inference_failed = 0
     inference_total = 0
     for attempt in range(max_retries):
+        if len(bad_models) >= len(models):
+            logger.error(
+                f"All {len(models)} judge models returned unparseable responses "
+                f"this eval; aborting after {attempt} attempts"
+            )
+            break
+        # Skip blacklisted models without consuming a retry slot.
+        while models[model_idx % len(models)] in bad_models:
+            model_idx += 1
         model = models[model_idx % len(models)]
         inference_total += 1
 
@@ -654,15 +668,18 @@ def score_reasoning_quality(
                         "inference_failed": inference_failed,
                         "inference_total": inference_total,
                     }
-                # 200 OK with empty/unparseable body — transient judge failure,
-                # not score=0. Rotate and retry.
+                # 200 OK with empty/unparseable body — model is broken upstream
+                # (Chutes serving an unhealthy TEE instance). Blacklist it for
+                # this eval and rotate immediately, with no rate-limit backoff.
                 inference_failed += 1
+                bad_models.add(model)
                 logger.warning(
                     f"Judge response unparseable from {model} "
                     f"(attempt {attempt + 1}/{max_retries}); "
+                    f"blacklisting for this eval; "
                     f"content[:200]={content[:200]!r}"
                 )
-                model_idx = _rotate_and_backoff(model_idx, attempt)
+                model_idx += 1
                 continue
 
             inference_failed += 1

--- a/subnet/tests/test_reasoning_scorer.py
+++ b/subnet/tests/test_reasoning_scorer.py
@@ -271,6 +271,66 @@ class TestScoreReasoningQuality:
         assert result["inference_failed"] == 0
         assert result["inference_total"] == 1
 
+    @patch("reasoning_scorer.time.sleep")
+    @patch("reasoning_scorer.requests.post")
+    def test_blacklists_model_after_unparseable_response(self, mock_post, _mock_sleep):
+        """A model that returns an empty 200 must not be selected again in
+        the same eval — Chutes occasionally serves an unhealthy TEE
+        instance that returns empty content on every call, and burning the
+        full retry budget on it causes the eval to FAIL needlessly."""
+        mock_post.side_effect = [
+            MagicMock(status_code=200, json=lambda: {"choices": [{"message": {"content": ""}}]}),
+            MagicMock(
+                status_code=200,
+                json=lambda: {
+                    "choices": [{"message": {"content": '{"reasoning_quality": 0.7, "explanation": "ok"}'}}]
+                },
+            ),
+        ]
+        result = score_reasoning_quality(REASONING_AGENT, api_key="test-key")
+        assert result["score"] == 0.7
+        # The two POSTs must have hit different models — proves the
+        # first-attempt model was skipped on the second attempt.
+        first_model = mock_post.call_args_list[0].kwargs["json"]["model"]
+        second_model = mock_post.call_args_list[1].kwargs["json"]["model"]
+        assert first_model != second_model
+        assert result["model"] == second_model
+
+    @patch("reasoning_scorer.time.sleep")
+    @patch("reasoning_scorer.requests.post")
+    def test_aborts_when_all_models_blacklisted(self, mock_post, _mock_sleep):
+        """Once every model has returned an unparseable 200 in this eval,
+        the loop must exit immediately rather than spinning through the
+        remaining retry budget on already-broken models."""
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"choices": [{"message": {"content": ""}}]},
+        )
+        # max_retries far exceeds model count; expect attempts == len(JUDGE_MODELS).
+        result = score_reasoning_quality(REASONING_AGENT, api_key="test-key", max_retries=20)
+        assert result["score"] == 0.0
+        assert result["inference_total"] == len(JUDGE_MODELS)
+        assert result["inference_failed"] == len(JUDGE_MODELS)
+
+    @patch("reasoning_scorer.time.sleep")
+    @patch("reasoning_scorer.requests.post")
+    def test_no_backoff_sleep_on_unparseable_response(self, mock_post, mock_sleep):
+        """Empty-content responses are model-health failures, not rate
+        limits — rotate immediately with no exponential backoff. Backoff
+        on empty content compounds with the per-call timeout and pushes
+        evals past the 900s scoring window."""
+        mock_post.side_effect = [
+            MagicMock(status_code=200, json=lambda: {"choices": [{"message": {"content": ""}}]}),
+            MagicMock(
+                status_code=200,
+                json=lambda: {
+                    "choices": [{"message": {"content": '{"reasoning_quality": 0.6, "explanation": "ok"}'}}]
+                },
+            ),
+        ]
+        score_reasoning_quality(REASONING_AGENT, api_key="test-key")
+        mock_sleep.assert_not_called()
+
     def test_empty_dialogue_returns_zero(self):
         result = score_reasoning_quality([], api_key="test-key")
         assert result["score"] == 0.0


### PR DESCRIPTION
## Description

Stops the validator's reasoning judge from burning its full retry budget on a Chutes TEE instance that is serving HTTP 200 with empty `content` on every call.

Today's prod logs (single validator, 60 min window):

| Model | Empty-content responses |
|---|---|
| `moonshotai/Kimi-K2.5-TEE` | ~141 |
| `zai-org/GLM-5-TEE` | ~56 |
| `zai-org/GLM-5.1-TEE` | ~14 |
| `google/gemma-4-31B-turbo-TEE` | 0 |

Failure rate hit 56–63% per eval, which trips `Reasoning judge infrastructure failure` and flips the eval to retry on another validator. The broken instances still report a healthy `active_instance_count` in the Chutes utilization API, so `_select_models_by_utilization` keeps routing to them.

## Changes Made

- Track a per-eval `bad_models` set in `score_reasoning_quality`; once a model returns an unparseable 200 it is skipped for the rest of this eval and the loop aborts early when every model in the rotation is blacklisted, instead of spinning through the remaining retry budget on already-broken models.
- Drop the rate-limit exponential backoff on the unparseable-200 path. Empty content is a model-health failure, not a rate limit — sleeping before rotating just compounds with the per-call timeout and pushes evals past the 900s scoring window. 429/5xx responses still go through `_rotate_and_backoff` unchanged.

## Issue Link

- Related to: N/A (operational fix surfaced from prod logs 2026-04-30 / 2026-05-01 UTC)
- Closes: N/A

## Testing

### Manual Testing

Re-ran `pytest subnet/tests/test_reasoning_scorer.py -v` — all 44 tests pass, including the three new tests covering the blacklist + no-backoff behavior. Existing `test_returns_zero_when_all_retries_unparseable` continues to pass under the new abort-early path because the rotation cycles through every model before the abort condition is reached at `max_retries=3`.

**Test Results:**
44 passed in 2.45s.

### Automated Testing

New tests:
- `test_blacklists_model_after_unparseable_response` — first attempt empty, second attempt must use a different model and return its score.
- `test_aborts_when_all_models_blacklisted` — `max_retries=20` but only `len(JUDGE_MODELS)` attempts are made before abort.
- `test_no_backoff_sleep_on_unparseable_response` — `time.sleep` is never called on the unparseable-200 path.

**Test Command(s):**
```bash
pytest subnet/tests/test_reasoning_scorer.py -v
```


## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify): N/A

**Documentation Changes:**
Inline comments in `score_reasoning_quality` explain why empty-content responses are blacklisted per-eval and why the rate-limit backoff is skipped on this path.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

The Chutes team has been pinged separately about the empty-content responses on Kimi-K2.5-TEE / GLM-5-TEE / GLM-5.1-TEE. This PR is the validator-side defence so a single broken upstream instance doesn't cascade into eval failures across the network.