### PR TITLE
fix: unblock local agent testing via docker compose run test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,18 +2,12 @@
 # Copy to .env and fill in required values:
 #   cp .env.example .env
 
-# === REQUIRED (while repo is private) ===
-
-# GitHub token with read:packages scope (required while repo is private)
-# Used for: docker login ghcr.io -u USERNAME --password-stdin
-# Create at: https://github.com/settings/tokens/new?scopes=read:packages
-GITHUB_TOKEN=
-
 # === MINER LOCAL TESTING ===
 
-# Chutes API key for LLM inference when testing agents locally
+# Chutes API key for LLM inference when testing agents locally.
 # Only needed for: docker compose run test --agent-file agent.py
-# Not needed for validators (miner tokens are forwarded automatically)
+# Not needed for validators (miner tokens are forwarded automatically).
+# Get one at: https://chutes.ai/
 CHUTES_API_KEY=
 
 # === OPTIONAL (defaults shown) ===

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     build:
       context: .
       dockerfile: docker/search-server/Dockerfile
-    container_name: shoppingbench-search-server
     environment:
       - HOST=${HOST:-0.0.0.0}
       - PORT=${PORT:-5632}
@@ -28,7 +27,6 @@ services:
     build:
       context: .
       dockerfile: docker/proxy/Dockerfile
-    container_name: shoppingbench-proxy
     environment:
       - SEARCH_SERVER_URL=${SEARCH_SERVER_URL:-search-server}
       - SEARCH_SERVER_PORT=${SEARCH_SERVER_PORT:-5632}
@@ -76,7 +74,6 @@ services:
     build:
       context: .
       dockerfile: docker/index-builder/Dockerfile
-    container_name: shoppingbench-index-builder
     volumes:
       - ./resources:/data/resources:ro
       - ./indexes:/data/indexes
@@ -139,7 +136,6 @@ services:
   # Footprint: ~150 MB RAM, <1% of one core idle.
   prometheus:
     image: prom/prometheus:v2.55.1
-    container_name: shoppingbench-prometheus
     profiles:
       - validator
     command:
@@ -158,7 +154,6 @@ services:
 
   proxy-exporter:
     image: nginx/nginx-prometheus-exporter:1.4.0
-    container_name: shoppingbench-proxy-exporter
     profiles:
       - validator
     command:
@@ -172,7 +167,6 @@ services:
 
   watchtower:
     image: containrrr/watchtower:latest
-    container_name: shoppingbench-watchtower
     profiles:
       - validator
     volumes:
@@ -213,7 +207,9 @@ services:
       - SANDBOX_IMAGE=${SANDBOX_IMAGE:-ghcr.io/oro-ai/oro/sandbox:${IMAGE_TAG:-stable}}
       - SANDBOX_NETWORK=sandbox-network
       - CHUTES_API_KEY=${CHUTES_API_KEY:-}
-    entrypoint: ["python", "-m", "subnet.test_runner"]
+    # Use the venv interpreter — bare `python` is the system Python and
+    # has no project dependencies installed (e.g. `requests`).
+    entrypoint: [".venv/bin/python", "-m", "subnet.test_runner"]
     networks:
       - main
     restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build:
       context: .
       dockerfile: docker/search-server/Dockerfile
+    container_name: shoppingbench-search-server
     environment:
       - HOST=${HOST:-0.0.0.0}
       - PORT=${PORT:-5632}
@@ -27,6 +28,7 @@ services:
     build:
       context: .
       dockerfile: docker/proxy/Dockerfile
+    container_name: shoppingbench-proxy
     environment:
       - SEARCH_SERVER_URL=${SEARCH_SERVER_URL:-search-server}
       - SEARCH_SERVER_PORT=${SEARCH_SERVER_PORT:-5632}
@@ -74,6 +76,7 @@ services:
     build:
       context: .
       dockerfile: docker/index-builder/Dockerfile
+    container_name: shoppingbench-index-builder
     volumes:
       - ./resources:/data/resources:ro
       - ./indexes:/data/indexes
@@ -136,6 +139,7 @@ services:
   # Footprint: ~150 MB RAM, <1% of one core idle.
   prometheus:
     image: prom/prometheus:v2.55.1
+    container_name: shoppingbench-prometheus
     profiles:
       - validator
     command:
@@ -154,6 +158,7 @@ services:
 
   proxy-exporter:
     image: nginx/nginx-prometheus-exporter:1.4.0
+    container_name: shoppingbench-proxy-exporter
     profiles:
       - validator
     command:
@@ -167,6 +172,7 @@ services:
 
   watchtower:
     image: containrrr/watchtower:latest
+    container_name: shoppingbench-watchtower
     profiles:
       - validator
     volumes:

