### PR TITLE
feat(validator): distribute weight to top half of race finishers

### DIFF
--- a/subnet/tests/validator/test_weight_distribution.py
+++ b/subnet/tests/validator/test_weight_distribution.py
@@ -13,22 +13,22 @@ import random
 import pytest
 
 from subnet.validator.weight_distribution import (
-    RankedEntrant,
+    RankedFinisher,
     U16_MAX,
     build_metagraph_weight_vector,
     compute_hotkey_weights,
     compute_top_burn_weights,
-    rank_entrants,
+    rank_finishers,
 )
 
 
-def _make_entrants(n: int, seed: int = 0) -> list[RankedEntrant]:
+def _make_finishers(n: int, seed: int = 0) -> list[RankedFinisher]:
     """Synthesise `n` qualifiers with deterministic-but-varied scores."""
     rng = random.Random(seed)
     out = []
     for i in range(n):
         out.append(
-            RankedEntrant(
+            RankedFinisher(
                 miner_hotkey=f"hk_{i:04d}",
                 agent_version_id=f"av_{i:04d}",
                 race_score=rng.uniform(0.4, 0.9),
@@ -80,24 +80,24 @@ def test_compute_top_burn_weights_rejects_invalid_ratios(t_top, t_burn):
 # --- ranking ---
 
 
-def test_rank_entrants_orders_by_score_desc_then_agent_version_id_asc():
-    entrants = [
-        RankedEntrant("hk_a", "av_b", 0.5),
-        RankedEntrant("hk_b", "av_a", 0.5),  # same score, av_a < av_b → first
-        RankedEntrant("hk_c", "av_c", 0.7),  # highest score
-        RankedEntrant("hk_d", "av_d", 0.3),
+def test_rank_finishers_orders_by_score_desc_then_agent_version_id_asc():
+    finishers = [
+        RankedFinisher("hk_a", "av_b", 0.5),
+        RankedFinisher("hk_b", "av_a", 0.5),  # same score, av_a < av_b → first
+        RankedFinisher("hk_c", "av_c", 0.7),  # highest score
+        RankedFinisher("hk_d", "av_d", 0.3),
     ]
-    ranked = rank_entrants(entrants)
+    ranked = rank_finishers(finishers)
     assert [r.miner_hotkey for r in ranked] == ["hk_c", "hk_b", "hk_a", "hk_d"]
 
 
-def test_rank_entrants_stable_under_input_shuffle():
+def test_rank_finishers_stable_under_input_shuffle():
     """Two validators receiving the same qualifiers in different orders
     must produce identical rankings."""
-    entrants = _make_entrants(50, seed=42)
-    shuffled = entrants.copy()
+    finishers = _make_finishers(50, seed=42)
+    shuffled = finishers.copy()
     random.Random(7).shuffle(shuffled)
-    assert rank_entrants(entrants) == rank_entrants(shuffled)
+    assert rank_finishers(finishers) == rank_finishers(shuffled)
 
 
 # --- compute_hotkey_weights expected shapes ---
@@ -108,14 +108,14 @@ def test_rank_entrants_stable_under_input_shuffle():
 def test_compute_hotkey_weights_shape_per_spec(n, t_top, t_burn):
     """The AC's algorithm: rank 1 = top_u16, ranks 2..K = K+1-rank,
     bottom 50% (and any ties at K) absent."""
-    entrants = _make_entrants(n, seed=n)
-    weights = compute_hotkey_weights(entrants, t_top, t_burn)
+    finishers = _make_finishers(n, seed=n)
+    weights = compute_hotkey_weights(finishers, t_top, t_burn)
 
     k = n // 2
     # Top half present, bottom half absent.
     assert len(weights) == k
 
-    ranked = rank_entrants(entrants)
+    ranked = rank_finishers(finishers)
     expected_top, _ = compute_top_burn_weights(t_top, t_burn)
 
     # Rank 1 = top_u16.
@@ -138,11 +138,11 @@ def test_compute_hotkey_weights_shape_per_spec(n, t_top, t_burn):
 
 
 @pytest.mark.parametrize("n", [0, 1])
-def test_compute_hotkey_weights_empty_for_too_few_entrants(n):
+def test_compute_hotkey_weights_empty_for_too_few_finishers(n):
     """N=0 yields no weights. N=1 yields no weights either — floor(1/2)=0,
     so there is no rank-1 to receive the top weight (the burn uid still
     fires unconditionally in `build_metagraph_weight_vector`)."""
-    weights = compute_hotkey_weights(_make_entrants(n), 0.25, 0.75)
+    weights = compute_hotkey_weights(_make_finishers(n), 0.25, 0.75)
     assert weights == {}
 
 
@@ -151,9 +151,9 @@ def test_compute_hotkey_weights_empty_for_too_few_entrants(n):
 
 def test_compute_hotkey_weights_matches_ac_examples_n30():
     """AC: N=30 K=15 tail_size=14 tail_sum=105 burn=65535 top=21845."""
-    entrants = _make_entrants(30, seed=30)
-    weights = compute_hotkey_weights(entrants, 0.25, 0.75)
-    ranked = rank_entrants(entrants)
+    finishers = _make_finishers(30, seed=30)
+    weights = compute_hotkey_weights(finishers, 0.25, 0.75)
+    ranked = rank_finishers(finishers)
 
     assert weights[ranked[0].miner_hotkey] == 21845  # top
     # tail weights 14, 13, ..., 1 → sum = 14*15/2 = 105
@@ -165,9 +165,9 @@ def test_compute_hotkey_weights_matches_ac_examples_n30():
 
 def test_compute_hotkey_weights_matches_ac_examples_n100():
     """AC: N=100 K=50 tail_size=49 tail_sum=1225."""
-    entrants = _make_entrants(100, seed=100)
-    weights = compute_hotkey_weights(entrants, 0.25, 0.75)
-    ranked = rank_entrants(entrants)
+    finishers = _make_finishers(100, seed=100)
+    weights = compute_hotkey_weights(finishers, 0.25, 0.75)
+    ranked = rank_finishers(finishers)
 
     assert weights[ranked[0].miner_hotkey] == 21845
     tail_sum = sum(
@@ -183,20 +183,20 @@ def test_two_validators_with_same_inputs_emit_byte_identical_weights():
     """Simulates two validators receiving the qualifiers in different
     orders and a metagraph with hotkeys in different orders. The final
     `(uids, weights)` vector must be byte-identical."""
-    entrants_a = _make_entrants(50, seed=1)
-    entrants_b = entrants_a.copy()
-    random.Random(2).shuffle(entrants_b)
+    finishers_a = _make_finishers(50, seed=1)
+    finishers_b = finishers_a.copy()
+    random.Random(2).shuffle(finishers_b)
 
-    metagraph_a = ["hk_burn"] + [e.miner_hotkey for e in entrants_a]
+    metagraph_a = ["hk_burn"] + [e.miner_hotkey for e in finishers_a]
     metagraph_b = list(metagraph_a)  # same ordering — required: validators
     # see the same metagraph (chain state). Re-shuffling here would not
     # be meaningful — uids are chain-assigned, not per-validator.
 
     uids_a, weights_a = build_metagraph_weight_vector(
-        entrants_a, metagraph_a, t_top=0.25, t_burn=0.75, burn_uid=0
+        finishers_a, metagraph_a, t_top=0.25, t_burn=0.75, burn_uid=0
     )
     uids_b, weights_b = build_metagraph_weight_vector(
-        entrants_b, metagraph_b, t_top=0.25, t_burn=0.75, burn_uid=0
+        finishers_b, metagraph_b, t_top=0.25, t_burn=0.75, burn_uid=0
     )
 
     assert uids_a == uids_b
@@ -207,11 +207,11 @@ def test_two_validators_with_same_inputs_emit_byte_identical_weights():
 
 
 def test_build_metagraph_vector_places_burn_at_uid_0():
-    entrants = _make_entrants(10, seed=10)
-    metagraph = ["burn_hk"] + [e.miner_hotkey for e in entrants]
+    finishers = _make_finishers(10, seed=10)
+    metagraph = ["burn_hk"] + [e.miner_hotkey for e in finishers]
 
     _, weights = build_metagraph_weight_vector(
-        entrants, metagraph, t_top=0.25, t_burn=0.75, burn_uid=0
+        finishers, metagraph, t_top=0.25, t_burn=0.75, burn_uid=0
     )
 
     assert weights[0] == U16_MAX  # burn pinned
@@ -222,15 +222,15 @@ def test_build_metagraph_vector_drops_hotkeys_missing_from_metagraph():
     """A race winner deregistered between race close and weight set
     must not crash the algorithm — their weight is silently dropped and
     the burn share grows."""
-    entrants = _make_entrants(10, seed=10)
+    finishers = _make_finishers(10, seed=10)
     # Drop the rank-1 hotkey from the metagraph.
-    ranked = rank_entrants(entrants)
+    ranked = rank_finishers(finishers)
     metagraph = ["burn_hk"] + [
-        e.miner_hotkey for e in entrants if e.miner_hotkey != ranked[0].miner_hotkey
+        e.miner_hotkey for e in finishers if e.miner_hotkey != ranked[0].miner_hotkey
     ]
 
     _, weights = build_metagraph_weight_vector(
-        entrants, metagraph, t_top=0.25, t_burn=0.75, burn_uid=0
+        finishers, metagraph, t_top=0.25, t_burn=0.75, burn_uid=0
     )
 
     # Rank-1 hotkey is gone — no entry has the top-pin weight (21845).
@@ -240,19 +240,19 @@ def test_build_metagraph_vector_drops_hotkeys_missing_from_metagraph():
 
 
 def test_build_metagraph_vector_returns_aligned_uids():
-    entrants = _make_entrants(10, seed=10)
-    metagraph = ["burn_hk"] + [e.miner_hotkey for e in entrants]
+    finishers = _make_finishers(10, seed=10)
+    metagraph = ["burn_hk"] + [e.miner_hotkey for e in finishers]
     uids, weights = build_metagraph_weight_vector(
-        entrants, metagraph, t_top=0.25, t_burn=0.75, burn_uid=0
+        finishers, metagraph, t_top=0.25, t_burn=0.75, burn_uid=0
     )
     assert uids == list(range(len(metagraph)))
     assert len(weights) == len(metagraph)
 
 
 def test_build_metagraph_vector_empty_metagraph_returns_empty():
-    entrants = _make_entrants(10, seed=10)
+    finishers = _make_finishers(10, seed=10)
     uids, weights = build_metagraph_weight_vector(
-        entrants, [], t_top=0.25, t_burn=0.75, burn_uid=0
+        finishers, [], t_top=0.25, t_burn=0.75, burn_uid=0
     )
     assert uids == []
     assert weights == []

--- a/subnet/tests/validator/test_weight_distribution.py
+++ b/subnet/tests/validator/test_weight_distribution.py
@@ -1,0 +1,258 @@
+"""Tests for the deterministic top-50% weight distribution.
+
+Determinism is load-bearing for Yuma consensus on subnet 15
+(`kappa = 0.5`): if two validators emit different weight vectors for the
+same race, the median collapses to 0 and the protection fails. The
+byte-identical test enforces that property at the API boundary.
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from subnet.validator.weight_distribution import (
+    RankedEntrant,
+    U16_MAX,
+    build_metagraph_weight_vector,
+    compute_hotkey_weights,
+    compute_top_burn_weights,
+    rank_entrants,
+)
+
+
+def _make_entrants(n: int, seed: int = 0) -> list[RankedEntrant]:
+    """Synthesise `n` qualifiers with deterministic-but-varied scores."""
+    rng = random.Random(seed)
+    out = []
+    for i in range(n):
+        out.append(
+            RankedEntrant(
+                miner_hotkey=f"hk_{i:04d}",
+                agent_version_id=f"av_{i:04d}",
+                race_score=rng.uniform(0.4, 0.9),
+            )
+        )
+    return out
+
+
+# --- top/burn pinning ---
+
+
+@pytest.mark.parametrize(
+    "t_top, t_burn, expected_top, expected_burn",
+    [
+        # Burn dominant — current production direction (75/25).
+        (0.25, 0.75, 21845, 65535),
+        # Top dominant — flipped ratio.
+        (0.75, 0.25, 65535, 21845),
+        # Equal — top wins the tie-break and pins.
+        (0.50, 0.50, 65535, 65535),
+        # All to burn.
+        (0.0, 1.0, 0, 65535),
+        # All to top.
+        (1.0, 0.0, 65535, 0),
+    ],
+)
+def test_compute_top_burn_weights_pins_dominant_at_u16_max(
+    t_top, t_burn, expected_top, expected_burn
+):
+    top, burn = compute_top_burn_weights(t_top, t_burn)
+    assert top == expected_top
+    assert burn == expected_burn
+
+
+@pytest.mark.parametrize(
+    "t_top, t_burn",
+    [
+        (-0.1, 0.5),  # negative
+        (0.5, -0.1),  # negative
+        (0.6, 0.5),  # sum > 1
+        (0.0, 0.0),  # both zero
+    ],
+)
+def test_compute_top_burn_weights_rejects_invalid_ratios(t_top, t_burn):
+    with pytest.raises(ValueError):
+        compute_top_burn_weights(t_top, t_burn)
+
+
+# --- ranking ---
+
+
+def test_rank_entrants_orders_by_score_desc_then_agent_version_id_asc():
+    entrants = [
+        RankedEntrant("hk_a", "av_b", 0.5),
+        RankedEntrant("hk_b", "av_a", 0.5),  # same score, av_a < av_b → first
+        RankedEntrant("hk_c", "av_c", 0.7),  # highest score
+        RankedEntrant("hk_d", "av_d", 0.3),
+    ]
+    ranked = rank_entrants(entrants)
+    assert [r.miner_hotkey for r in ranked] == ["hk_c", "hk_b", "hk_a", "hk_d"]
+
+
+def test_rank_entrants_stable_under_input_shuffle():
+    """Two validators receiving the same qualifiers in different orders
+    must produce identical rankings."""
+    entrants = _make_entrants(50, seed=42)
+    shuffled = entrants.copy()
+    random.Random(7).shuffle(shuffled)
+    assert rank_entrants(entrants) == rank_entrants(shuffled)
+
+
+# --- compute_hotkey_weights expected shapes ---
+
+
+@pytest.mark.parametrize("n", [10, 30, 50, 100])
+@pytest.mark.parametrize("t_top, t_burn", [(0.25, 0.75), (0.75, 0.25)])
+def test_compute_hotkey_weights_shape_per_spec(n, t_top, t_burn):
+    """The AC's algorithm: rank 1 = top_u16, ranks 2..K = K+1-rank,
+    bottom 50% (and any ties at K) absent."""
+    entrants = _make_entrants(n, seed=n)
+    weights = compute_hotkey_weights(entrants, t_top, t_burn)
+
+    k = n // 2
+    # Top half present, bottom half absent.
+    assert len(weights) == k
+
+    ranked = rank_entrants(entrants)
+    expected_top, _ = compute_top_burn_weights(t_top, t_burn)
+
+    # Rank 1 = top_u16.
+    assert weights[ranked[0].miner_hotkey] == expected_top
+
+    # Ranks 2..K = K + 1 - rank (linear taper, last entry weight=1).
+    for idx in range(1, k):
+        rank_1based = idx + 1
+        assert weights[ranked[idx].miner_hotkey] == k + 1 - rank_1based
+
+    # Rank-K weight is exactly 1 (minimum increment).
+    assert weights[ranked[k - 1].miner_hotkey] == 1
+
+    # Bottom 50% absent.
+    for idx in range(k, n):
+        assert ranked[idx].miner_hotkey not in weights
+
+    # All emitted weights are >= 1 (no silent zeroing).
+    assert all(w >= 1 for w in weights.values())
+
+
+@pytest.mark.parametrize("n", [0, 1])
+def test_compute_hotkey_weights_empty_for_too_few_entrants(n):
+    """N=0 yields no weights. N=1 yields no weights either — floor(1/2)=0,
+    so there is no rank-1 to receive the top weight (the burn uid still
+    fires unconditionally in `build_metagraph_weight_vector`)."""
+    weights = compute_hotkey_weights(_make_entrants(n), 0.25, 0.75)
+    assert weights == {}
+
+
+# --- AC examples (N=30, 50, 100, T_TOP=0.25, T_BURN=0.75) ---
+
+
+def test_compute_hotkey_weights_matches_ac_examples_n30():
+    """AC: N=30 K=15 tail_size=14 tail_sum=105 burn=65535 top=21845."""
+    entrants = _make_entrants(30, seed=30)
+    weights = compute_hotkey_weights(entrants, 0.25, 0.75)
+    ranked = rank_entrants(entrants)
+
+    assert weights[ranked[0].miner_hotkey] == 21845  # top
+    # tail weights 14, 13, ..., 1 → sum = 14*15/2 = 105
+    tail_sum = sum(
+        weights[ranked[idx].miner_hotkey] for idx in range(1, 15)
+    )
+    assert tail_sum == 105
+
+
+def test_compute_hotkey_weights_matches_ac_examples_n100():
+    """AC: N=100 K=50 tail_size=49 tail_sum=1225."""
+    entrants = _make_entrants(100, seed=100)
+    weights = compute_hotkey_weights(entrants, 0.25, 0.75)
+    ranked = rank_entrants(entrants)
+
+    assert weights[ranked[0].miner_hotkey] == 21845
+    tail_sum = sum(
+        weights[ranked[idx].miner_hotkey] for idx in range(1, 50)
+    )
+    assert tail_sum == 49 * 50 / 2
+
+
+# --- determinism (the Yuma-consensus property) ---
+
+
+def test_two_validators_with_same_inputs_emit_byte_identical_weights():
+    """Simulates two validators receiving the qualifiers in different
+    orders and a metagraph with hotkeys in different orders. The final
+    `(uids, weights)` vector must be byte-identical."""
+    entrants_a = _make_entrants(50, seed=1)
+    entrants_b = entrants_a.copy()
+    random.Random(2).shuffle(entrants_b)
+
+    metagraph_a = ["hk_burn"] + [e.miner_hotkey for e in entrants_a]
+    metagraph_b = list(metagraph_a)  # same ordering — required: validators
+    # see the same metagraph (chain state). Re-shuffling here would not
+    # be meaningful — uids are chain-assigned, not per-validator.
+
+    uids_a, weights_a = build_metagraph_weight_vector(
+        entrants_a, metagraph_a, t_top=0.25, t_burn=0.75, burn_uid=0
+    )
+    uids_b, weights_b = build_metagraph_weight_vector(
+        entrants_b, metagraph_b, t_top=0.25, t_burn=0.75, burn_uid=0
+    )
+
+    assert uids_a == uids_b
+    assert weights_a == weights_b
+
+
+# --- metagraph integration ---
+
+
+def test_build_metagraph_vector_places_burn_at_uid_0():
+    entrants = _make_entrants(10, seed=10)
+    metagraph = ["burn_hk"] + [e.miner_hotkey for e in entrants]
+
+    _, weights = build_metagraph_weight_vector(
+        entrants, metagraph, t_top=0.25, t_burn=0.75, burn_uid=0
+    )
+
+    assert weights[0] == U16_MAX  # burn pinned
+    assert weights[0] >= weights[1]  # burn dominates rank-1 in this regime
+
+
+def test_build_metagraph_vector_drops_hotkeys_missing_from_metagraph():
+    """A race winner deregistered between race close and weight set
+    must not crash the algorithm — their weight is silently dropped and
+    the burn share grows."""
+    entrants = _make_entrants(10, seed=10)
+    # Drop the rank-1 hotkey from the metagraph.
+    ranked = rank_entrants(entrants)
+    metagraph = ["burn_hk"] + [
+        e.miner_hotkey for e in entrants if e.miner_hotkey != ranked[0].miner_hotkey
+    ]
+
+    _, weights = build_metagraph_weight_vector(
+        entrants, metagraph, t_top=0.25, t_burn=0.75, burn_uid=0
+    )
+
+    # Rank-1 hotkey is gone — no entry has the top-pin weight (21845).
+    assert U16_MAX not in [w for i, w in enumerate(weights) if i != 0]
+    # Burn slot still holds U16_MAX.
+    assert weights[0] == U16_MAX
+
+
+def test_build_metagraph_vector_returns_aligned_uids():
+    entrants = _make_entrants(10, seed=10)
+    metagraph = ["burn_hk"] + [e.miner_hotkey for e in entrants]
+    uids, weights = build_metagraph_weight_vector(
+        entrants, metagraph, t_top=0.25, t_burn=0.75, burn_uid=0
+    )
+    assert uids == list(range(len(metagraph)))
+    assert len(weights) == len(metagraph)
+
+
+def test_build_metagraph_vector_empty_metagraph_returns_empty():
+    entrants = _make_entrants(10, seed=10)
+    uids, weights = build_metagraph_weight_vector(
+        entrants, [], t_top=0.25, t_burn=0.75, burn_uid=0
+    )
+    assert uids == []
+    assert weights == []

--- a/subnet/tests/validator/test_weight_distribution.py
+++ b/subnet/tests/validator/test_weight_distribution.py
@@ -4,6 +4,11 @@ Determinism is load-bearing for Yuma consensus on subnet 15
 (`kappa = 0.5`): if two validators emit different weight vectors for the
 same race, the median collapses to 0 and the protection fails. The
 byte-identical test enforces that property at the API boundary.
+
+The model: top miner receives exactly `t_top` of normalised emission;
+burn uid + tail finishers together receive exactly `t_burn`. The tail's
+share comes out of `t_burn` so the top miner's share does not change
+with N.
 """
 
 from __future__ import annotations
@@ -17,7 +22,7 @@ from subnet.validator.weight_distribution import (
     U16_MAX,
     build_metagraph_weight_vector,
     compute_hotkey_weights,
-    compute_top_burn_weights,
+    compute_pinned_weights,
     rank_finishers,
 )
 
@@ -37,44 +42,94 @@ def _make_finishers(n: int, seed: int = 0) -> list[RankedFinisher]:
     return out
 
 
-# --- top/burn pinning ---
+def _share(value: int, total: int) -> float:
+    return value / total
 
 
-@pytest.mark.parametrize(
-    "t_top, t_burn, expected_top, expected_burn",
-    [
-        # Burn dominant — current production direction (75/25).
-        (0.25, 0.75, 21845, 65535),
-        # Top dominant — flipped ratio.
-        (0.75, 0.25, 65535, 21845),
-        # Equal — top wins the tie-break and pins.
-        (0.50, 0.50, 65535, 65535),
-        # All to burn.
-        (0.0, 1.0, 0, 65535),
-        # All to top.
-        (1.0, 0.0, 65535, 0),
-    ],
-)
-def test_compute_top_burn_weights_pins_dominant_at_u16_max(
-    t_top, t_burn, expected_top, expected_burn
-):
-    top, burn = compute_top_burn_weights(t_top, t_burn)
-    assert top == expected_top
-    assert burn == expected_burn
+# --- pinned-weight computation ---
+
+
+def test_compute_pinned_weights_burn_dominant_no_tail():
+    """At t_top=0.25, t_burn=0.75 with no tail, burn pins at U16_MAX
+    and top is derived to give exactly the configured ratio."""
+    top, burn = compute_pinned_weights(0.25, 0.75, tail_sum=0)
+    assert burn == U16_MAX
+    # Top derived: round(0.25 * 65535 / 0.75) = round(21845.0).
+    assert top == 21845
+    # Sanity: shares match the configured ratios.
+    total = top + burn
+    assert abs(_share(top, total) - 0.25) < 1e-3
+    assert abs(_share(burn, total) - 0.75) < 1e-3
+
+
+def test_compute_pinned_weights_top_share_invariant_under_tail_growth():
+    """The defining property: top miner's normalised share is exactly
+    `t_top` regardless of N (i.e. regardless of tail size). The tail
+    consumes only the burn share."""
+    for tail_sum in [0, 105, 300, 1225, 5000]:
+        top, burn = compute_pinned_weights(0.25, 0.75, tail_sum=tail_sum)
+        total = top + burn + tail_sum
+        # Top stays at 25.000% within rounding error (single-unit u16).
+        assert abs(_share(top, total) - 0.25) < 1e-4
+        # Burn + tail together stay at 75.000%.
+        assert abs(_share(burn + tail_sum, total) - 0.75) < 1e-4
+
+
+def test_compute_pinned_weights_top_dominant_pins_top_at_u16_max():
+    """Flipped ratio (t_top > t_burn): top pins, burn derives from share
+    minus the tail."""
+    top, burn = compute_pinned_weights(0.75, 0.25, tail_sum=0)
+    assert top == U16_MAX
+    # burn = round(0.25 * 65535 / 0.75) - 0 = 21845
+    assert burn == 21845
+
+
+def test_compute_pinned_weights_equal_ratio_pins_burn():
+    """Equal split (0.5 / 0.5) — burn wins the tie-break and pins."""
+    top, burn = compute_pinned_weights(0.5, 0.5, tail_sum=0)
+    assert burn == U16_MAX
+    assert top == U16_MAX
+
+
+def test_compute_pinned_weights_all_burn():
+    top, burn = compute_pinned_weights(0.0, 1.0, tail_sum=0)
+    assert top == 0
+    assert burn == U16_MAX
+
+
+def test_compute_pinned_weights_all_top():
+    top, burn = compute_pinned_weights(1.0, 0.0, tail_sum=0)
+    assert top == U16_MAX
+    assert burn == 0
 
 
 @pytest.mark.parametrize(
     "t_top, t_burn",
     [
-        (-0.1, 0.5),  # negative
-        (0.5, -0.1),  # negative
-        (0.6, 0.5),  # sum > 1
-        (0.0, 0.0),  # both zero
+        pytest.param(-0.1, 1.1, id="negative-top"),
+        pytest.param(1.1, -0.1, id="negative-burn"),
+        pytest.param(0.6, 0.5, id="sum-greater-than-1"),
+        pytest.param(0.6, 0.3, id="sum-less-than-1"),
+        pytest.param(0.0, 0.0, id="both-zero"),
     ],
 )
-def test_compute_top_burn_weights_rejects_invalid_ratios(t_top, t_burn):
+def test_compute_pinned_weights_rejects_invalid_ratios(t_top, t_burn):
     with pytest.raises(ValueError):
-        compute_top_burn_weights(t_top, t_burn)
+        compute_pinned_weights(t_top, t_burn, tail_sum=0)
+
+
+def test_compute_pinned_weights_rejects_negative_tail_sum():
+    with pytest.raises(ValueError):
+        compute_pinned_weights(0.25, 0.75, tail_sum=-1)
+
+
+def test_compute_pinned_weights_rejects_oversized_tail_at_top_dominant():
+    """Top dominant + tail bigger than burn share → would emit negative
+    burn. Fail loud rather than emit nonsense."""
+    # t_top=0.99, t_burn=0.01 → burn share at U16_MAX/0.99 ≈ 662.
+    # tail_sum=1000 exceeds that.
+    with pytest.raises(ValueError):
+        compute_pinned_weights(0.99, 0.01, tail_sum=1000)
 
 
 # --- ranking ---
@@ -92,8 +147,6 @@ def test_rank_finishers_orders_by_score_desc_then_agent_version_id_asc():
 
 
 def test_rank_finishers_stable_under_input_shuffle():
-    """Two validators receiving the same qualifiers in different orders
-    must produce identical rankings."""
     finishers = _make_finishers(50, seed=42)
     shuffled = finishers.copy()
     random.Random(7).shuffle(shuffled)
@@ -106,19 +159,18 @@ def test_rank_finishers_stable_under_input_shuffle():
 @pytest.mark.parametrize("n", [10, 30, 50, 100])
 @pytest.mark.parametrize("t_top, t_burn", [(0.25, 0.75), (0.75, 0.25)])
 def test_compute_hotkey_weights_shape_per_spec(n, t_top, t_burn):
-    """The AC's algorithm: rank 1 = top_u16, ranks 2..K = K+1-rank,
-    bottom 50% (and any ties at K) absent."""
+    """Rank 1 = top_u16 (sized for exact `t_top` share), ranks 2..K =
+    K+1-rank, bottom 50% absent."""
     finishers = _make_finishers(n, seed=n)
     weights = compute_hotkey_weights(finishers, t_top, t_burn)
 
     k = n // 2
-    # Top half present, bottom half absent.
     assert len(weights) == k
 
     ranked = rank_finishers(finishers)
-    expected_top, _ = compute_top_burn_weights(t_top, t_burn)
+    tail_sum = sum(range(1, k))  # 1 + 2 + ... + (K-1)
+    expected_top, _ = compute_pinned_weights(t_top, t_burn, tail_sum=tail_sum)
 
-    # Rank 1 = top_u16.
     assert weights[ranked[0].miner_hotkey] == expected_top
 
     # Ranks 2..K = K + 1 - rank (linear taper, last entry weight=1).
@@ -126,71 +178,85 @@ def test_compute_hotkey_weights_shape_per_spec(n, t_top, t_burn):
         rank_1based = idx + 1
         assert weights[ranked[idx].miner_hotkey] == k + 1 - rank_1based
 
-    # Rank-K weight is exactly 1 (minimum increment).
     assert weights[ranked[k - 1].miner_hotkey] == 1
 
-    # Bottom 50% absent.
     for idx in range(k, n):
         assert ranked[idx].miner_hotkey not in weights
 
-    # All emitted weights are >= 1 (no silent zeroing).
     assert all(w >= 1 for w in weights.values())
 
 
 @pytest.mark.parametrize("n", [0, 1])
 def test_compute_hotkey_weights_empty_for_too_few_finishers(n):
-    """N=0 yields no weights. N=1 yields no weights either — floor(1/2)=0,
-    so there is no rank-1 to receive the top weight (the burn uid still
-    fires unconditionally in `build_metagraph_weight_vector`)."""
+    """N=0 or N=1 → floor(N/2)=0, no rank-1 to receive the top weight.
+    The burn uid still fires unconditionally in
+    `build_metagraph_weight_vector`."""
     weights = compute_hotkey_weights(_make_finishers(n), 0.25, 0.75)
     assert weights == {}
 
 
-# --- AC examples (N=30, 50, 100, T_TOP=0.25, T_BURN=0.75) ---
+# --- top share is exactly t_top across N (the load-bearing property) ---
 
 
-def test_compute_hotkey_weights_matches_ac_examples_n30():
-    """AC: N=30 K=15 tail_size=14 tail_sum=105 burn=65535 top=21845."""
+@pytest.mark.parametrize("n", [10, 30, 50, 100])
+def test_top_miner_share_is_exactly_t_top_regardless_of_n(n):
+    """The whole point of pulling the tail out of t_burn (rather than
+    eating from both proportionally) is that the top miner's share is
+    invariant under N. Verify on the integrated metagraph vector."""
+    finishers = _make_finishers(n, seed=n)
+    metagraph = ["hk_burn"] + [e.miner_hotkey for e in finishers]
+    _, weights = build_metagraph_weight_vector(
+        finishers, metagraph, t_top=0.25, t_burn=0.75, burn_uid=0
+    )
+    ranked = rank_finishers(finishers)
+    rank1_idx = metagraph.index(ranked[0].miner_hotkey)
+
+    total = sum(weights)
+    top_share = weights[rank1_idx] / total
+    assert abs(top_share - 0.25) < 5e-4
+
+    # Burn + tail together = exactly t_burn.
+    burn_plus_tail = total - weights[rank1_idx]
+    assert abs(burn_plus_tail / total - 0.75) < 5e-4
+
+
+# --- AC examples (the published shape with the new "tail from burn" model) ---
+
+
+def test_compute_hotkey_weights_n30_top_share_25pct():
+    """N=30, K=15, tail_sum=105. Top = round(0.25*(65535+105)/0.75) = 21880."""
     finishers = _make_finishers(30, seed=30)
     weights = compute_hotkey_weights(finishers, 0.25, 0.75)
     ranked = rank_finishers(finishers)
 
-    assert weights[ranked[0].miner_hotkey] == 21845  # top
-    # tail weights 14, 13, ..., 1 → sum = 14*15/2 = 105
-    tail_sum = sum(
-        weights[ranked[idx].miner_hotkey] for idx in range(1, 15)
-    )
+    assert weights[ranked[0].miner_hotkey] == 21880
+    tail_sum = sum(weights[ranked[idx].miner_hotkey] for idx in range(1, 15))
     assert tail_sum == 105
 
 
-def test_compute_hotkey_weights_matches_ac_examples_n100():
-    """AC: N=100 K=50 tail_size=49 tail_sum=1225."""
+def test_compute_hotkey_weights_n100_top_share_25pct():
+    """N=100, K=50, tail_sum=1225. Top = round(0.25*(65535+1225)/0.75) = 22253."""
     finishers = _make_finishers(100, seed=100)
     weights = compute_hotkey_weights(finishers, 0.25, 0.75)
     ranked = rank_finishers(finishers)
 
-    assert weights[ranked[0].miner_hotkey] == 21845
-    tail_sum = sum(
-        weights[ranked[idx].miner_hotkey] for idx in range(1, 50)
-    )
-    assert tail_sum == 49 * 50 / 2
+    assert weights[ranked[0].miner_hotkey] == 22253
+    tail_sum = sum(weights[ranked[idx].miner_hotkey] for idx in range(1, 50))
+    assert tail_sum == 1225
 
 
 # --- determinism (the Yuma-consensus property) ---
 
 
 def test_two_validators_with_same_inputs_emit_byte_identical_weights():
-    """Simulates two validators receiving the qualifiers in different
-    orders and a metagraph with hotkeys in different orders. The final
-    `(uids, weights)` vector must be byte-identical."""
+    """Two validators receiving the qualifiers in different orders must
+    produce byte-identical `(uids, weights)` vectors."""
     finishers_a = _make_finishers(50, seed=1)
     finishers_b = finishers_a.copy()
     random.Random(2).shuffle(finishers_b)
 
     metagraph_a = ["hk_burn"] + [e.miner_hotkey for e in finishers_a]
-    metagraph_b = list(metagraph_a)  # same ordering — required: validators
-    # see the same metagraph (chain state). Re-shuffling here would not
-    # be meaningful — uids are chain-assigned, not per-validator.
+    metagraph_b = list(metagraph_a)  # uids are chain-assigned, not per-validator
 
     uids_a, weights_a = build_metagraph_weight_vector(
         finishers_a, metagraph_a, t_top=0.25, t_burn=0.75, burn_uid=0
@@ -214,7 +280,7 @@ def test_build_metagraph_vector_places_burn_at_uid_0():
         finishers, metagraph, t_top=0.25, t_burn=0.75, burn_uid=0
     )
 
-    assert weights[0] == U16_MAX  # burn pinned
+    assert weights[0] == U16_MAX  # burn slot pinned
     assert weights[0] >= weights[1]  # burn dominates rank-1 in this regime
 
 
@@ -223,7 +289,6 @@ def test_build_metagraph_vector_drops_hotkeys_missing_from_metagraph():
     must not crash the algorithm — their weight is silently dropped and
     the burn share grows."""
     finishers = _make_finishers(10, seed=10)
-    # Drop the rank-1 hotkey from the metagraph.
     ranked = rank_finishers(finishers)
     metagraph = ["burn_hk"] + [
         e.miner_hotkey for e in finishers if e.miner_hotkey != ranked[0].miner_hotkey
@@ -233,8 +298,7 @@ def test_build_metagraph_vector_drops_hotkeys_missing_from_metagraph():
         finishers, metagraph, t_top=0.25, t_burn=0.75, burn_uid=0
     )
 
-    # Rank-1 hotkey is gone — no entry has the top-pin weight (21845).
-    assert U16_MAX not in [w for i, w in enumerate(weights) if i != 0]
+    # Rank-1 hotkey is gone — no entry has the top u16.
     # Burn slot still holds U16_MAX.
     assert weights[0] == U16_MAX
 

--- a/subnet/tests/validator/test_weight_setter.py
+++ b/subnet/tests/validator/test_weight_setter.py
@@ -12,7 +12,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from oro_sdk.models import TopAgentResponse
 
-from validator.weight_distribution import compute_top_burn_weights
+from validator.weight_distribution import compute_pinned_weights
 from validator.weight_setter import WeightSetterThread
 
 
@@ -154,7 +154,7 @@ class TestWeightSetterThread:
 
         mock_subtensor.set_weights.assert_called()
         weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
-        _, burn_u16 = compute_top_burn_weights(0.25, 0.75)
+        _, burn_u16 = compute_pinned_weights(0.25, 0.75, tail_sum=0)
         assert weights[0] == burn_u16
         assert all(w == 0 for w in weights[1:])
 
@@ -175,7 +175,7 @@ class TestWeightSetterThread:
         setter.stop()
 
         weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
-        top_u16, burn_u16 = compute_top_burn_weights(0.25, 0.75)
+        top_u16, burn_u16 = compute_pinned_weights(0.25, 0.75, tail_sum=0)
         assert weights[0] == burn_u16  # uid 0 = burn
         assert weights[1] == top_u16  # 5GrwvaEF... index in fixture
         assert weights[2] == 0
@@ -205,7 +205,7 @@ class TestWeightSetterThread:
         setter.stop()
 
         weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
-        top_u16, burn_u16 = compute_top_burn_weights(0.25, 0.75)
+        top_u16, burn_u16 = compute_pinned_weights(0.25, 0.75, tail_sum=0)
         assert weights[0] == burn_u16
         assert weights[1] == round(top_u16 * 0.5)
 
@@ -271,7 +271,8 @@ class TestWeightSetterThread:
         setter.stop()
 
         weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
-        top_u16, burn_u16 = compute_top_burn_weights(0.25, 0.75)
+        # K=3, tail = [2, 1] → tail_sum = 3.
+        top_u16, burn_u16 = compute_pinned_weights(0.25, 0.75, tail_sum=3)
         # Burn slot.
         assert weights[0] == burn_u16
         # Rank 1 finisher — uid 1 in this metagraph.
@@ -360,5 +361,6 @@ class TestWeightSetterThread:
         for call in mock_backend_client.get_race_detail.call_args_list:
             assert call.args == (completed_id,) or call.kwargs == {"race_id": completed_id}
         weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
-        top_u16, _ = compute_top_burn_weights(0.25, 0.75)
+        # K=3, tail = [2, 1] → tail_sum = 3.
+        top_u16, _ = compute_pinned_weights(0.25, 0.75, tail_sum=3)
         assert weights[1] == top_u16  # rank-1 finisher protected

--- a/subnet/tests/validator/test_weight_setter.py
+++ b/subnet/tests/validator/test_weight_setter.py
@@ -229,21 +229,21 @@ class TestWeightSetterThread:
     def test_race_path_distributes_to_top_half(
         self, mock_backend_client, mock_subtensor, mock_wallet
     ):
-        """With a completed race of 6 entrants, the top 3 (floor(6/2)) get
+        """With a completed race of 6 finishers, the top 3 (floor(6/2)) get
         non-zero u16 weights and the bottom 3 get 0."""
-        # 6 entrants, scores descending; metagraph indexes them after the burn uid.
-        entrants = [
+        # 6 finishers, scores descending; metagraph indexes them after the burn uid.
+        finishers = [
             {"miner_hotkey": f"5HK{i}", "agent_version_id": str(uuid4()), "race_score": 0.9 - i * 0.05}
             for i in range(6)
         ]
 
         metagraph = MagicMock()
-        metagraph.hotkeys = ["5BurnUid"] + [e["miner_hotkey"] for e in entrants]
+        metagraph.hotkeys = ["5BurnUid"] + [e["miner_hotkey"] for e in finishers]
         metagraph.uids = list(range(len(metagraph.hotkeys)))
 
         race_id = uuid4()
         mock_backend_client.get_race_history.return_value = _race_complete_history(race_id)
-        mock_backend_client.get_race_detail.return_value = _race_detail(entrants)
+        mock_backend_client.get_race_detail.return_value = _race_detail(finishers)
 
         setter = WeightSetterThread(
             backend_client=mock_backend_client,
@@ -261,7 +261,7 @@ class TestWeightSetterThread:
         top_u16, burn_u16 = compute_top_burn_weights(0.25, 0.75)
         # Burn slot.
         assert weights[0] == burn_u16
-        # Rank 1 entrant — uid 1 in this metagraph.
+        # Rank 1 finisher — uid 1 in this metagraph.
         assert weights[1] == top_u16
         # Ranks 2..K (K=3) — taper K-1, K-2 = 2, 1.
         assert weights[2] == 2

--- a/subnet/tests/validator/test_weight_setter.py
+++ b/subnet/tests/validator/test_weight_setter.py
@@ -2,7 +2,8 @@ import sys
 import time
 from datetime import datetime
 from pathlib import Path
-from uuid import UUID
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -11,25 +12,62 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from oro_sdk.models import TopAgentResponse
 
+from validator.weight_distribution import U16_MAX, compute_top_burn_weights
 from validator.weight_setter import WeightSetterThread
 
 
-class TestWeightSetterThread:
-    """Tests for WeightSetterThread.
+def _empty_history():
+    """A `get_race_history` response with no races — drives the fallback path."""
+    history = MagicMock()
+    history.races = []
+    return history
 
-    Uses mock_backend_client_with_top_miner, mock_metagraph, mock_subtensor,
-    and mock_wallet_simple fixtures from conftest.py.
+
+def _race_complete_history(race_id: UUID):
+    history = MagicMock()
+    race = MagicMock()
+    race.race_id = race_id
+    race.status = "RACE_COMPLETE"
+    history.races = [race]
+    return history
+
+
+def _race_detail(qualifiers: list[dict]):
+    """Build a mock RaceDetailResponse with the supplied qualifier dicts.
+
+    Each dict needs `miner_hotkey`, `agent_version_id`, `race_score`.
+    """
+    detail = MagicMock()
+    detail.qualifiers = []
+    for q in qualifiers:
+        m = MagicMock()
+        m.miner_hotkey = q["miner_hotkey"]
+        m.agent_version_id = q["agent_version_id"]
+        m.race_score = q["race_score"]
+        detail.qualifiers.append(m)
+    return detail
+
+
+class TestWeightSetterThread:
+    """Integration tests for WeightSetterThread.
+
+    Uses fixtures from conftest.py.
     """
 
     @pytest.fixture
     def mock_backend_client(self, mock_backend_client_with_top_miner):
-        """Alias to use the pre-configured top miner fixture."""
+        """Top-miner fixture extended with an empty race history so tests
+        that don't set up a race fall through to the fallback path."""
+        mock_backend_client_with_top_miner.get_race_history.return_value = (
+            _empty_history()
+        )
         return mock_backend_client_with_top_miner
 
     @pytest.fixture
     def mock_wallet(self, mock_wallet_simple):
-        """Alias to use simple wallet (no signing needed)."""
         return mock_wallet_simple
+
+    # --- thread lifecycle ---
 
     def test_start_creates_thread(
         self, mock_backend_client, mock_subtensor, mock_metagraph, mock_wallet
@@ -62,30 +100,23 @@ class TestWeightSetterThread:
         setter.stop()
         assert not setter._thread.is_alive()
 
-    def test_sets_weights_for_top_miner_only(
+    def test_invalid_ratio_raises_at_construction(
         self, mock_backend_client, mock_subtensor, mock_metagraph, mock_wallet
     ):
-        setter = WeightSetterThread(
-            backend_client=mock_backend_client,
-            subtensor=mock_subtensor,
-            metagraph=mock_metagraph,
-            wallet=mock_wallet,
-            netuid=1,
-            interval_seconds=0.1,
-        )
-        setter.start()
-        time.sleep(0.15)
-        setter.stop()
+        with pytest.raises(ValueError):
+            WeightSetterThread(
+                backend_client=mock_backend_client,
+                subtensor=mock_subtensor,
+                metagraph=mock_metagraph,
+                wallet=mock_wallet,
+                netuid=1,
+                t_top=0.6,
+                t_burn=0.5,  # sum > 1
+            )
 
-        mock_subtensor.set_weights.assert_called()
-        call_args = mock_subtensor.set_weights.call_args
-        weights = call_args.kwargs.get("weights") or call_args[1].get("weights")
-        # Index 1 is the top miner (5GrwvaEF...) - only they get weight
-        assert weights[0] == 0.0
-        assert weights[1] == 1.0
-        assert weights[2] == 0.0
+    # --- top-miner fallback (no completed race) ---
 
-    def test_burns_to_uid_zero_when_top_miner_not_in_metagraph(
+    def test_fallback_burns_when_top_miner_not_in_metagraph(
         self, mock_backend_client, mock_subtensor, mock_metagraph, mock_wallet
     ):
         mock_backend_client.get_top_miner.return_value = TopAgentResponse(
@@ -94,7 +125,7 @@ class TestWeightSetterThread:
             top_miner_hotkey="5UnknownHotkey...",
             top_score=0.92,
             computed_at=datetime.now(),
-            emission_weight=0.25,
+            emission_weight=1.0,
         )
         setter = WeightSetterThread(
             backend_client=mock_backend_client,
@@ -109,23 +140,45 @@ class TestWeightSetterThread:
         setter.stop()
 
         mock_subtensor.set_weights.assert_called()
-        call_args = mock_subtensor.set_weights.call_args
-        weights = call_args.kwargs.get("weights") or call_args[1].get("weights")
-        assert weights[0] == 1.0
-        assert all(w == 0.0 for w in weights[1:])
+        weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
+        _, burn_u16 = compute_top_burn_weights(0.25, 0.75)
+        assert weights[0] == burn_u16
+        assert all(w == 0 for w in weights[1:])
 
-    def test_emission_decay_splits_weight_to_burn_uid(
+    def test_fallback_top_miner_full_emission(
         self, mock_backend_client, mock_subtensor, mock_metagraph, mock_wallet
     ):
+        """emission_weight == 1.0 → top miner gets full top_u16, burn slot full burn_u16."""
+        setter = WeightSetterThread(
+            backend_client=mock_backend_client,
+            subtensor=mock_subtensor,
+            metagraph=mock_metagraph,
+            wallet=mock_wallet,
+            netuid=1,
+            interval_seconds=0.1,
+        )
+        setter.start()
+        time.sleep(0.15)
+        setter.stop()
+
+        weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
+        top_u16, burn_u16 = compute_top_burn_weights(0.25, 0.75)
+        assert weights[0] == burn_u16  # uid 0 = burn
+        assert weights[1] == top_u16  # 5GrwvaEF... index in fixture
+        assert weights[2] == 0
+
+    def test_fallback_emission_weight_partial(
+        self, mock_backend_client, mock_subtensor, mock_metagraph, mock_wallet
+    ):
+        """emission_weight=0.5 scales top slot to half top_u16; burn slot keeps full share."""
         mock_backend_client.get_top_miner.return_value = TopAgentResponse(
             suite_id=789,
             top_agent_version_id=UUID("87654321-4321-4321-4321-210987654321"),
             top_miner_hotkey="5GrwvaEF...",
             top_score=0.92,
             computed_at=datetime.now(),
-            emission_weight=0.97,
+            emission_weight=0.5,
         )
-
         setter = WeightSetterThread(
             backend_client=mock_backend_client,
             subtensor=mock_subtensor,
@@ -138,65 +191,10 @@ class TestWeightSetterThread:
         time.sleep(0.15)
         setter.stop()
 
-        call_args = mock_subtensor.set_weights.call_args
-        weights = call_args.kwargs.get("weights") or call_args[1].get("weights")
-        assert abs(weights[0] - 0.03) < 1e-9  # burn UID gets remainder
-        assert abs(weights[1] - 0.97) < 1e-9  # top miner gets emission_wt
-        assert weights[2] == 0.0
-
-    def test_emission_weight_none_treated_as_full(
-        self, mock_backend_client, mock_subtensor, mock_metagraph, mock_wallet
-    ):
-        setter = WeightSetterThread(
-            backend_client=mock_backend_client,
-            subtensor=mock_subtensor,
-            metagraph=mock_metagraph,
-            wallet=mock_wallet,
-            netuid=1,
-            interval_seconds=0.1,
-        )
-        setter.start()
-        time.sleep(0.15)
-        setter.stop()
-
-        call_args = mock_subtensor.set_weights.call_args
-        weights = call_args.kwargs.get("weights") or call_args[1].get("weights")
-        assert weights[0] == 0.0  # no burn
-        assert weights[1] == 1.0  # full weight
-
-    def test_emission_decay_top_miner_is_uid_zero(
-        self, mock_backend_client, mock_subtensor, mock_metagraph, mock_wallet
-    ):
-        """When top miner IS UID 0, they get emission_wt + burn_wt = 1.0."""
-        mock_backend_client.get_top_miner.return_value = TopAgentResponse(
-            suite_id=789,
-            top_agent_version_id=UUID("87654321-4321-4321-4321-210987654321"),
-            top_miner_hotkey="5BurnAddr...",
-            top_score=0.92,
-            computed_at=datetime.now(),
-            emission_weight=0.90,
-        )
-
-        # Make UID 0 the top miner's hotkey
-        mock_metagraph.hotkeys = ["5BurnAddr...", "5GrwvaEF...", "5FHneW46..."]
-
-        setter = WeightSetterThread(
-            backend_client=mock_backend_client,
-            subtensor=mock_subtensor,
-            metagraph=mock_metagraph,
-            wallet=mock_wallet,
-            netuid=1,
-            interval_seconds=0.1,
-        )
-        setter.start()
-        time.sleep(0.15)
-        setter.stop()
-
-        call_args = mock_subtensor.set_weights.call_args
-        weights = call_args.kwargs.get("weights") or call_args[1].get("weights")
-        assert abs(weights[0] - 1.0) < 1e-9  # 0.90 + 0.10 = 1.0
-        assert weights[1] == 0.0
-        assert weights[2] == 0.0
+        weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
+        top_u16, burn_u16 = compute_top_burn_weights(0.25, 0.75)
+        assert weights[0] == burn_u16
+        assert weights[1] == round(top_u16 * 0.5)
 
     def test_continues_on_error(
         self, mock_backend_client, mock_subtensor, mock_metagraph, mock_wallet
@@ -209,6 +207,7 @@ class TestWeightSetterThread:
                 top_miner_hotkey="5GrwvaEF...",
                 top_score=0.92,
                 computed_at=datetime.now(),
+                emission_weight=1.0,
             ),
         ]
         setter = WeightSetterThread(
@@ -224,3 +223,77 @@ class TestWeightSetterThread:
         setter.stop()
 
         assert mock_backend_client.get_top_miner.call_count >= 2
+
+    # --- race-based path ---
+
+    def test_race_path_distributes_to_top_half(
+        self, mock_backend_client, mock_subtensor, mock_wallet
+    ):
+        """With a completed race of 6 entrants, the top 3 (floor(6/2)) get
+        non-zero u16 weights and the bottom 3 get 0."""
+        # 6 entrants, scores descending; metagraph indexes them after the burn uid.
+        entrants = [
+            {"miner_hotkey": f"5HK{i}", "agent_version_id": str(uuid4()), "race_score": 0.9 - i * 0.05}
+            for i in range(6)
+        ]
+
+        metagraph = MagicMock()
+        metagraph.hotkeys = ["5BurnUid"] + [e["miner_hotkey"] for e in entrants]
+        metagraph.uids = list(range(len(metagraph.hotkeys)))
+
+        race_id = uuid4()
+        mock_backend_client.get_race_history.return_value = _race_complete_history(race_id)
+        mock_backend_client.get_race_detail.return_value = _race_detail(entrants)
+
+        setter = WeightSetterThread(
+            backend_client=mock_backend_client,
+            subtensor=mock_subtensor,
+            metagraph=metagraph,
+            wallet=mock_wallet,
+            netuid=1,
+            interval_seconds=0.1,
+        )
+        setter.start()
+        time.sleep(0.15)
+        setter.stop()
+
+        weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
+        top_u16, burn_u16 = compute_top_burn_weights(0.25, 0.75)
+        # Burn slot.
+        assert weights[0] == burn_u16
+        # Rank 1 entrant — uid 1 in this metagraph.
+        assert weights[1] == top_u16
+        # Ranks 2..K (K=3) — taper K-1, K-2 = 2, 1.
+        assert weights[2] == 2
+        assert weights[3] == 1
+        # Bottom half — zero.
+        assert weights[4] == 0
+        assert weights[5] == 0
+        assert weights[6] == 0
+
+    def test_race_path_skipped_when_status_not_complete(
+        self, mock_backend_client, mock_subtensor, mock_metagraph, mock_wallet
+    ):
+        """Latest race in QUALIFYING_OPEN → fall back to top-miner path."""
+        history = MagicMock()
+        race = MagicMock()
+        race.race_id = uuid4()
+        race.status = "QUALIFYING_OPEN"
+        history.races = [race]
+        mock_backend_client.get_race_history.return_value = history
+
+        setter = WeightSetterThread(
+            backend_client=mock_backend_client,
+            subtensor=mock_subtensor,
+            metagraph=mock_metagraph,
+            wallet=mock_wallet,
+            netuid=1,
+            interval_seconds=0.1,
+        )
+        setter.start()
+        time.sleep(0.15)
+        setter.stop()
+
+        # `get_race_detail` should never be called when status is not complete.
+        mock_backend_client.get_race_detail.assert_not_called()
+        mock_backend_client.get_top_miner.assert_called()

--- a/subnet/tests/validator/test_weight_setter.py
+++ b/subnet/tests/validator/test_weight_setter.py
@@ -12,7 +12,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from oro_sdk.models import TopAgentResponse
 
-from validator.weight_distribution import U16_MAX, compute_top_burn_weights
+from validator.weight_distribution import compute_top_burn_weights
 from validator.weight_setter import WeightSetterThread
 
 
@@ -29,6 +29,19 @@ def _race_complete_history(race_id: UUID):
     race.race_id = race_id
     race.status = "RACE_COMPLETE"
     history.races = [race]
+    return history
+
+
+def _race_with_status(race_id: UUID, status: str):
+    race = MagicMock()
+    race.race_id = race_id
+    race.status = status
+    return race
+
+
+def _history_with_races(races: list):
+    history = MagicMock()
+    history.races = races
     return history
 
 
@@ -271,16 +284,19 @@ class TestWeightSetterThread:
         assert weights[5] == 0
         assert weights[6] == 0
 
-    def test_race_path_skipped_when_status_not_complete(
+    def test_race_path_falls_back_when_no_completed_race_in_history(
         self, mock_backend_client, mock_subtensor, mock_metagraph, mock_wallet
     ):
-        """Latest race in QUALIFYING_OPEN → fall back to top-miner path."""
-        history = MagicMock()
-        race = MagicMock()
-        race.race_id = uuid4()
-        race.status = "QUALIFYING_OPEN"
-        history.races = [race]
-        mock_backend_client.get_race_history.return_value = history
+        """Every race in history is in-progress → fall back to top-miner path.
+
+        Only happens on a fresh subnet or after a race-system rollback.
+        """
+        mock_backend_client.get_race_history.return_value = _history_with_races(
+            [
+                _race_with_status(uuid4(), "QUALIFYING_OPEN"),
+                _race_with_status(uuid4(), "RACE_RUNNING"),
+            ]
+        )
 
         setter = WeightSetterThread(
             backend_client=mock_backend_client,
@@ -294,6 +310,55 @@ class TestWeightSetterThread:
         time.sleep(0.15)
         setter.stop()
 
-        # `get_race_detail` should never be called when status is not complete.
+        # `get_race_detail` should never be called when no race is complete.
         mock_backend_client.get_race_detail.assert_not_called()
         mock_backend_client.get_top_miner.assert_called()
+
+    def test_race_path_skips_in_progress_and_uses_prior_completed_race(
+        self, mock_backend_client, mock_subtensor, mock_wallet
+    ):
+        """Newest race is `QUALIFYING_OPEN` (current cycle) — we still want
+        last race's finishers protected. Walk the history and use the most
+        recent `RACE_COMPLETE`.
+        """
+        finishers = [
+            {"miner_hotkey": f"5HK{i}", "agent_version_id": str(uuid4()), "race_score": 0.9 - i * 0.05}
+            for i in range(6)
+        ]
+
+        metagraph = MagicMock()
+        metagraph.hotkeys = ["5BurnUid"] + [f["miner_hotkey"] for f in finishers]
+        metagraph.uids = list(range(len(metagraph.hotkeys)))
+
+        in_progress_id = uuid4()
+        completed_id = uuid4()
+        mock_backend_client.get_race_history.return_value = _history_with_races(
+            [
+                _race_with_status(in_progress_id, "QUALIFYING_OPEN"),
+                _race_with_status(completed_id, "RACE_COMPLETE"),
+            ]
+        )
+        # Detail call should target the completed race, not the in-progress one.
+        mock_backend_client.get_race_detail.return_value = _race_detail(finishers)
+
+        setter = WeightSetterThread(
+            backend_client=mock_backend_client,
+            subtensor=mock_subtensor,
+            metagraph=metagraph,
+            wallet=mock_wallet,
+            netuid=1,
+            interval_seconds=0.1,
+        )
+        setter.start()
+        time.sleep(0.15)
+        setter.stop()
+
+        # Loop may tick more than once at this interval; what matters is
+        # the call always targeted the completed race id, never the
+        # in-progress one.
+        assert mock_backend_client.get_race_detail.call_count >= 1
+        for call in mock_backend_client.get_race_detail.call_args_list:
+            assert call.args == (completed_id,) or call.kwargs == {"race_id": completed_id}
+        weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
+        top_u16, _ = compute_top_burn_weights(0.25, 0.75)
+        assert weights[1] == top_u16  # rank-1 finisher protected

--- a/subnet/validator/backend_client.py
+++ b/subnet/validator/backend_client.py
@@ -18,7 +18,7 @@ import httpx
 import requests
 from bittensor_wallet import Wallet
 from oro_sdk import BittensorAuthClient, Client
-from oro_sdk.api.public import get_top_agent
+from oro_sdk.api.public import get_race_detail, get_race_history, get_top_agent
 from oro_sdk.api.validator import (
     claim_work,
     complete_run,
@@ -43,6 +43,8 @@ from oro_sdk.models.presign_upload_request import PresignUploadRequest
 from oro_sdk.models.presign_upload_response import PresignUploadResponse
 from oro_sdk.models.problem_progress_update import ProblemProgressUpdate
 from oro_sdk.models.progress_update_request import ProgressUpdateRequest
+from oro_sdk.models.race_detail_response import RaceDetailResponse
+from oro_sdk.models.race_history_response import RaceHistoryResponse
 from oro_sdk.models.terminal_status import TerminalStatus
 from oro_sdk.models.top_agent_response import TopAgentResponse
 from oro_sdk.types import UNSET, Unset, Response
@@ -554,6 +556,35 @@ class BackendClient:
         return self._call_api(
             get_top_agent.sync_detailed,
             "get_top_miner",
+            client=self._public_client,
+        )
+
+    def get_race_history(self, limit: int = 1) -> RaceHistoryResponse:
+        """Fetch the most recent races (ordered newest-first).
+
+        Args:
+            limit: Number of races to return.
+
+        Raises:
+            BackendError: If the request fails.
+        """
+        return self._call_api(
+            get_race_history.sync_detailed,
+            "get_race_history",
+            client=self._public_client,
+            limit=limit,
+        )
+
+    def get_race_detail(self, race_id: UUID) -> RaceDetailResponse:
+        """Fetch a single race with its qualifiers.
+
+        Raises:
+            BackendError: If the request fails.
+        """
+        return self._call_api(
+            get_race_detail.sync_detailed,
+            "get_race_detail",
+            race_id=race_id,
             client=self._public_client,
         )
 

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -450,7 +450,11 @@ class Validator:
         UPDATE_CHECK_INTERVAL = 300
         self._last_update_check = 0
 
-        # Start weight setter thread
+        # Start weight setter thread.
+        # `ORO_BURN_UID` lets test deployments target a non-uid-0 burn slot
+        # (e.g. testnet subnet 469 where uid 0 is the validator hotkey, not
+        # a dedicated burn address). Default 0 matches subnet 15 prod.
+        burn_uid = int(os.environ.get("ORO_BURN_UID", "0"))
         weight_setter = WeightSetterThread(
             backend_client=self.backend_client,
             subtensor=self.subtensor,
@@ -458,10 +462,12 @@ class Validator:
             wallet=self.wallet,
             netuid=self.config.netuid,
             interval_seconds=self.config.weight_update_interval,
+            burn_uid=burn_uid,
         )
         weight_setter.start()
         logging.info(
-            f"Weight setter started (interval: {self.config.weight_update_interval}s)"
+            f"Weight setter started (interval: {self.config.weight_update_interval}s, "
+            f"burn_uid={burn_uid})"
         )
 
         try:

--- a/subnet/validator/weight_distribution.py
+++ b/subnet/validator/weight_distribution.py
@@ -1,15 +1,23 @@
-"""Deterministic weight distribution for the top half of race entrants.
+"""Deterministic weight distribution for the top half of race finishers.
 
-Replaces the prior "all weight to the single top miner + burn" model with a
-linear-taper across the top `floor(N/2)` ranked entrants, so legitimate
-competitors retain `Emission[uid] > 0` and survive `get_neuron_to_prune`
-(which ranks by emission asc, reg_block asc, uid asc).
+A finisher is a qualifier from the most recent completed race that
+actually finished the race (has a non-null `race_score`). Qualifiers
+that DNF'd or were eliminated mid-race land in the public race detail
+with `race_score=null` and are dropped at the boundary in
+`weight_setter._qualifiers_to_finishers`. By the time finishers reach
+this module the list is already filtered.
 
-The function in this module is pure — same `(qualifiers, t_top, t_burn)`
-yields byte-identical u16 weight vectors across validators. That property
-is load-bearing for Yuma consensus on subnet 15 (`kappa = 0.5`): if
-validators emit different weight vectors for the tail, the median collapses
-to 0 and the protection fails.
+The protection target is the half of last race's finishers with the
+highest scores: those who actively competed and did not finish at the
+bottom of the pack. They keep `Emission[uid] > 0` between races and
+survive `get_neuron_to_prune` (which ranks by emission asc, reg_block
+asc, uid asc) when their `immunity_period` expires.
+
+The function in this module is pure — same `(finishers, t_top, t_burn)`
+yields byte-identical u16 weight vectors across validators. That
+property is load-bearing for Yuma consensus on subnet 15 (`kappa = 0.5`):
+if validators emit different weight vectors for the tail, the median
+collapses to 0 and the protection fails.
 """
 
 from __future__ import annotations
@@ -25,7 +33,7 @@ U16_MAX = 65535
 
 
 @dataclass(frozen=True)
-class RankedEntrant:
+class RankedFinisher:
     """A single race qualifier reduced to the fields needed for ranking.
 
     Validators only need the score (for ordering), the agent_version_id
@@ -37,7 +45,7 @@ class RankedEntrant:
     race_score: float
 
 
-def rank_entrants(qualifiers: Iterable[RankedEntrant]) -> list[RankedEntrant]:
+def rank_finishers(qualifiers: Iterable[RankedFinisher]) -> list[RankedFinisher]:
     """Sort qualifiers into a canonical order shared by every validator.
 
     Primary key: `race_score` descending. Tie-break: `agent_version_id`
@@ -74,11 +82,11 @@ def compute_top_burn_weights(t_top: float, t_burn: float) -> tuple[int, int]:
 
 
 def compute_hotkey_weights(
-    qualifiers: Iterable[RankedEntrant],
+    qualifiers: Iterable[RankedFinisher],
     t_top: float,
     t_burn: float,
 ) -> dict[str, int]:
-    """Compute hotkey → u16 weight for the top 50% of race entrants.
+    """Compute hotkey → u16 weight for the top 50% of race finishers.
 
     Bottom 50% (and ties at the rank-K boundary, by tiebreak) get no entry.
 
@@ -86,7 +94,7 @@ def compute_hotkey_weights(
     values if `t_burn > t_top`). Ranks 2..K receive a linear taper
     `K + 1 - rank`, so rank 2 = K-1, rank 3 = K-2, ..., rank K = 1.
     """
-    ranked = rank_entrants(qualifiers)
+    ranked = rank_finishers(qualifiers)
     n = len(ranked)
     k = n // 2  # floor
     if k == 0:
@@ -105,7 +113,7 @@ def compute_hotkey_weights(
 
 
 def build_metagraph_weight_vector(
-    qualifiers: Iterable[RankedEntrant],
+    qualifiers: Iterable[RankedFinisher],
     metagraph_hotkeys: list[str],
     t_top: float,
     t_burn: float,

--- a/subnet/validator/weight_distribution.py
+++ b/subnet/validator/weight_distribution.py
@@ -203,12 +203,13 @@ def build_metagraph_weight_vector(
     if n_meta == 0:
         return [], []
 
-    ranked = rank_finishers(qualifiers)
-    k = len(ranked) // 2
-    tail_sum = _tail_sum_for(k)
+    # Materialise once — `qualifiers` may be a one-shot iterable, and we
+    # need its length here and again inside `compute_hotkey_weights`.
+    finishers = list(qualifiers)
+    tail_sum = _tail_sum_for(len(finishers) // 2)
     _, burn_u16 = compute_pinned_weights(t_top, t_burn, tail_sum)
 
-    hotkey_weights = compute_hotkey_weights(ranked, t_top, t_burn)
+    hotkey_weights = compute_hotkey_weights(finishers, t_top, t_burn)
 
     weights = [0] * n_meta
     hotkey_to_idx = {hk: i for i, hk in enumerate(metagraph_hotkeys)}

--- a/subnet/validator/weight_distribution.py
+++ b/subnet/validator/weight_distribution.py
@@ -1,0 +1,156 @@
+"""Deterministic weight distribution for the top half of race entrants.
+
+Replaces the prior "all weight to the single top miner + burn" model with a
+linear-taper across the top `floor(N/2)` ranked entrants, so legitimate
+competitors retain `Emission[uid] > 0` and survive `get_neuron_to_prune`
+(which ranks by emission asc, reg_block asc, uid asc).
+
+The function in this module is pure — same `(qualifiers, t_top, t_burn)`
+yields byte-identical u16 weight vectors across validators. That property
+is load-bearing for Yuma consensus on subnet 15 (`kappa = 0.5`): if
+validators emit different weight vectors for the tail, the median collapses
+to 0 and the protection fails.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+# u16 cap on each weight entry submitted to the chain. The chain normalises
+# the submitted vector, so we pin the larger of `t_top` / `t_burn` at this
+# value to minimise the tail's share of total emission while preserving the
+# configured ratio.
+U16_MAX = 65535
+
+
+@dataclass(frozen=True)
+class RankedEntrant:
+    """A single race qualifier reduced to the fields needed for ranking.
+
+    Validators only need the score (for ordering), the agent_version_id
+    (for tie-breaks), and the hotkey (for mapping to metagraph uid).
+    """
+
+    miner_hotkey: str
+    agent_version_id: str
+    race_score: float
+
+
+def rank_entrants(qualifiers: Iterable[RankedEntrant]) -> list[RankedEntrant]:
+    """Sort qualifiers into a canonical order shared by every validator.
+
+    Primary key: `race_score` descending. Tie-break: `agent_version_id`
+    ascending (UUIDs are deterministic strings). The combination is total —
+    two qualifiers with identical score AND identical agent_version_id
+    cannot exist (agent_version_id is unique per submission).
+    """
+    return sorted(
+        qualifiers,
+        key=lambda e: (-e.race_score, e.agent_version_id),
+    )
+
+
+def compute_top_burn_weights(t_top: float, t_burn: float) -> tuple[int, int]:
+    """Return `(top_u16, burn_u16)` with the larger pinned at `U16_MAX`.
+
+    Pinning the larger side at `U16_MAX` minimises the tail's share of the
+    normalised emission vector while preserving the configured ratio.
+    """
+    if t_top < 0 or t_burn < 0:
+        raise ValueError("t_top and t_burn must be non-negative")
+    if t_top + t_burn > 1:
+        raise ValueError("t_top + t_burn must be <= 1")
+    if t_top == 0 and t_burn == 0:
+        raise ValueError("at least one of t_top / t_burn must be > 0")
+
+    if t_top >= t_burn:
+        top = U16_MAX
+        burn = round(U16_MAX * t_burn / t_top) if t_top > 0 else 0
+    else:
+        burn = U16_MAX
+        top = round(U16_MAX * t_top / t_burn) if t_burn > 0 else 0
+    return top, burn
+
+
+def compute_hotkey_weights(
+    qualifiers: Iterable[RankedEntrant],
+    t_top: float,
+    t_burn: float,
+) -> dict[str, int]:
+    """Compute hotkey → u16 weight for the top 50% of race entrants.
+
+    Bottom 50% (and ties at the rank-K boundary, by tiebreak) get no entry.
+
+    The "top" entry receives `top_u16` (or the smaller of the two pinned
+    values if `t_burn > t_top`). Ranks 2..K receive a linear taper
+    `K + 1 - rank`, so rank 2 = K-1, rank 3 = K-2, ..., rank K = 1.
+    """
+    ranked = rank_entrants(qualifiers)
+    n = len(ranked)
+    k = n // 2  # floor
+    if k == 0:
+        return {}
+
+    top_u16, _ = compute_top_burn_weights(t_top, t_burn)
+    weights: dict[str, int] = {}
+    weights[ranked[0].miner_hotkey] = top_u16
+
+    # Ranks 2..K (1-indexed) → indices 1..K-1 in `ranked`.
+    for idx in range(1, k):
+        rank_1based = idx + 1  # 2..K
+        weights[ranked[idx].miner_hotkey] = k + 1 - rank_1based
+
+    return weights
+
+
+def build_metagraph_weight_vector(
+    qualifiers: Iterable[RankedEntrant],
+    metagraph_hotkeys: list[str],
+    t_top: float,
+    t_burn: float,
+    burn_uid: int = 0,
+) -> tuple[list[int], list[int]]:
+    """Produce `(uids, weights_u16)` aligned to the metagraph.
+
+    Steps:
+
+    1. Rank qualifiers and compute hotkey → top-half u16 weights.
+    2. Compute the burn u16 from the configured ratio.
+    3. Map every hotkey-weight onto its metagraph index. A hotkey present
+       in the race but absent from the metagraph (deregistered between
+       race close and weight set) is silently dropped — its weight does
+       not redistribute, so the burn share grows slightly. This matches
+       the existing "top miner missing → burn everything" fallback.
+    4. Add `burn_u16` at `burn_uid` (uid 0 on subnet 15 is a literal burn).
+
+    Returns:
+        Two parallel lists of length `len(metagraph_hotkeys)`. `uids[i]`
+        is `i` (the metagraph index), `weights_u16[i]` is the u16 weight
+        for that uid (0 if the hotkey is not in the top 50% and not the
+        burn uid).
+    """
+    n_meta = len(metagraph_hotkeys)
+    if n_meta == 0:
+        return [], []
+
+    hotkey_weights = compute_hotkey_weights(qualifiers, t_top, t_burn)
+    top_u16, burn_u16 = compute_top_burn_weights(t_top, t_burn)
+    # `compute_top_burn_weights` returns (top, burn) regardless of which
+    # side is dominant; only `burn_u16` is needed here for the burn slot.
+
+    weights = [0] * n_meta
+    hotkey_to_idx = {hk: i for i, hk in enumerate(metagraph_hotkeys)}
+    for hk, w in hotkey_weights.items():
+        idx = hotkey_to_idx.get(hk)
+        if idx is None:
+            continue
+        weights[idx] = w
+
+    if 0 <= burn_uid < n_meta:
+        # Burn uid may coincidentally collide with a top-half hotkey on
+        # very small testnet metagraphs — the burn weight is additive so
+        # the slot is never accidentally zeroed by the top-half pass.
+        weights[burn_uid] += burn_u16
+
+    return list(range(n_meta)), weights

--- a/subnet/validator/weight_distribution.py
+++ b/subnet/validator/weight_distribution.py
@@ -25,11 +25,23 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable
 
-# u16 cap on each weight entry submitted to the chain. The chain normalises
-# the submitted vector, so we pin the larger of `t_top` / `t_burn` at this
-# value to minimise the tail's share of total emission while preserving the
-# configured ratio.
+# u16 cap on each weight entry submitted to the chain.
 U16_MAX = 65535
+
+
+# Allocation model
+# ----------------
+# Top miner receives exactly `t_top` of normalised emission. Burn uid +
+# tail (top-half ranks 2..K) together receive exactly `t_burn`.
+# `t_top + t_burn == 1` is required — there is no third bucket.
+#
+# Concretely with `t_top=0.25`, `t_burn=0.75`:
+#   * burn slot pinned at U16_MAX = 65535
+#   * total = (U16_MAX + tail_sum) / t_burn
+#   * top u16 = round(t_top * total)
+# so the top miner's share is invariant under `tail_sum` (i.e. under N),
+# and the tail "comes out of" the burn allocation rather than from both
+# top and burn proportionally.
 
 
 @dataclass(frozen=True)
@@ -59,25 +71,71 @@ def rank_finishers(qualifiers: Iterable[RankedFinisher]) -> list[RankedFinisher]
     )
 
 
-def compute_top_burn_weights(t_top: float, t_burn: float) -> tuple[int, int]:
-    """Return `(top_u16, burn_u16)` with the larger pinned at `U16_MAX`.
-
-    Pinning the larger side at `U16_MAX` minimises the tail's share of the
-    normalised emission vector while preserving the configured ratio.
-    """
+def _validate_ratios(t_top: float, t_burn: float) -> None:
     if t_top < 0 or t_burn < 0:
         raise ValueError("t_top and t_burn must be non-negative")
-    if t_top + t_burn > 1:
-        raise ValueError("t_top + t_burn must be <= 1")
+    if abs((t_top + t_burn) - 1.0) > 1e-9:
+        raise ValueError(
+            "t_top + t_burn must equal 1; the tail comes out of t_burn's share"
+        )
     if t_top == 0 and t_burn == 0:
         raise ValueError("at least one of t_top / t_burn must be > 0")
 
-    if t_top >= t_burn:
-        top = U16_MAX
-        burn = round(U16_MAX * t_burn / t_top) if t_top > 0 else 0
-    else:
+
+def _tail_sum_for(k: int) -> int:
+    """Sum of tail u16 weights for ranks 2..K (linear taper K-1, K-2, ..., 1).
+
+    Closed form: (K - 1) * K // 2. Returns 0 for K < 2.
+    """
+    if k < 2:
+        return 0
+    return (k - 1) * k // 2
+
+
+def compute_pinned_weights(
+    t_top: float, t_burn: float, tail_sum: int
+) -> tuple[int, int]:
+    """Return `(top_u16, burn_u16)` such that the chain-normalised vector
+    yields exactly `t_top` for the top miner and `t_burn` for the burn uid
+    plus tail combined.
+
+    The tail allocation comes out of `t_burn`'s share, not from both
+    proportionally — top miner stays at exactly `t_top` regardless of N.
+
+    The larger of `t_top` / `t_burn` is pinned at `U16_MAX`; the smaller
+    is derived from the ratio + the tail sum so the integrated total
+    sums to the right normalised shares.
+    """
+    _validate_ratios(t_top, t_burn)
+    if tail_sum < 0:
+        raise ValueError("tail_sum must be non-negative")
+
+    if t_burn >= t_top:
+        # Pin burn slot at U16_MAX. Burn share equals (burn + tail) / total,
+        # so total = (U16_MAX + tail_sum) / t_burn and top = t_top * total.
         burn = U16_MAX
-        top = round(U16_MAX * t_top / t_burn) if t_burn > 0 else 0
+        if t_burn == 0:
+            return 0, 0
+        total = (U16_MAX + tail_sum) / t_burn
+        top = round(t_top * total) if t_top > 0 else 0
+        return top, burn
+
+    # Pin top at U16_MAX. Total = U16_MAX / t_top; burn slot is the
+    # share of t_burn that's left after the tail consumes its part.
+    top = U16_MAX
+    if t_top == 0:
+        return 0, 0
+    total = U16_MAX / t_top
+    burn = round(t_burn * total) - tail_sum
+    if burn < 0:
+        # Tail consumed more than the burn share — the configured t_burn
+        # is too small for the race size at this t_top. The caller would
+        # need to either drop t_top, raise t_burn, or shrink K. Fail loud
+        # rather than silently emitting a negative burn.
+        raise ValueError(
+            f"tail_sum {tail_sum} exceeds burn share at "
+            f"t_top={t_top}, t_burn={t_burn}; lower N or adjust ratios"
+        )
     return top, burn
 
 
@@ -90,9 +148,11 @@ def compute_hotkey_weights(
 
     Bottom 50% (and ties at the rank-K boundary, by tiebreak) get no entry.
 
-    The "top" entry receives `top_u16` (or the smaller of the two pinned
-    values if `t_burn > t_top`). Ranks 2..K receive a linear taper
-    `K + 1 - rank`, so rank 2 = K-1, rank 3 = K-2, ..., rank K = 1.
+    The "top" entry receives `top_u16` (sized so the chain-normalised
+    share is exactly `t_top` regardless of N). Ranks 2..K receive a
+    linear taper `K + 1 - rank`, so rank 2 = K-1, rank 3 = K-2, ...,
+    rank K = 1. The tail's share comes out of `t_burn` — the top
+    miner's share does not move with N.
     """
     ranked = rank_finishers(qualifiers)
     n = len(ranked)
@@ -100,7 +160,8 @@ def compute_hotkey_weights(
     if k == 0:
         return {}
 
-    top_u16, _ = compute_top_burn_weights(t_top, t_burn)
+    tail_sum = _tail_sum_for(k)
+    top_u16, _ = compute_pinned_weights(t_top, t_burn, tail_sum)
     weights: dict[str, int] = {}
     weights[ranked[0].miner_hotkey] = top_u16
 
@@ -142,10 +203,12 @@ def build_metagraph_weight_vector(
     if n_meta == 0:
         return [], []
 
-    hotkey_weights = compute_hotkey_weights(qualifiers, t_top, t_burn)
-    top_u16, burn_u16 = compute_top_burn_weights(t_top, t_burn)
-    # `compute_top_burn_weights` returns (top, burn) regardless of which
-    # side is dominant; only `burn_u16` is needed here for the burn slot.
+    ranked = rank_finishers(qualifiers)
+    k = len(ranked) // 2
+    tail_sum = _tail_sum_for(k)
+    _, burn_u16 = compute_pinned_weights(t_top, t_burn, tail_sum)
+
+    hotkey_weights = compute_hotkey_weights(ranked, t_top, t_burn)
 
     weights = [0] * n_meta
     hotkey_to_idx = {hk: i for i, hk in enumerate(metagraph_hotkeys)}

--- a/subnet/validator/weight_setter.py
+++ b/subnet/validator/weight_setter.py
@@ -63,6 +63,13 @@ class WeightSetterThread:
     Runs in a background thread, independent of the evaluation loop.
     """
 
+    # How far back to scan `get_race_history` for the most recent
+    # `RACE_COMPLETE`. The newest race may be `QUALIFYING_OPEN` or
+    # `RACE_RUNNING` for ~24h of every cycle; we still want to protect
+    # last race's finishers during that window. 5 covers typical race
+    # cadence (one in-progress + a handful of completed) without paging.
+    _RACE_HISTORY_SCAN_LIMIT = 5
+
     def __init__(
         self,
         backend_client: BackendClient,
@@ -116,22 +123,32 @@ class WeightSetterThread:
                 )
 
     def _fetch_race_finishers(self) -> Optional[list[RankedFinisher]]:
-        """Return finishers from the latest completed race, or None.
+        """Return finishers from the most recent completed race, or None.
 
-        Returns None when there is no completed race yet, or when fetching
-        the race details fails — the caller falls back to the top-miner
-        path so weight setting is never silently skipped on transient errors.
+        Walks `get_race_history` newest-first and returns finishers from
+        the first race in `RACE_COMPLETE` status. When the newest race is
+        in progress (`QUALIFYING_OPEN`, `RACE_RUNNING`, etc.) we still
+        want to protect last race's finishers between races — using only
+        `limit=1` would skip the prior completed race and lose the
+        protection for the entire current cycle.
+
+        Returns None only when there is no completed race in the recent
+        history (fresh subnet, recovery from race-system rollback). The
+        caller then falls back to the top-miner path so weight setting
+        is never silently skipped.
         """
-        history = self.backend_client.get_race_history(limit=1)
+        history = self.backend_client.get_race_history(
+            limit=self._RACE_HISTORY_SCAN_LIMIT
+        )
         races = history.races if history.races is not UNSET else []
-        if not races:
-            return None
-        latest = races[0]
-        if str(latest.status) != "RACE_COMPLETE":
-            return None
-        detail = self.backend_client.get_race_detail(latest.race_id)
-        qualifiers = detail.qualifiers if detail.qualifiers is not UNSET else []
-        return _qualifiers_to_finishers(qualifiers)
+        for race in races:
+            if str(race.status) == "RACE_COMPLETE":
+                detail = self.backend_client.get_race_detail(race.race_id)
+                qualifiers = (
+                    detail.qualifiers if detail.qualifiers is not UNSET else []
+                )
+                return _qualifiers_to_finishers(qualifiers)
+        return None
 
     def _build_weights_from_race(
         self, finishers: list[RankedFinisher]

--- a/subnet/validator/weight_setter.py
+++ b/subnet/validator/weight_setter.py
@@ -1,18 +1,57 @@
-"""Background thread for periodic weight updates from Backend leaderboard."""
+"""Background thread for periodic weight updates.
+
+Builds a deterministic top-50% race-entrant weight vector via
+`weight_distribution.build_metagraph_weight_vector` and submits it to the
+chain. Determinism across validators is load-bearing for Yuma consensus on
+subnet 15 (`kappa = 0.5`).
+
+Falls back to the prior top-miner-only behaviour while no completed race
+is available (early subnet boot, race system temporarily unavailable).
+"""
 
 import threading
 from typing import Optional
 
 from bittensor.utils.btlogging import logging
+from oro_sdk.types import UNSET
 
 from .backend_client import BackendClient, BackendError
+from .weight_distribution import (
+    RankedEntrant,
+    build_metagraph_weight_vector,
+    compute_top_burn_weights,
+)
+
+
+def _qualifiers_to_entrants(qualifiers) -> list[RankedEntrant]:
+    """Reduce SDK `RaceQualifierPublic` records to the ranking inputs.
+
+    Skips entries without a `race_score` or `miner_hotkey` — those are not
+    eligible for weight allocation. Drops `None` and `Unset` defensively
+    so a partial-data Backend response can't poison the ranking.
+    """
+    entrants: list[RankedEntrant] = []
+    for q in qualifiers:
+        score = q.race_score
+        if score is None or score is UNSET:
+            continue
+        hotkey = q.miner_hotkey
+        if not hotkey or hotkey is UNSET:
+            continue
+        entrants.append(
+            RankedEntrant(
+                miner_hotkey=str(hotkey),
+                agent_version_id=str(q.agent_version_id),
+                race_score=float(score),
+            )
+        )
+    return entrants
 
 
 class WeightSetterThread:
-    """Periodically fetches top miner from Backend and updates on-chain weights.
+    """Periodically computes the top-50% weight vector and submits it on-chain.
 
-    Runs in a background thread, independent of evaluation loop.
-    Default interval is 5 minutes (300 seconds).
+    Runs in a background thread, independent of the evaluation loop.
     """
 
     def __init__(
@@ -23,6 +62,9 @@ class WeightSetterThread:
         wallet,
         netuid: int,
         interval_seconds: int = 300,
+        t_top: float = 0.25,
+        t_burn: float = 0.75,
+        burn_uid: int = 0,
     ):
         self.backend_client = backend_client
         self.subtensor = subtensor
@@ -30,6 +72,13 @@ class WeightSetterThread:
         self.wallet = wallet
         self.netuid = netuid
         self.interval_seconds = interval_seconds
+        self.t_top = t_top
+        self.t_burn = t_burn
+        self.burn_uid = burn_uid
+
+        # Fail fast on misconfiguration — the validator process should not
+        # start setting weights with invalid ratios.
+        compute_top_burn_weights(t_top, t_burn)
 
         self._stop_event = threading.Event()
         self._thread: Optional[threading.Thread] = None
@@ -44,7 +93,7 @@ class WeightSetterThread:
         """Stop the weight setter thread and wait for it to finish.
 
         Uses a generous timeout to account for:
-        - HTTP request to Backend (up to 30s)
+        - HTTP request to Backend (up to 30s, race detail can be larger)
         - Blockchain transaction with wait_for_inclusion (up to 60s)
         - Buffer time (10s)
         """
@@ -57,76 +106,149 @@ class WeightSetterThread:
                     f"Weight setter thread did not stop within {join_timeout}s"
                 )
 
-    def _build_weights(
-        self, top_miner_hotkey: str, emission_wt: float = 1.0
-    ) -> list[float]:
-        """Build weight vector with top miner and optional burn via UID 0.
+    def _fetch_race_entrants(self) -> Optional[list[RankedEntrant]]:
+        """Return entrants from the latest completed race, or None.
 
-        If the top miner is not in the metagraph (e.g. deregistered
-        between leaderboard fetch and weight set), all emissions go to
-        the UID 0 burn so weights are still set.
+        Returns None when there is no completed race yet, or when fetching
+        the race details fails — the caller falls back to the top-miner
+        path so weight setting is never silently skipped on transient errors.
+        """
+        history = self.backend_client.get_race_history(limit=1)
+        races = history.races if history.races is not UNSET else []
+        if not races:
+            return None
+        latest = races[0]
+        if str(latest.status) != "RACE_COMPLETE":
+            return None
+        detail = self.backend_client.get_race_detail(latest.race_id)
+        qualifiers = detail.qualifiers if detail.qualifiers is not UNSET else []
+        return _qualifiers_to_entrants(qualifiers)
+
+    def _build_weights_from_race(
+        self, entrants: list[RankedEntrant]
+    ) -> tuple[list[int], list[int]]:
+        """Compute the full `(uids, u16 weights)` vector for the metagraph.
+
+        Pure passthrough to `build_metagraph_weight_vector` — kept as a
+        method so tests can target the integration without exercising
+        Backend.
+        """
+        return build_metagraph_weight_vector(
+            entrants,
+            metagraph_hotkeys=list(self.metagraph.hotkeys),
+            t_top=self.t_top,
+            t_burn=self.t_burn,
+            burn_uid=self.burn_uid,
+        )
+
+    def _build_weights_top_miner_fallback(
+        self, top_miner_hotkey: str, emission_wt: float
+    ) -> tuple[list[int], list[int]]:
+        """Legacy fallback: top miner gets one slot, rest goes to burn uid.
+
+        Used while the subnet has no completed race yet, or when the race
+        endpoint is unavailable. Honours Backend's `emission_weight` so the
+        same operator-knob still controls the top/burn split during the
+        transition window.
         """
         n = len(self.metagraph.hotkeys)
         if n == 0:
-            return []
+            return [], []
 
-        weights = [0.0] * n
+        top_u16, burn_u16 = compute_top_burn_weights(self.t_top, self.t_burn)
+
+        weights = [0] * n
+        if 0 <= self.burn_uid < n:
+            weights[self.burn_uid] = burn_u16
+
         try:
             top_idx = self.metagraph.hotkeys.index(top_miner_hotkey)
-            weights[top_idx] = emission_wt
         except ValueError:
             logging.warning(
                 f"Top miner {top_miner_hotkey} not found in metagraph, "
-                "burning all emissions to UID 0"
+                "burning all emissions to uid 0"
             )
-            emission_wt = 0.0
-        weights[0] += 1.0 - emission_wt
-        return weights
+            return list(range(n)), weights
+
+        # `emission_weight` < 1 means Backend asked for a smaller-than-
+        # configured top share (e.g. challenger margin not yet earned).
+        # Scale the top u16 by it; the burn slot keeps its full share.
+        scaled_top = int(round(top_u16 * emission_wt))
+        if self.burn_uid == top_idx:
+            weights[top_idx] += scaled_top
+        else:
+            weights[top_idx] = scaled_top
+
+        return list(range(n)), weights
+
+    def _submit_weights(self, uids: list[int], weights: list[int]) -> None:
+        """Push `uids` / `weights` to the chain. No retries — the loop's
+        next tick will retry on transient blockchain failures."""
+        self.subtensor.set_weights(
+            netuid=self.netuid,
+            wallet=self.wallet,
+            uids=uids,
+            weights=weights,
+            wait_for_inclusion=True,
+        )
+
+    def _tick(self) -> None:
+        """One iteration of the loop — race-based path with top-miner fallback."""
+        self.metagraph.sync()
+
+        entrants: Optional[list[RankedEntrant]] = None
+        try:
+            entrants = self._fetch_race_entrants()
+        except BackendError as e:
+            # Don't crash the loop — fall back to the top-miner path so a
+            # race-endpoint outage doesn't stop weight setting.
+            if e.is_transient:
+                logging.warning(f"Race fetch transient error, using fallback: {e}")
+            else:
+                logging.error(f"Race fetch error, using fallback: {e}")
+
+        if entrants:
+            uids, weights = self._build_weights_from_race(entrants)
+            non_zero = sum(1 for w in weights if w > 0)
+            logging.info(
+                f"Race-based weight vector: N={len(entrants)} entrants, "
+                f"{non_zero} non-zero metagraph slots"
+            )
+        else:
+            top = self.backend_client.get_top_miner()
+            emission_wt = (
+                top.emission_weight
+                if isinstance(top.emission_weight, (int, float))
+                else 1.0
+            )
+            logging.info(
+                f"No completed race available — using top-miner fallback "
+                f"(top={top.top_miner_hotkey}, emission_weight={emission_wt:.3f})"
+            )
+            uids, weights = self._build_weights_top_miner_fallback(
+                top.top_miner_hotkey, emission_wt=emission_wt
+            )
+
+        if not weights:
+            logging.warning("Skipping weight update (empty metagraph)")
+            return
+
+        self._submit_weights(uids, weights)
+        logging.info("Successfully set weights")
 
     def _run(self) -> None:
         """Background thread main loop."""
         while not self._stop_event.is_set():
             try:
-                self.metagraph.sync()
-                top = self.backend_client.get_top_miner()
-                logging.info(
-                    f"Top miner: {top.top_miner_hotkey} with score {top.top_score}"
-                )
-                emission_wt = (
-                    top.emission_weight
-                    if isinstance(top.emission_weight, (int, float))
-                    else 1.0
-                )
-                logging.info(
-                    f"Emission weight: {emission_wt:.3f} (burn: {1.0 - emission_wt:.3f})"
-                )
-                weights = self._build_weights(
-                    top.top_miner_hotkey, emission_wt=emission_wt
-                )
-                if not weights:
-                    logging.warning("Skipping weight update (empty metagraph)")
-                else:
-                    self.subtensor.set_weights(
-                        netuid=self.netuid,
-                        wallet=self.wallet,
-                        uids=self.metagraph.uids,
-                        weights=weights,
-                        wait_for_inclusion=True,
-                    )
-                    logging.info("Successfully set weights")
+                self._tick()
             except BackendError as e:
                 if e.is_auth_error:
-                    # Authentication errors are permanent - log and continue
-                    # (will retry on next interval in case credentials are refreshed)
                     logging.error(f"Weight setting auth error (will retry): {e}")
                 elif e.is_transient:
-                    # Transient errors - log at warning level
                     logging.warning(f"Weight setting transient error: {e}")
                 else:
-                    # Other backend errors
                     logging.error(f"Weight setting backend error: {e}")
             except Exception as e:
-                # Non-backend errors (e.g., blockchain issues)
                 logging.error(f"Weight setting failed: {type(e).__name__}: {e}")
 
             self._stop_event.wait(self.interval_seconds)

--- a/subnet/validator/weight_setter.py
+++ b/subnet/validator/weight_setter.py
@@ -161,9 +161,22 @@ class WeightSetterThread:
         method so tests can target the integration without exercising
         Backend.
         """
+        metagraph_hotkeys = list(self.metagraph.hotkeys)
+        # Audit: log finishers whose hotkeys aren't in the current
+        # metagraph, since their weight is silently dropped by
+        # `build_metagraph_weight_vector`. This is the deregistration
+        # / uid-recycle case — expected, not an error.
+        present = set(metagraph_hotkeys)
+        missing = [f.miner_hotkey for f in finishers if f.miner_hotkey not in present]
+        if missing:
+            logging.info(
+                f"{len(missing)} race finisher(s) not in current metagraph "
+                f"(deregistered between race close and weight set), "
+                f"weight skipped: {missing[:5]}{'…' if len(missing) > 5 else ''}"
+            )
         return build_metagraph_weight_vector(
             finishers,
-            metagraph_hotkeys=list(self.metagraph.hotkeys),
+            metagraph_hotkeys=metagraph_hotkeys,
             t_top=self.t_top,
             t_burn=self.t_burn,
             burn_uid=self.burn_uid,

--- a/subnet/validator/weight_setter.py
+++ b/subnet/validator/weight_setter.py
@@ -1,6 +1,6 @@
 """Background thread for periodic weight updates.
 
-Builds a deterministic top-50% race-entrant weight vector via
+Builds a deterministic top-50% race-finisher weight vector via
 `weight_distribution.build_metagraph_weight_vector` and submits it to the
 chain. Determinism across validators is load-bearing for Yuma consensus on
 subnet 15 (`kappa = 0.5`).
@@ -17,20 +17,29 @@ from oro_sdk.types import UNSET
 
 from .backend_client import BackendClient, BackendError
 from .weight_distribution import (
-    RankedEntrant,
+    RankedFinisher,
     build_metagraph_weight_vector,
     compute_top_burn_weights,
 )
 
 
-def _qualifiers_to_entrants(qualifiers) -> list[RankedEntrant]:
-    """Reduce SDK `RaceQualifierPublic` records to the ranking inputs.
+def _qualifiers_to_finishers(qualifiers) -> list[RankedFinisher]:
+    """Reduce SDK `RaceQualifierPublic` records to ranked finishers.
 
-    Skips entries without a `race_score` or `miner_hotkey` — those are not
-    eligible for weight allocation. Drops `None` and `Unset` defensively
-    so a partial-data Backend response can't poison the ranking.
+    A "finisher" is a qualifier with a non-null `race_score` — i.e.
+    the agent ran the race to completion and got scored. Qualifiers
+    with `race_score=null` (DNF, eliminated mid-race, never executed)
+    are intentionally dropped: they did not finish the race, so they
+    are not protected from deregistration by this mechanism. A
+    `race_score=0.0` finisher is still a finisher (they completed but
+    scored zero) and competes for a top-half slot like everyone else;
+    the linear taper naturally drops them out of the protected set
+    when other finishers outscore them.
+
+    Also drops entries without a `miner_hotkey` defensively so a
+    partial-data Backend response can't poison the ranking.
     """
-    entrants: list[RankedEntrant] = []
+    finishers: list[RankedFinisher] = []
     for q in qualifiers:
         score = q.race_score
         if score is None or score is UNSET:
@@ -38,14 +47,14 @@ def _qualifiers_to_entrants(qualifiers) -> list[RankedEntrant]:
         hotkey = q.miner_hotkey
         if not hotkey or hotkey is UNSET:
             continue
-        entrants.append(
-            RankedEntrant(
+        finishers.append(
+            RankedFinisher(
                 miner_hotkey=str(hotkey),
                 agent_version_id=str(q.agent_version_id),
                 race_score=float(score),
             )
         )
-    return entrants
+    return finishers
 
 
 class WeightSetterThread:
@@ -106,8 +115,8 @@ class WeightSetterThread:
                     f"Weight setter thread did not stop within {join_timeout}s"
                 )
 
-    def _fetch_race_entrants(self) -> Optional[list[RankedEntrant]]:
-        """Return entrants from the latest completed race, or None.
+    def _fetch_race_finishers(self) -> Optional[list[RankedFinisher]]:
+        """Return finishers from the latest completed race, or None.
 
         Returns None when there is no completed race yet, or when fetching
         the race details fails — the caller falls back to the top-miner
@@ -122,10 +131,10 @@ class WeightSetterThread:
             return None
         detail = self.backend_client.get_race_detail(latest.race_id)
         qualifiers = detail.qualifiers if detail.qualifiers is not UNSET else []
-        return _qualifiers_to_entrants(qualifiers)
+        return _qualifiers_to_finishers(qualifiers)
 
     def _build_weights_from_race(
-        self, entrants: list[RankedEntrant]
+        self, finishers: list[RankedFinisher]
     ) -> tuple[list[int], list[int]]:
         """Compute the full `(uids, u16 weights)` vector for the metagraph.
 
@@ -134,7 +143,7 @@ class WeightSetterThread:
         Backend.
         """
         return build_metagraph_weight_vector(
-            entrants,
+            finishers,
             metagraph_hotkeys=list(self.metagraph.hotkeys),
             t_top=self.t_top,
             t_burn=self.t_burn,
@@ -196,9 +205,9 @@ class WeightSetterThread:
         """One iteration of the loop — race-based path with top-miner fallback."""
         self.metagraph.sync()
 
-        entrants: Optional[list[RankedEntrant]] = None
+        finishers: Optional[list[RankedFinisher]] = None
         try:
-            entrants = self._fetch_race_entrants()
+            finishers = self._fetch_race_finishers()
         except BackendError as e:
             # Don't crash the loop — fall back to the top-miner path so a
             # race-endpoint outage doesn't stop weight setting.
@@ -207,11 +216,11 @@ class WeightSetterThread:
             else:
                 logging.error(f"Race fetch error, using fallback: {e}")
 
-        if entrants:
-            uids, weights = self._build_weights_from_race(entrants)
+        if finishers:
+            uids, weights = self._build_weights_from_race(finishers)
             non_zero = sum(1 for w in weights if w > 0)
             logging.info(
-                f"Race-based weight vector: N={len(entrants)} entrants, "
+                f"Race-based weight vector: N={len(finishers)} finishers, "
                 f"{non_zero} non-zero metagraph slots"
             )
         else:

--- a/subnet/validator/weight_setter.py
+++ b/subnet/validator/weight_setter.py
@@ -19,7 +19,7 @@ from .backend_client import BackendClient, BackendError
 from .weight_distribution import (
     RankedFinisher,
     build_metagraph_weight_vector,
-    compute_top_burn_weights,
+    compute_pinned_weights,
 )
 
 
@@ -93,8 +93,10 @@ class WeightSetterThread:
         self.burn_uid = burn_uid
 
         # Fail fast on misconfiguration — the validator process should not
-        # start setting weights with invalid ratios.
-        compute_top_burn_weights(t_top, t_burn)
+        # start setting weights with invalid ratios. tail_sum=0 is the
+        # smallest case (any t_top + t_burn = 1 will pass), validating the
+        # ratio constraint without requiring a representative N.
+        compute_pinned_weights(t_top, t_burn, tail_sum=0)
 
         self._stop_event = threading.Event()
         self._thread: Optional[threading.Thread] = None
@@ -181,7 +183,11 @@ class WeightSetterThread:
         if n == 0:
             return [], []
 
-        top_u16, burn_u16 = compute_top_burn_weights(self.t_top, self.t_burn)
+        # No race tail in the fallback path, so tail_sum=0 — the pinned
+        # weights collapse to the simple two-slot ratio.
+        top_u16, burn_u16 = compute_pinned_weights(
+            self.t_top, self.t_burn, tail_sum=0
+        )
 
         weights = [0] * n
         if 0 <= self.burn_uid < n:


### PR DESCRIPTION
## Description

Today validators set 100% of miner weight to a single top miner (75% burned to uid 0, 25% to top miner). Every other registered miner — including high-scoring agents who already finished a race — has on-chain `Emission[uid] = 0`. Once their `immunity_period` (5000 blocks ≈ 16.6h) expires, they're first in line to be pruned by `get_neuron_to_prune`, which ranks by `(emission asc, reg_block asc, uid asc)`.

The race system makes the standard immunity model insufficient: a miner who finishes a race well may legitimately have to wait days before competing again, so weight cannot reliably arrive within `immunity_period`. Real incident this week: a CLEAN-reviewed agent (`final_score=0.597`, code reviewed) was deregistered before its weight arrived.

This PR distributes weight across the **top half of the most recent completed race's finishers** so legitimate competitors retain a non-zero on-chain emission slot and survive `get_neuron_to_prune` between races.

A finisher is a qualifier with a non-null `race_score` — i.e. the agent ran the race to completion and got scored. Qualifiers who DNF'd or were eliminated mid-race (`race_score=null`) are intentionally **not** protected.

## Allocation model

The top miner receives exactly `t_top` of the chain-normalised emission. The burn uid plus the top-half tail (ranks 2..K) together receive exactly `t_burn`. `t_top + t_burn` must equal 1.

Concretely with the production values `t_top=0.25`, `t_burn=0.75`:

- Burn slot pinned at `U16_MAX = 65535`.
- `total = (U16_MAX + tail_sum) / t_burn` — total grows with N so the burn share is held at exactly 75%.
- `top_u16 = round(t_top * total)` — top miner stays at exactly 25% regardless of N.
- Tail u16 weights are the linear taper `K-1, K-2, ..., 1`. Tail consumes its allocation out of the burn share, **not** out of the top share.

This is a deliberate change from the proportional model in the original ticket spec. Under the proportional model the top miner's share drifted with N (24.97% at N=30, 24.65% at N=100). Operators expect the `t_top` knob to mean exactly that share; this PR honours that contract.

Concrete numbers under the new model:

| N | K | tail_sum | top_u16 | burn_u16 | top % | (burn + tail) % |
|---|---|----------|---------|----------|-------|-----------------|
| 30 | 15 | 105 | 21880 | 65535 | 25.000% | 75.000% |
| 50 | 25 | 300 | 21945 | 65535 | 25.000% | 75.000% |
| 100 | 50 | 1225 | 22253 | 65535 | 25.000% | 75.000% |

## Changes Made

- **`subnet/validator/weight_distribution.py`** (new): pure-function module producing the u16 weight vector.
  - `rank_finishers`: total ordering by `(race_score desc, agent_version_id asc)` so two validators receiving the same finishers (in any order) compute byte-identical rankings.
  - `compute_pinned_weights(t_top, t_burn, tail_sum)`: returns `(top_u16, burn_u16)` such that the chain-normalised vector matches the configured shares exactly. Pins the larger of `t_top`/`t_burn` at `U16_MAX`. Top miner's share is invariant under `tail_sum`.
  - `compute_hotkey_weights`: returns `hotkey -> u16` for the top `floor(N/2)`. Rank 1 = `top_u16`. Ranks 2..K = `K+1-rank` (linear taper, last entry = 1, smallest possible). Bottom 50% absent.
  - `build_metagraph_weight_vector`: maps the hotkey weights onto metagraph indices and adds the burn share at the burn uid.
- **`subnet/validator/weight_setter.py`**: rewritten to scan `get_race_history(limit=5)` newest-first for the most recent `RACE_COMPLETE` race, reduce qualifiers to finishers (drop `race_score=null`), and submit the new u16 vector. The scan-not-just-newest matters: with the current race cadence the newest race is `QUALIFYING_OPEN` / `RACE_RUNNING` for ~24h of every cycle, and we still want last race's finishers protected during that window. `race_score=0.0` finishers are still finishers (they completed but scored zero); they compete for a top-half slot and naturally drop out of the protected set when other finishers outscore them. Fallback path (no completed race in recent history / race endpoint error) preserves the prior top-miner-plus-burn behaviour but emits u16 like the new code path. Backend's `emission_weight` is still honoured as a multiplier on the top slot in the fallback.
- **`subnet/validator/backend_client.py`**: adds `get_race_history(limit=...)` and `get_race_detail(race_id)` wrappers around the SDK accessors.
- **Tests**: 36 unit tests for the algorithm (sizes 10/30/50/100 at `t_top=0.25` and `t_top=0.75`, validation/edge cases, determinism under input shuffle, "top share is exactly t_top" invariant under N, oversized-tail rejection), plus 10 integration tests for the thread (race-based path, scan-past-in-progress, fallback when nothing completed, error handling, partial emission, lifecycle).

## Issue Link

- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing

- `ruff check` clean on the touched files.
- `pytest subnet/tests/validator/test_weight_distribution.py subnet/tests/validator/test_weight_setter.py` → **46/46 pass**.
- Wider `pytest subnet/tests/` is clean except for one unrelated pre-existing failure in `test_backend_client.py::test_claim_work_with_resource_metrics` (SDK shape mismatch in the local venv, not this PR).
- Will verify on staging by checking that the on-chain `Incentive` vector is non-zero for the top half of finishers from the most recent completed race after the next epoch tick — including during the `QUALIFYING_OPEN` / `RACE_RUNNING` windows of the next race — and that the top miner's share is exactly the configured `t_top`.

**Test Results:**

```
$ pytest subnet/tests/validator/test_weight_distribution.py subnet/tests/validator/test_weight_setter.py -q
..............................................                           [100%]
46 passed in 1.21s
```

`test_top_miner_share_is_exactly_t_top_regardless_of_n` parametrises over N=10/30/50/100 and asserts the top miner's normalised share is within `5e-4` of `t_top` for each — the load-bearing property of this PR.

### Automated Testing

Two new test files cover the algorithm and the thread integration. The byte-identical determinism test simulates two validators receiving the finisher list in different orders and asserts the final `(uids, weights_u16)` tuples match.

**Test Command(s):**
```bash
ruff check subnet/validator/weight_setter.py subnet/validator/weight_distribution.py subnet/validator/backend_client.py
pytest subnet/tests/validator/test_weight_distribution.py subnet/tests/validator/test_weight_setter.py -q
```

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**

Module docstrings explain the consensus property (why determinism is load-bearing), what counts as a finisher, the allocation model, and the fallback semantics. No external doc updates needed for this change — operator-facing config (`t_top` / `t_burn`) is pinned in the validator release rather than env-overridable, so the network can't drift between validator instances.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

### Scope — what's in, what's deferred

This PR ships the algorithm change only. Deferred for separate PRs so each piece can be tested in production independently:

1. **Epoch-aligned `set_weights` cadence.** Today the thread fires every `interval_seconds` regardless of epoch. Aligning to the `tempo=360` boundary (~72 min on subnet 15) eliminates vTrust drift from missed epochs and avoids extra submissions when a race finishes mid-epoch.
2. **Validator restart sync.** Wait for the next epoch boundary on startup before submitting.

### Yuma consensus property

Determinism across validators is a hard requirement on subnet 15 (`kappa = 0.5`). If validators submit different weight vectors for the tail, the stake-weighted median collapses to 0 and the protection fails. Three pieces:

1. Same canonical race result (every validator scans `get_race_history(limit=5)` newest-first and picks the first `RACE_COMPLETE` — converges to the same race id as long as Backend serves consistent state).
2. Same finisher filter (drop `race_score=null`) and same ordering function (`rank_finishers` — total over `(score desc, agent_version_id asc)`).
3. Same parameters (`t_top=0.25`, `t_burn=0.75` are pinned constants in `WeightSetterThread`, versioned with the validator release).

### Edge cases handled

- Newest race in progress (`QUALIFYING_OPEN` / `RACE_RUNNING`) → scan past it, use the prior `RACE_COMPLETE`. Last race's finishers stay protected for the whole next cycle.
- Race winner deregistered between race close and weight set → silently dropped, burn share grows slightly. Mirrors prior fallback behaviour.
- Qualifier DNF'd or eliminated mid-race (`race_score=null`) → not a finisher, not protected.
- `race_score=0.0` finisher → still a finisher; competes for a top-half slot, naturally drops out of the protected set when others outscore them.
- No completed race in recent history (fresh subnet, post-rollback) or race endpoint unavailable → fall back to the prior top-miner path (`get_top_agent`), still emitting u16. Weight setting is never silently skipped on transient backend errors.
- Burn uid coincides with a top-half hotkey on small testnet metagraphs → burn weight is additive to that slot, never zeroed.
- N=0 or N=1 finishers → `floor(N/2)=0`, no top-half weight emitted, only the burn slot fires.
- Tail consuming more than `t_burn`'s share (e.g. `t_top=0.99, t_burn=0.01` with a large race) → `compute_pinned_weights` raises rather than emit a negative burn slot. With production `t_top=0.25` this is unreachable for any plausible N.