### PR TITLE
refactor(types): hoist validator dataclasses + add shared TypedDicts

### DIFF
--- a/src/agent/reasoning_scorer.py
+++ b/src/agent/reasoning_scorer.py
@@ -15,6 +15,8 @@ from typing import Any
 
 import requests
 
+from src.agent.types import Dialogue, JudgeResult
+
 # Base delay for rate-limit retries (seconds). Matches ProxyClient convention.
 RATE_LIMIT_RETRY_DELAY = 5
 
@@ -456,7 +458,7 @@ def _summarize_proxy_calls(proxy_calls: list[dict[str, Any]]) -> str:
     return "\n".join(lines)
 
 
-def format_trajectory_for_judge(dialogue: list[dict[str, Any]]) -> str:
+def format_trajectory_for_judge(dialogue: Dialogue) -> str:
     """Format a dialogue trajectory into a readable string for the LLM judge.
 
     Truncates thinking text and tool results per step to keep total length
@@ -586,11 +588,11 @@ def _rotate_and_backoff(model_idx: int, attempt: int) -> int:
 
 
 def score_reasoning_quality(
-    dialogue: list[dict[str, Any]],
+    dialogue: Dialogue,
     api_key: str,
     proxy_url: str = PROXY_URL,
     max_retries: int = 8,
-) -> dict[str, Any]:
+) -> JudgeResult:
     """Score reasoning quality of an agent trajectory using an LLM judge.
 
     Retries with model rotation on transient failures (429, 502-504).

--- a/src/agent/types.py
+++ b/src/agent/types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Any, List, TypedDict
 
 
 class ScoreDict(TypedDict, total=False):
@@ -35,3 +35,84 @@ class SandboxMetadata(TypedDict):
     exit_code: int | None
     duration_seconds: float | None
     stderr_tail: str | None
+
+
+class DialogueMessage(TypedDict, total=False):
+    """The `message` sub-dict of a dialogue step.
+
+    Subset of think/tool_call/response — keys are present only when the
+    agent emitted that role on this step.
+    """
+    think: str
+    tool_call: List[dict]
+    response: str
+
+
+class DialogueCompletion(TypedDict):
+    """The `completion` sub-dict of a dialogue step."""
+    reasoning_content: str
+    content: str
+    message: DialogueMessage
+
+
+class DialogueExtraInfo(TypedDict):
+    """The `extra_info` sub-dict of a dialogue step."""
+    step: int
+    query: str
+    timestamp: int
+
+
+class DialogueStep(TypedDict):
+    """One step in an agent trajectory, as emitted by `create_dialogue_step`."""
+    completion: DialogueCompletion
+    extra_info: DialogueExtraInfo
+
+
+# A complete agent trajectory: list of steps in execution order.
+Dialogue = List[DialogueStep]
+
+
+class ProblemDict(TypedDict, total=False):
+    """A single problem record as loaded from a problem suite or fetched
+    from the backend.
+
+    `query` and `category` are always present; the rest are optional and
+    depend on the source (suite vs backend) and category (product/shop/
+    voucher).
+    """
+    query: str
+    category: str
+    reward: Any
+    difficulty: str
+    title: str
+    reward_title_embeddings: Any
+    problem_id: str
+
+
+class JudgeResult(TypedDict):
+    """Return value of `score_reasoning_quality`.
+
+    `score` is 0.0–1.0; `model` is the Chutes model that returned the
+    parseable JSON, or "" when the judge failed entirely.
+    """
+    score: float
+    explanation: str
+    model: str
+    inference_failed: int
+    inference_total: int
+
+
+class ReasoningSummary(TypedDict):
+    """Aggregate reasoning metrics returned by
+    `ProgressReporter.get_reasoning_data` for run-level score components.
+    """
+    reasoning_quality: float
+    reasoning_coefficient: float
+    judge_inference_failed: int
+    judge_inference_total: int
+
+
+class ScoreComponentsSummary(TypedDict, total=False):
+    """Per-problem reasoning detail attached to a `ProblemProgressUpdate`."""
+    reasoning_explanation: str
+    reasoning_model: str

