### PR TITLE
chore: bump validator image to force Watchtower restart

### DIFF
--- a/src/agent/reasoning_scorer.py
+++ b/src/agent/reasoning_scorer.py
@@ -595,7 +595,9 @@ def score_reasoning_quality(
     """Score reasoning quality of an agent trajectory using an LLM judge.
 
     Retries with model rotation on transient failures (429, 502-504).
-    Uses exponential backoff matching ProxyClient conventions.
+    Uses exponential backoff matching ProxyClient conventions on rate
+    limits; rotates without backoff and blacklists the model for the
+    rest of this eval when a 200 returns unparseable content.
     Stops immediately on auth failures (401, 403).
 
     Returns:


### PR DESCRIPTION
## Description

Several external operators' validators are currently wedged after intermittent Finney WS RPC failures crashed `setup_bittensor_objects` mid-eval and left the container in a bad state. Watchtower defers image pulls while an eval is active, so wedged validators never pull new images. Cutting a fresh tag and promoting it to `stable` forces every operator's Watchtower to recreate the container on its next poll. v1.0.66 (the judge fix that just shipped) is still the underlying code; this is purely a rebuild trigger.

## Changes Made

- Touch `score_reasoning_quality` docstring in `src/agent/reasoning_scorer.py` to document the blacklist behaviour added in v1.0.66 (the existing docstring still only mentioned rate-limit backoff).
-
-

## Issue Link

- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing
No code changes; nothing to test functionally. After merge + tag, verify:
1. `Publish Docker Images` workflow succeeds for `v1.0.67`.
2. `Promote Images to Stable` succeeds.
3. Wedged external validators recreate their containers within their Watchtower poll interval.

**Test Results:**
N/A

### Automated Testing
N/A

**Test Command(s):**
```bash
# n/a
```


## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify): N/A

**Documentation Changes:**
Updated the `score_reasoning_quality` docstring to mention the per-eval model blacklist behaviour.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

After merge, immediately tag `v1.0.67` on the merge commit and run `Promote Images to Stable` so external operators' Watchtowers pull within ~5 minutes.