### PR TITLE
revert: drop venv-vs-python sh fallback from test entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -213,20 +213,9 @@ services:
       - SANDBOX_IMAGE=${SANDBOX_IMAGE:-ghcr.io/oro-ai/oro/sandbox:${IMAGE_TAG:-stable}}
       - SANDBOX_NETWORK=sandbox-network
       - CHUTES_API_KEY=${CHUTES_API_KEY:-}
-    # Prefer the venv interpreter (current images install deps via uv into
-    # `/app/.venv/`), but fall back to bare `python` so older cached images
-    # — which installed deps system-wide and have no `.venv/` — still work
-    # without forcing miners to `docker compose pull` first.
-    entrypoint:
-      - "sh"
-      - "-c"
-      - |
-        if [ -x /app/.venv/bin/python ]; then
-          exec /app/.venv/bin/python -m subnet.test_runner "$@"
-        else
-          exec python -m subnet.test_runner "$@"
-        fi
-      - "--"
+    # Use the venv interpreter — bare `python` is the system Python and
+    # has no project dependencies installed (e.g. `requests`).
+    entrypoint: [".venv/bin/python", "-m", "subnet.test_runner"]
     networks:
       - main
     restart: "no"


### PR DESCRIPTION
## Description

#117 added a `sh -c` wrapper to the test service entrypoint that picked between `/app/.venv/bin/python` and bare `python` depending on which existed in the image. Intent: spare miners with stale cached `validator` images from re-pulling.

That's not the right tradeoff. `docker compose pull test` is the standard recovery path for an image-cache mismatch, and the wrapper hides what's actually wrong. Restore the simple, intentional `.venv/bin/python` entrypoint.

The envelope-format fix in `subnet/test_runner.py` (the other half of #117) stays — that one is a real shape mismatch between the current sandbox and the test runner, not a cache-staleness issue.

## Changes Made

- `docker-compose.yml`: revert the `test` service entrypoint to `[".venv/bin/python", "-m", "subnet.test_runner"]`. Drop the `sh -c` wrapper.

## Issue Link

- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing

`docker compose config test` confirms the entrypoint is back to the literal venv interpreter form. Smoke-tested `docker compose run --rm test --agent-file foo.py` against a freshly built image: container starts, runs `subnet.test_runner` via the venv, hits the `CHUTES_API_KEY` validation, exits cleanly.

**Test Results:**

- Build: `docker compose build test` succeeds.
- Lint: no Python changes to lint.

### Automated Testing

N/A — single-line revert.

**Test Command(s):**
```bash
docker compose config test
docker compose build test
docker compose run --rm test --agent-file foo.py
```

## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**

None.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

If miners on stale cached images hit `runc create failed: exec: ".venv/bin/python": stat .venv/bin/python: no such file or directory`, the recovery is one command:

```bash
docker compose pull test
```