--- a/subnet/validator/backend_client.py
+++ b/subnet/validator/backend_client.py
@@ -48,13 +48,12 @@ from oro_sdk.models.top_agent_response import TopAgentResponse
 from oro_sdk.types import UNSET, Unset, Response
 from oro_sdk import errors as sdk_errors
 
-
-_HEARTBEAT_METRIC_KEYS = ("cpu_pct", "ram_pct", "disk_pct", "docker_container_count")
+from .types import ResourceMetrics
 
 
 def _build_heartbeat_body(
     service_versions: Optional[dict[str, str]],
-    resource_metrics: Optional[dict[str, Any]],
+    resource_metrics: Optional[ResourceMetrics],
 ) -> Optional[SdkHeartbeatRequest]:
     """Build an SdkHeartbeatRequest from optional inputs, or None if both empty.
 
@@ -64,7 +63,7 @@ def _build_heartbeat_body(
     if service_versions is not None:
         body_kwargs["service_versions"] = service_versions
     if resource_metrics:
-        for key in _HEARTBEAT_METRIC_KEYS:
+        for key in ResourceMetrics.__annotations__:
             value = resource_metrics.get(key)
             if value is not None:
                 body_kwargs[key] = value
@@ -353,7 +352,7 @@ class BackendClient:
     def claim_work(
         self,
         service_versions: Optional[dict[str, str]] = None,
-        resource_metrics: Optional[dict[str, Any]] = None,
+        resource_metrics: Optional[ResourceMetrics] = None,
     ) -> Optional[ClaimWorkResponse]:
         """Claim the next available work item.
 
@@ -390,7 +389,7 @@ class BackendClient:
         self,
         eval_run_id: UUID,
         service_versions: Optional[dict[str, str]] = None,
-        resource_metrics: Optional[dict[str, Any]] = None,
+        resource_metrics: Optional[ResourceMetrics] = None,
     ) -> HeartbeatResponse:
         """Send heartbeat to maintain lease.
 

--- a/subnet/validator/heartbeat_manager.py
+++ b/subnet/validator/heartbeat_manager.py
@@ -2,11 +2,12 @@
 
 import threading
 import logging
-from typing import Any, Callable, Optional
+from typing import Callable, Optional
 from uuid import UUID
 
 from .backend_client import BackendClient, BackendError
 from .metrics import HEARTBEAT_TOTAL
+from .types import ResourceMetrics
 
 
 class HeartbeatManager:
@@ -23,7 +24,7 @@ class HeartbeatManager:
         eval_run_id: UUID,
         interval_seconds: int = 30,
         service_versions: dict[str, str] | None = None,
-        resource_metrics_provider: Optional[Callable[[], dict[str, Any]]] = None,
+        resource_metrics_provider: Optional[Callable[[], ResourceMetrics]] = None,
     ):
         self.backend_client = backend_client
         self.eval_run_id = eval_run_id
@@ -74,7 +75,7 @@ class HeartbeatManager:
         """Background thread main loop."""
         while not self._stop_event.is_set():
             try:
-                resource_metrics: Optional[dict[str, Any]] = None
+                resource_metrics: Optional[ResourceMetrics] = None
                 if self.resource_metrics_provider is not None:
                     try:
                         resource_metrics = self.resource_metrics_provider()

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -19,7 +19,7 @@ from oro_sdk.models.claim_work_response import ClaimWorkResponse
 from oro_sdk.models.problem_progress_update import ProblemProgressUpdate
 from oro_sdk.types import Unset
 from src.agent.scoring import blend_final_score
-from src.agent.types import SandboxMetadata
+from src.agent.types import ProblemDict, SandboxMetadata
 from .backend_client import BackendClient, BackendError
 from .heartbeat_manager import HeartbeatManager
 from .output_split import split_output_by_problem
@@ -619,7 +619,7 @@ class Validator:
 
     def fetch_problems(
         self, suite_id: int, eval_run_id_str: str
-    ) -> tuple[Optional[Path], list[UUID], list[dict]]:
+    ) -> tuple[Optional[Path], list[UUID], list[ProblemDict]]:
         """Fetch problems from Backend API and save sanitized version to temp file.
 
         The full problem data (with reward/voucher) is returned in memory for

