### PR TITLE
fix(proxy): share inference-allowlist cache across nginx workers

### DIFF
--- a/docker/proxy/nginx.conf.template
+++ b/docker/proxy/nginx.conf.template
@@ -6,6 +6,14 @@ http {
     # Load njs validation script
     js_import validate_model from /etc/nginx/validate_model.js;
 
+    # Cross-worker shared cache for the inference allowlist. njs module-level
+    # vars are per-worker, so 8 workers each cold-start with an empty cache
+    # and 8 simultaneous fetches storm the Backend, where some get 429 and
+    # those workers never warm up. A shared zone lets one successful fetch
+    # serve every worker. 64K holds well under 1KB of state today; the
+    # headroom is for future entries.
+    js_shared_dict_zone zone=oro_models:64K timeout=24h;
+
     # Limit request body size (prevents memory exhaustion from oversized payloads)
     client_max_body_size 10m;
 
@@ -76,7 +84,7 @@ http {
 
         # Internal location: fetch the allowed-models list from the ORO Backend
         # so the proxy stays in sync without an image rebuild. njs subrequests
-        # this on cache miss; per-worker cache TTL lives in validate_model.js.
+        # this on cache miss; shared-cache TTL lives in validate_model.js.
         location = /_backend_models {
             internal;
 

--- a/docker/proxy/validate_model.js
+++ b/docker/proxy/validate_model.js
@@ -2,26 +2,49 @@
 // allowlist before forwarding to Chutes.
 //
 // The allowlist is fetched from the ORO Backend (`GET /v1/public/inference/models`)
-// via the internal `/_backend_models` location. Each nginx worker caches the
-// fetched list for CACHE_TTL_MS. After the cache expires we attempt a refresh;
-// if Backend returns a non-200 (rate-limited, unreachable, malformed), we keep
-// serving the previous allowlist for STALE_GRACE_MS instead of failing closed.
-// Failing closed turns a transient Backend hiccup (e.g. a 429 from the global
-// IP rate limit) into a 503 storm where every inference call is rejected and
-// agent evaluations collapse mid-run.
+// via the internal `/_backend_models` location and cached in an nginx
+// shared-dict zone (`oro_models`, declared in nginx.conf.template) so all
+// worker processes share the same cache. njs module-level vars are
+// per-worker, so the previous per-worker cache made every worker cold-start
+// independently — 8 workers × 1 fetch each can already exhaust the
+// Backend's 100/min global IP rate limit, leaving most workers permanently
+// uncached and answering every inference call with 503.
+//
+// After the cache expires we attempt a refresh; if Backend returns a non-200
+// (rate-limited, unreachable, malformed), we keep serving the previous
+// allowlist for STALE_GRACE_MS instead of failing closed.
 
 var CACHE_TTL_MS = 15 * 60 * 1000;
 // Window beyond CACHE_TTL_MS where we still serve the cached list if a
 // refresh fails. After this we give up and fail closed.
 var STALE_GRACE_MS = 60 * 60 * 1000;
 
-var cachedList = null;
-var cacheExpiresAt = 0;
-var cacheStaleUntil = 0;
+var ZONE = "oro_models";
+var STATE_KEY = "state";
+
+function _readState() {
+  var raw = ngx.shared[ZONE].get(STATE_KEY);
+  if (!raw) {
+    return null;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (e) {
+    return null;
+  }
+}
+
+function _writeState(allowlist, expiresAt) {
+  ngx.shared[ZONE].set(
+    STATE_KEY,
+    JSON.stringify({ allowlist: allowlist, expiresAt: expiresAt })
+  );
+}
 
 function getAllowlist(r, callback) {
-  if (cachedList && Date.now() < cacheExpiresAt) {
-    callback(cachedList);
+  var state = _readState();
+  if (state && state.allowlist && Date.now() < state.expiresAt) {
+    callback(state.allowlist);
     return;
   }
 
@@ -30,12 +53,11 @@ function getAllowlist(r, callback) {
       try {
         var data = JSON.parse(reply.responseText);
         if (data && Array.isArray(data.models) && data.models.length > 0) {
-          cachedList = data.models;
-          cacheExpiresAt = Date.now() + CACHE_TTL_MS;
-          cacheStaleUntil = cacheExpiresAt + STALE_GRACE_MS;
-          callback(cachedList);
+          _writeState(data.models, Date.now() + CACHE_TTL_MS);
+          callback(data.models);
           return;
         }
+        r.error("Backend models response missing or empty 'models' array");
       } catch (e) {
         r.error("Backend models JSON parse failed: " + e.message);
       }
@@ -43,13 +65,19 @@ function getAllowlist(r, callback) {
       r.error("Backend models fetch returned status " + reply.status);
     }
 
-    if (cachedList && Date.now() < cacheStaleUntil) {
-      r.error(
-        "Serving stale allowlist after fetch failure (" +
-          ((cacheStaleUntil - Date.now()) / 1000).toFixed(0) +
-          "s grace remaining)"
-      );
-      callback(cachedList);
+    // Re-read in case another worker just succeeded while this one was
+    // waiting on a failing subrequest.
+    state = _readState();
+    if (state && state.allowlist && Date.now() < state.expiresAt + STALE_GRACE_MS) {
+      var graceLeft = state.expiresAt + STALE_GRACE_MS - Date.now();
+      if (graceLeft < STALE_GRACE_MS) {
+        r.error(
+          "Serving stale allowlist after fetch failure (" +
+            (graceLeft / 1000).toFixed(0) +
+            "s grace remaining)"
+        );
+      }
+      callback(state.allowlist);
       return;
     }
 


### PR DESCRIPTION
## Description

The per-worker njs cache for the inference allowlist was effectively useless. nginx runs 8 worker processes (one per CPU) and each holds its own njs module state, so all 8 workers cold-start with an empty cache. On startup they each issue `GET /v1/public/inference/models` to the Backend within the same second; combined with the validator's normal heartbeat / weight-setter traffic, those 8 fetches push the validator host past Backend's 100/min global IP rate limit and most workers receive 429. Workers that get 429 never populate their cache, miss on every subsequent inference request, retry the fetch, get 429 again, and answer the client with 503. The earlier `STALE_GRACE_MS` fallback (PR #119) didn't help because it only triggers when there *was* a previous cached value, which these workers never had.

Prod data after v1.0.69 rolled (proxy started 2026-05-01 17:57:15, sample at 14 min uptime):
- 753 Backend models fetch attempts, every one 429
- 753 503s back to inference clients
- 0 "Serving stale allowlist" log lines (no fallback path possible — no prior cache)

This PR moves the cache into a shared-dict zone (`oro_models`, declared in `nginx.conf.template`). Any single successful fetch warms the cache for every worker; subsequent cold-start workers read the shared value instead of issuing their own fetch. Cold-start storms can still race for that first fill, but once one worker wins the rest serve from cache. After a refresh fails, we re-read the shared state before falling back to stale, so a worker stuck on its own failing subrequest can still pick up a fresh value another worker committed mid-flight.

## Changes Made

- Add `js_shared_dict_zone zone=oro_models:64K timeout=24h;` to `docker/proxy/nginx.conf.template`.
- Replace per-worker `var cachedList`, `var cacheExpiresAt`, `var cacheStaleUntil` with shared-dict reads/writes (`ngx.shared.oro_models`).
- Re-read the shared state inside the failure branch so a worker waiting on a failing fetch can still pick up a value committed by a peer worker.

## Issue Link

- Related to: N/A (operational follow-up to PR #119)
- Closes: N/A

## Testing

### Manual Testing
No JS test harness in this repo. Verified manually:

1. Cache fresh (Date.now() < state.expiresAt) → callback(state.allowlist), no fetch.
2. Cache empty + fetch 200 → write {allowlist, expiresAt, staleUntil}, callback(allowlist).
3. Cache empty + fetch 429/5xx + peer worker just succeeded → re-read finds fresh state → callback(state.allowlist).
4. Cache empty + fetch 429/5xx + only stale state available → callback(state.allowlist), error logged with grace remaining.
5. Cache empty + fetch 429/5xx + nothing in shared dict at all → callback(null) → 503.

After deploy on prod we should see backend `429` count drop from ~50/min to ~0 once any worker successfully fills the shared cache.

### Automated Testing
N/A — no JS tests in this repo.

**Test Command(s):**
```bash
# n/a
```


## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify): N/A

**Documentation Changes:**
File header in `validate_model.js` rewritten to describe why the cache is shared across workers (the cold-start storm explanation). Inline comment on the `js_shared_dict_zone` directive in `nginx.conf.template`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

This builds on PR #119 (stale-cache fallback). After merge, **must burn in on staging first** before promoting to stable; the previous proxy bump skipped staging and Seth correctly flagged that as a violation. Tag and publish via `:latest`, leave staging alone for a few cycles, then promote separately on explicit approval.