### PR TITLE
fix(proxy): serve stale allowlist on Backend fetch failure

### DIFF
--- a/docker/proxy/validate_model.js
+++ b/docker/proxy/validate_model.js
@@ -3,14 +3,21 @@
 //
 // The allowlist is fetched from the ORO Backend (`GET /v1/public/inference/models`)
 // via the internal `/_backend_models` location. Each nginx worker caches the
-// fetched list for CACHE_TTL_MS. If the Backend is unreachable on cache miss,
-// we fail closed with 503 — a stale fallback would only paper over a deeper
-// outage (the validator is broken anyway when the Backend is down).
+// fetched list for CACHE_TTL_MS. After the cache expires we attempt a refresh;
+// if Backend returns a non-200 (rate-limited, unreachable, malformed), we keep
+// serving the previous allowlist for STALE_GRACE_MS instead of failing closed.
+// Failing closed turns a transient Backend hiccup (e.g. a 429 from the global
+// IP rate limit) into a 503 storm where every inference call is rejected and
+// agent evaluations collapse mid-run.
 
 var CACHE_TTL_MS = 15 * 60 * 1000;
+// Window beyond CACHE_TTL_MS where we still serve the cached list if a
+// refresh fails. After this we give up and fail closed.
+var STALE_GRACE_MS = 60 * 60 * 1000;
 
 var cachedList = null;
 var cacheExpiresAt = 0;
+var cacheStaleUntil = 0;
 
 function getAllowlist(r, callback) {
   if (cachedList && Date.now() < cacheExpiresAt) {
@@ -25,6 +32,7 @@ function getAllowlist(r, callback) {
         if (data && Array.isArray(data.models) && data.models.length > 0) {
           cachedList = data.models;
           cacheExpiresAt = Date.now() + CACHE_TTL_MS;
+          cacheStaleUntil = cacheExpiresAt + STALE_GRACE_MS;
           callback(cachedList);
           return;
         }
@@ -34,6 +42,17 @@ function getAllowlist(r, callback) {
     } else {
       r.error("Backend models fetch returned status " + reply.status);
     }
+
+    if (cachedList && Date.now() < cacheStaleUntil) {
+      r.error(
+        "Serving stale allowlist after fetch failure (" +
+          ((cacheStaleUntil - Date.now()) / 1000).toFixed(0) +
+          "s grace remaining)"
+      );
+      callback(cachedList);
+      return;
+    }
+
     callback(null);
   });
 }


### PR DESCRIPTION
## Description

The validator's inference proxy was failing closed (`503 Inference allowlist unavailable`) whenever a post-cache-expiry refresh of `/v1/public/inference/models` returned non-200. Today's prod incident showed this turning a transient Backend 429 (global per-IP rate limit, 100/min) into a 503 storm: every inference request out of the validator was rejected for several minutes, agent evaluations collapsed mid-run, and the validator's reasoning judge — which routes through the same proxy — timed out enough to flip evaluations to STALE / FAILED across multiple validators.

## Changes Made

- `docker/proxy/validate_model.js` keeps the previously-cached allowlist for `STALE_GRACE_MS` (1h) beyond the regular `CACHE_TTL_MS` expiry. If a refresh fails inside the grace window, the proxy serves the stale list and logs the remaining grace time. Outside the grace window we still fail closed, so a genuine prolonged Backend outage is still surfaced.
-
-

## Issue Link

- Related to: N/A (operational fix surfaced from prod logs 2026-05-01)
- Closes: N/A

## Testing

### Manual Testing
The change is in nginx-njs JavaScript with no test harness in this repo. Verified manually by reading the diff and tracing the cache state machine against today's incident logs.

**Test Results:**
- Cache fresh → callback with cachedList (unchanged)
- Cache expired + refresh 200 → callback with new list, expiry + grace bumped (unchanged)
- Cache expired + refresh 429/5xx + Date.now() < cacheStaleUntil → callback with stale cachedList, error logged (NEW)
- Cache expired + refresh 429/5xx + Date.now() >= cacheStaleUntil → callback null → 503 (unchanged for prolonged outage)
- No prior cache (cold start) + refresh fails → callback null → 503 (unchanged, can't serve what we never had)

### Automated Testing
N/A — no JS tests in this repo.

**Test Command(s):**
```bash
# n/a
```


## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify): N/A

**Documentation Changes:**
Updated the file header comment in `validate_model.js` to describe the stale-cache fallback policy and explain why it matters (the prod incident).

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

This is a defense-in-depth change — it does not address why the proxy hits the Backend rate limit in the first place. If the 429 cadence keeps happening even after this fix lands, follow up by either exempting `/v1/public/inference/models` from the global IP rate limiter in Backend or raising its per-endpoint limit.