--- a/subnet/validator/output_watcher.py
+++ b/subnet/validator/output_watcher.py
@@ -13,11 +13,12 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Iterator, Optional
 
 from bittensor.utils.btlogging import logging
 
 from src.agent.sandbox_status import SandboxProblemStatus
+from src.agent.types import Dialogue
 
 
 @dataclass
@@ -38,7 +39,7 @@ class ProblemRecord:
     inference_failure_count: int
     inference_total: int
     error: Optional[ErrorInfo]
-    dialogue: Optional[List[Dict[str, Any]]]
+    dialogue: Optional[Dialogue]
 
 
 class OutputWatcher:

--- a/subnet/validator/progress_reporter.py
+++ b/subnet/validator/progress_reporter.py
@@ -12,7 +12,6 @@ import time
 import traceback
 import threading
 from concurrent.futures import Future, ThreadPoolExecutor
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional, List, Dict, Any
 from uuid import UUID
@@ -24,44 +23,18 @@ from bittensor.utils.btlogging import logging
 from src.agent.problem_scorer import ProblemScorer, clear_product_cache
 from src.agent.sandbox_status import SandboxProblemStatus
 from src.agent.scoring import is_problem_successful, compute_aggregate, reasoning_coefficient
-from src.agent.types import ScoreDict
+from src.agent.types import (
+    AggregateScore,
+    ProblemDict,
+    ReasoningSummary,
+    ScoreComponentsSummary,
+)
 from subnet.sandbox import attach_title_embeddings
 import requests
 
 from .backend_client import BackendClient, BackendError
 from .output_watcher import ErrorInfo, OutputWatcher
-
-
-@dataclass
-class EnvelopeMeta:
-    """Per-problem metadata captured from the sandbox envelope line.
-
-    Held under ``ProgressReporter._lock`` and read by both dispatch (terminal
-    branch) and the scoring worker thread.
-    """
-
-    inference_failure_count: int
-    inference_total: int
-    execution_time: float
-
-
-@dataclass
-class ProblemResult:
-    """Single source of truth for one problem's scoring outcome."""
-
-    problem_id: str
-    category: str
-    status: ProblemStatus
-    score: float
-    score_dict: ScoreDict = field(default_factory=dict)
-    inference_failures: int = 0
-    inference_total: int = 0
-    reasoning_score: float | None = None
-    reasoning_explanation: str = ""
-    reasoning_model: str = ""
-    reasoning_inf_failed: int = 0
-    reasoning_inf_total: int = 0
-    execution_time: float | None = None
+from .types import EnvelopeMeta, ProblemResult
 
 
 # Default number of concurrent scoring workers
@@ -86,7 +59,7 @@ class ProgressReporter:
         backend_client: BackendClient,
         eval_run_id: UUID,
         output_file: Path,
-        problems: List[Dict[str, Any]],
+        problems: List[ProblemDict],
         workspace_dir: Path,
         poll_interval: float = 1.0,
         scoring_timeout: float = 900.0,
@@ -132,7 +105,7 @@ class ProgressReporter:
         self._scoring_futures: Dict[str, Future] = {}
 
         # Build problem_id -> problem lookup
-        self._id_to_problem: Dict[str, Dict[str, Any]] = {}
+        self._id_to_problem: Dict[str, ProblemDict] = {}
         for problem in problems:
             problem_id = str(problem.get("problem_id") or problem.get("id"))
             if problem_id:
@@ -213,7 +186,7 @@ class ProgressReporter:
                 )
         self._scoring_executor.shutdown(wait=False)
 