--- a/subnet/test_runner.py
+++ b/subnet/test_runner.py
@@ -184,6 +184,15 @@ def run_test(
         Score (0.0 - 1.0), or -1.0 on failure.
     """
     agent_path = Path(agent_file)
+    # Resolve relative paths against the read-only /workspace mount used
+    # by `docker compose run test` so `--agent-file my_agent.py` works
+    # without forcing miners to think about container paths.
+    if not agent_path.is_absolute() and not agent_path.exists():
+        for prefix in [Path("/workspace"), Path("/app"), Path(".")]:
+            candidate = prefix / agent_file
+            if candidate.exists():
+                agent_path = candidate
+                break
     if not agent_path.exists():
         print(f"Error: Agent file not found: {agent_path}", file=sys.stderr)
         return -1.0
@@ -301,6 +310,19 @@ def main():
     )
 
     args = parser.parse_args()
+
+    # Fail fast on a missing/empty Chutes key — without one the agent's
+    # inference calls hit the proxy, get 429'd, and silently retry for
+    # ~3 minutes before the run aborts.
+    if not os.environ.get("CHUTES_API_KEY"):
+        print(
+            "Error: CHUTES_API_KEY is not set.\n"
+            "  Set it in your shell or copy .env.example to .env and fill it in.\n"
+            "  Get a key at https://chutes.ai/",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
     score = run_test(args.agent_file, args.problem_file, args.max_workers, args.timeout, args.skip_reasoning)
 
     if score < 0:


### PR DESCRIPTION
## Description

`docker compose run test --agent-file <file>` is the documented way for miners to test an agent locally before submitting. Three bugs in that path prevented it from working out of the box on a fresh clone, all surfaced this week by miners trying to follow the README and miner guide.

## Changes Made

- `docker-compose.yml`: switch the `test` service entrypoint from bare `python -m subnet.test_runner` to `.venv/bin/python -m subnet.test_runner`. The validator Dockerfile installs every project dependency into `/app/.venv/` via `uv sync --frozen`; the system Python has no project deps, so the previous entrypoint died on `ModuleNotFoundError: No module named 'requests'` before reaching the agent.
- `subnet/test_runner.py`: extend the existing `/workspace` fallback path (already used for `--problem-file`) to `--agent-file`. Bare-relative paths like `my_agent.py` now resolve against the read-only `/workspace` mount, matching the miner-guide example. Absolute paths still take precedence.
- `subnet/test_runner.py`: validate `CHUTES_API_KEY` at startup and exit with a clear message + key URL if it's missing or empty. Previously an empty key let the proxy launch the sandbox, hit 429s, and silently retry for ~3 minutes before aborting.
- `.env.example`: drop the "REQUIRED while repo is private" `GITHUB_TOKEN` block. All four images at `ghcr.io/oro-ai/oro/{validator,proxy,search-server,sandbox}:stable` pull anonymously today; the comment block was misleading.

## Issue Link

- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing

In a fresh clone with `IMAGE_TAG=stable` and an empty `.env`, ran:

```bash
docker compose run --rm test --agent-file my_agent.py --problem-file data/suites/problem_suite_v3.json
```

Before this change: containers start, then immediately die with `ModuleNotFoundError: No module named 'requests'` from `src/agent/problem_scorer.py`.

After this change with an empty `CHUTES_API_KEY`:

```
Error: CHUTES_API_KEY is not set.
  Set it in your shell or copy .env.example to .env and fill it in.
  Get a key at https://chutes.ai/
```

Exit code 2.

After this change with a real key, the test runner reaches the sandbox phase, the dependency error no longer appears, and the test_runner emits per-problem results (`[1/30] ...`) — verified against the locally rebuilt `validator` image and a real agent file.

**Test Results:**

- Build: `docker compose build test` succeeds (~40s incremental).
- Run with empty key: clear error, fast exit (no 429 retry storm).
- Run with valid key: pipeline reaches sandbox, per-problem results emit.
- Lint: `ruff check subnet/test_runner.py` — all checks passed.

### Automated Testing

No new automated tests added — the regressions are configuration / startup paths that are awkward to cover in unit tests. Existing test suite still passes.

**Test Command(s):**
```bash
ruff check subnet/test_runner.py
docker compose build test
docker compose run --rm test --agent-file my_agent.py --problem-file data/suites/problem_suite_v3.json
```

## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**

`.env.example` is updated. The miner guide already documents `--agent-file my_agent.py`; that example is now correct (it was previously broken by the working-dir mismatch). No miner-guide rewrite needed.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

The `validator` service still uses bare `python` because its entrypoint is set in the Dockerfile (`ENTRYPOINT [".venv/bin/python", "-m", "subnet.validator.main"]`) and never overridden by compose. Only the `test` service was overriding the entrypoint with the broken bare-`python` form.

An earlier commit on this branch removed the hardcoded `container_name:` lines from the compose services. That was reverted on review — operators may have name-based tooling that depends on those names, and the collision case it addressed only matters when running two clones on the same host.