### PR TITLE
fix(validator): shadow only the new race-path, keep fallback live (ORO-1008)

### DIFF
--- a/subnet/tests/validator/test_weight_setter.py
+++ b/subnet/tests/validator/test_weight_setter.py
@@ -360,10 +360,14 @@ class TestWeightSetterThread:
         top_u16, _ = compute_pinned_weights(0.25, 0.75, tail_sum=3)
         assert weights[1] == top_u16  # rank-1 finisher protected
 
-    def test_shadow_mode_skips_chain_call(
+    def test_shadow_mode_no_race_uses_fallback(
         self, mock_backend_client, mock_subtensor, mock_metagraph, mock_wallet
     ):
-        """shadow_mode=True: weight vector is computed but never submitted."""
+        """shadow_mode=True with no completed race: still submits via fallback.
+
+        Shadow mode must never silently stop weight setting; the legacy
+        top-miner path stays live so prod doesn't lose vTrust on deploy.
+        """
         setter = WeightSetterThread(
             backend_client=mock_backend_client,
             subtensor=mock_subtensor,
@@ -377,4 +381,60 @@ class TestWeightSetterThread:
         time.sleep(0.15)
         setter.stop()
 
-        mock_subtensor.set_weights.assert_not_called()
+        mock_subtensor.set_weights.assert_called()
+        weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
+        top_u16, burn_u16 = compute_pinned_weights(0.25, 0.75, tail_sum=0)
+        assert weights[0] == burn_u16
+        assert weights[1] == top_u16  # 5GrwvaEF... fixture top miner
+
+    def test_shadow_mode_with_race_submits_fallback_vector(
+        self, mock_backend_client, mock_subtensor, mock_wallet
+    ):
+        """shadow_mode=True with a completed race: submits the legacy
+        top-miner vector (NOT the race-based one), even though a race
+        result is available. New algorithm only runs in live mode.
+        """
+        finishers = [
+            {
+                "miner_hotkey": f"5Hotkey{i}",
+                "agent_version_id": str(uuid4()),
+                "race_score": 0.9 - i * 0.1,
+            }
+            for i in range(6)
+        ]
+
+        metagraph = MagicMock()
+        metagraph.hotkeys = [
+            "5BurnUid",
+            "5GrwvaEF...",  # fallback top-miner fixture hotkey
+        ] + [f["miner_hotkey"] for f in finishers]
+        metagraph.uids = list(range(len(metagraph.hotkeys)))
+
+        completed_id = uuid4()
+        mock_backend_client.get_race_history.return_value = _race_complete_history(
+            completed_id
+        )
+        mock_backend_client.get_race_detail.return_value = _race_detail(finishers)
+
+        setter = WeightSetterThread(
+            backend_client=mock_backend_client,
+            subtensor=mock_subtensor,
+            metagraph=metagraph,
+            wallet=mock_wallet,
+            netuid=1,
+            interval_seconds=0.1,
+            shadow_mode=True,
+        )
+        setter.start()
+        time.sleep(0.15)
+        setter.stop()
+
+        mock_subtensor.set_weights.assert_called()
+        weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
+        top_u16, burn_u16 = compute_pinned_weights(0.25, 0.75, tail_sum=0)
+        # Fallback vector: only burn slot + top-miner slot get weight,
+        # race finishers (uids 2..7) all stay at 0 because the race
+        # path was suppressed by shadow_mode.
+        assert weights[0] == burn_u16
+        assert weights[1] == top_u16
+        assert all(w == 0 for w in weights[2:])

--- a/subnet/validator/weight_setter.py
+++ b/subnet/validator/weight_setter.py
@@ -226,20 +226,7 @@ class WeightSetterThread:
 
     def _submit_weights(self, uids: list[int], weights: list[int]) -> None:
         """Push `uids` / `weights` to the chain. No retries — the loop's
-        next tick will retry on transient blockchain failures.
-
-        In shadow mode, log the would-be submission and skip the chain call
-        so the new distribution can be exercised on a live validator without
-        actually moving emissions.
-        """
-        if self.shadow_mode:
-            non_zero = [(u, w) for u, w in zip(uids, weights) if w > 0]
-            logging.info(
-                f"[SHADOW] would set_weights netuid={self.netuid} "
-                f"non_zero={len(non_zero)} total_u16={sum(weights)} "
-                f"vector={non_zero}"
-            )
-            return
+        next tick will retry on transient blockchain failures."""
         self.subtensor.set_weights(
             netuid=self.netuid,
             wallet=self.wallet,
@@ -248,8 +235,32 @@ class WeightSetterThread:
             wait_for_inclusion=True,
         )
 
+    def _log_shadow_race_vector(self, finishers: list[RankedFinisher]) -> None:
+        """Compute the would-be race-based vector and log it without submitting.
+
+        Used in shadow mode to verify the new distribution against real race
+        results while the legacy top-miner fallback continues to set weights
+        on chain — so a deploy can't accidentally stop weight setting.
+        """
+        uids, weights = self._build_weights_from_race(finishers)
+        non_zero = [(u, w) for u, w in zip(uids, weights) if w > 0]
+        logging.info(
+            f"[SHADOW] race-based vector (not submitted) "
+            f"netuid={self.netuid} N={len(finishers)} "
+            f"non_zero={len(non_zero)} total_u16={sum(weights)} "
+            f"vector={non_zero}"
+        )
+
     def _tick(self) -> None:
-        """One iteration of the loop — race-based path with top-miner fallback."""
+        """One iteration of the loop.
+
+        Shadow mode: always submit via the legacy top-miner fallback so prod
+        keeps setting weights, but additionally log the race-based vector
+        that *would* have been submitted for offline verification.
+
+        Live mode: submit the race-based vector when a completed race is
+        available, otherwise fall back to top-miner.
+        """
         self.metagraph.sync()
 
         finishers: Optional[list[RankedFinisher]] = None
@@ -263,7 +274,7 @@ class WeightSetterThread:
             else:
                 logging.error(f"Race fetch error, using fallback: {e}")
 
-        if finishers:
+        if finishers and not self.shadow_mode:
             uids, weights = self._build_weights_from_race(finishers)
             non_zero = sum(1 for w in weights if w > 0)
             logging.info(
@@ -271,6 +282,8 @@ class WeightSetterThread:
                 f"{non_zero} non-zero metagraph slots"
             )
         else:
+            if finishers and self.shadow_mode:
+                self._log_shadow_race_vector(finishers)
             top = self.backend_client.get_top_miner()
             emission_wt = (
                 top.emission_weight
@@ -278,8 +291,9 @@ class WeightSetterThread:
                 else 1.0
             )
             logging.info(
-                f"No completed race available — using top-miner fallback "
-                f"(top={top.top_miner_hotkey}, emission_weight={emission_wt:.3f})"
+                f"Using top-miner weight path "
+                f"(top={top.top_miner_hotkey}, emission_weight={emission_wt:.3f}, "
+                f"shadow_mode={self.shadow_mode})"
             )
             uids, weights = self._build_weights_top_miner_fallback(
                 top.top_miner_hotkey, emission_wt=emission_wt
@@ -290,10 +304,7 @@ class WeightSetterThread:
             return
 
         self._submit_weights(uids, weights)
-        if self.shadow_mode:
-            logging.info("Shadow mode: skipped on-chain weight submission")
-        else:
-            logging.info("Successfully set weights")
+        logging.info("Successfully set weights")
 
     def _run(self) -> None:
         """Background thread main loop."""


### PR DESCRIPTION
## Description

The shadow mode in #127/#128 short-circuited \`_submit_weights\` entirely, so v1.0.76 on staging stopped setting any weights. Promoting that to prod would drop vTrust because prod also wouldn't submit until \`ORO_WEIGHT_SETTER_LIVE=true\` was explicitly set on every host.

Correct intent: shadow mode should run the new top-50% race-based vector through compute + log only, while the legacy 25/75 top-miner fallback continues to set weights on chain. That way the new algorithm gets exercised against real race data on a live validator without any risk of breaking weight setting on prod.

## Changes Made

- \`_submit_weights\` always submits — no shadow short-circuit.
- New \`_log_shadow_race_vector\` helper builds the would-be race vector and logs it as \`[SHADOW] race-based vector (not submitted) ...\` without touching the chain.
- \`_tick\` now: if shadow + finishers → log race vector + submit fallback; if live + finishers → submit race vector; otherwise → submit fallback (unchanged).
- Updated \`test_shadow_mode_skips_chain_call\` → \`test_shadow_mode_no_race_uses_fallback\` (assert fallback fires).
- Added \`test_shadow_mode_with_race_submits_fallback_vector\` — asserts fallback vector is submitted, not race vector, when shadow + race both present.

## Issue Link

- Related to: ORO-1008
- Closes:

## Testing

### Manual Testing
After v1.0.77 deploys to staging:
- Boot log: \`shadow_mode=True\`.
- Each tick: \`[SHADOW] race-based vector (not submitted) ...\` + \`Successfully set weights\` (fallback fired).
- Chain Weights[469][uid] updated each tick (LastUpdate age stays low).

**Test Results:**
Pending staging deploy.

### Automated Testing
48 weight tests pass (47 prior + 1 new shadow+race coverage).

**Test Command(s):**
\`\`\`bash
.venv/bin/python -m pytest subnet/tests/validator/test_weight_setter.py subnet/tests/validator/test_weight_distribution.py -q
\`\`\`

## Documentation

- [x] Code comments added/updated
- [ ] README updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
Inline docstrings on \`_log_shadow_race_vector\` and \`_tick\` document the dual-path behaviour.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

After merge + tag v1.0.77, prod can be promoted with no operator action — fallback path keeps prod weights flowing exactly as today. \`ORO_WEIGHT_SETTER_LIVE=true\` is only flipped once we've verified shadow logs match expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)