-    def get_aggregate_score(self) -> Optional[Dict[str, Any]]:
+    def get_aggregate_score(self) -> Optional[AggregateScore]:
         """Compute aggregate score on demand from _results."""
         total = self._total_problems if self._total_problems > 0 else 1
 
@@ -238,7 +211,7 @@ class ProgressReporter:
 
         return aggregate
 
-    def get_reasoning_data(self) -> Dict[str, Any]:
+    def get_reasoning_data(self) -> ReasoningSummary:
         """Return aggregate reasoning metrics for run-level score_components.
 
         Per-problem reasoning data is now sent via progress reports.
@@ -623,7 +596,7 @@ class ProgressReporter:
         updates = []
         for r in results:
             # Include per-problem reasoning data if judge ran
-            scs = None
+            scs: Optional[ScoreComponentsSummary] = None
             if r.reasoning_score is not None:
                 scs = {
                     "reasoning_explanation": r.reasoning_explanation,

--- a/subnet/validator/resource_collector.py
+++ b/subnet/validator/resource_collector.py
@@ -10,22 +10,17 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
-from typing import Any, Callable, TypedDict
+from typing import Any, Callable
 
 import psutil
+
+from .types import ResourceMetrics
 
 logger = logging.getLogger(__name__)
 
 # Sandbox workdirs live under SANDBOX_DIR; fall back to root when unset
 # since that's the volume holding the Docker image cache anyway.
 _SANDBOX_DIR_ENV = "SANDBOX_DIR"
-
-
-class ResourceMetrics(TypedDict, total=False):
-    cpu_pct: float
-    ram_pct: float
-    disk_pct: float
-    docker_container_count: int
 
 
 def _docker_container_count() -> int:

--- a/subnet/validator/types.py
+++ b/subnet/validator/types.py
@@ -1,0 +1,60 @@
+"""Validator-internal data types shared across modules.
+
+Agent-level types live in :mod:`src.agent.types`; this module is for
+state types that only validator components produce or consume.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, TypedDict
+
+from oro_sdk.models import ProblemStatus
+
+from src.agent.types import ScoreDict
+
+
+class ResourceMetrics(TypedDict, total=False):
+    """Host resource utilisation snapshot reported on the heartbeat path."""
+    cpu_pct: float
+    ram_pct: float
+    disk_pct: float
+    docker_container_count: int
+
+
+# Tuple of (metric name, collector callable). The collector raises on
+# failure so the caller can decide whether to record the metric or skip
+# it; never returns sentinel values.
+ResourceCollector = tuple[str, Callable[[], Any]]
+
+
+@dataclass
+class EnvelopeMeta:
+    """Per-problem metadata captured from the sandbox envelope line.
+
+    Held under ``ProgressReporter._lock`` and read by both dispatch (terminal
+    branch) and the scoring worker thread.
+    """
+
+    inference_failure_count: int
+    inference_total: int
+    execution_time: float
+
+
+@dataclass
+class ProblemResult:
+    """Single source of truth for one problem's scoring outcome."""
+
+    problem_id: str
+    category: str
+    status: ProblemStatus
+    score: float
+    score_dict: ScoreDict = field(default_factory=dict)
+    inference_failures: int = 0
+    inference_total: int = 0
+    reasoning_score: float | None = None
+    reasoning_explanation: str = ""
+    reasoning_model: str = ""
+    reasoning_inf_failed: int = 0
+    reasoning_inf_total: int = 0
+    execution_time: float | None = None

--- a/subnet/validator/types.py
+++ b/subnet/validator/types.py
@@ -7,7 +7,7 @@ state types that only validator components produce or consume.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Callable, TypedDict
+from typing import TypedDict
 
 from oro_sdk.models import ProblemStatus
 
@@ -20,12 +20,6 @@ class ResourceMetrics(TypedDict, total=False):
     ram_pct: float
     disk_pct: float
     docker_container_count: int
-
-
-# Tuple of (metric name, collector callable). The collector raises on
-# failure so the caller can decide whether to record the metric or skip
-# it; never returns sentinel values.
-ResourceCollector = tuple[str, Callable[[], Any]]
 
 
 @dataclass


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does. Include the motivation and context if relevant. -->

Type-only refactor that tightens the implicit data contract between the validator, the scorers, the reasoning judge, and the backend. Several cross-cutting payloads were previously typed as `Dict[str, Any]` (or as local dataclasses defined inside the module that produces them), so the shape of a dialogue, a problem dict, a judge result, etc. was only documented in prose. This PR introduces shared TypedDicts and dataclasses for those payloads and updates the producers/consumers to use them.

No runtime behavior changes — every replacement is a static-type rename. Local pytest run (308/309 — the one failure is a pre-existing local-venv `oro-sdk` version mismatch already seen before this branch) and `ruff check` both clean.

## Changes Made

<!-- List the key changes made in this PR: -->
- New `subnet/validator/types.py`: hoists the previously-local `EnvelopeMeta` and `ProblemResult` dataclasses out of `progress_reporter.py`, plus the `ResourceMetrics` TypedDict out of `resource_collector.py`.
- Extends `src/agent/types.py` with cross-cutting TypedDicts:
  - `DialogueMessage`, `DialogueCompletion`, `DialogueExtraInfo`, `DialogueStep`, and the `Dialogue = list[DialogueStep]` alias for the trajectory shape produced by `create_dialogue_step` and consumed by the judge.
  - `ProblemDict` for the problem schema loaded from a suite or fetched from the backend.
  - `JudgeResult` for the return value of `score_reasoning_quality`.
  - `ReasoningSummary` for the aggregate dict returned by `ProgressReporter.get_reasoning_data`.
  - `ScoreComponentsSummary` for the per-problem detail attached to a `ProblemProgressUpdate`.
- Replaces `Dict[str, Any]` annotations at module boundaries:
  - `ProgressReporter.__init__(problems: List[ProblemDict])` and the `_id_to_problem` map.
  - `ProgressReporter.get_aggregate_score()` → `Optional[AggregateScore]`, `get_reasoning_data()` → `ReasoningSummary`.
  - `score_components_summary` is annotated `Optional[ScoreComponentsSummary]`.
  - `score_reasoning_quality` and `format_trajectory_for_judge` take `Dialogue`; the former returns `JudgeResult`.
  - `OutputWatcher.ProblemRecord.dialogue` is `Optional[Dialogue]`.
  - `Validator.fetch_problems` returns `list[ProblemDict]`.

## Issue Link

<!-- Link to the related issue(s). Use "Closes #issue_number" or "Fixes #issue_number" if this PR resolves an issue: -->
- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing
<!-- Describe the manual testing steps you performed: -->

Verified the types module imports cleanly in isolation, then ran the full test suite. The one local failure
(`test_claim_work_with_resource_metrics`) is the same pre-existing local-venv mismatch on `oro-sdk` we saw on the previous PR — not caused by this change and not present in the version pinned by `docker/validator/pyproject.toml`.

**Test Results:**
<!-- Provide details about test results, including any metrics or outputs: -->

```
308 passed, 1 failed (pre-existing local env), 2 warnings in 18.20s
```

### Automated Testing
<!-- Describe any automated tests that were run like unit tests, integration tests, scripts, etc.: -->

Same CI matrix as before — `pytest --ignore=tests/integration -v --cov=src ...` plus `ruff check`.

**Test Command(s):**
```bash
pytest --ignore=tests/integration -v --cov=src --cov-report=term-missing --cov-report=html
ruff check
```


## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**

Module + class docstrings on the new TypedDicts and on `subnet/validator/types.py`.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

`score_components` (the run-level component dict on `_complete_run`) is intentionally left as `Optional[Dict[str, Any]]` — its two call sites pass either an `AggregateScore`-shaped dict or `{"success_rate": float}`, and constraining the annotation today would either narrow inaccurately or invent an overly broad union. Deferred to the validator-main decomposition where the surface settles.