### PR TITLE
fix(validator): emission_weight is the literal top share, not a multiplier (ORO-1008)

### DIFF
--- a/subnet/tests/validator/test_weight_setter.py
+++ b/subnet/tests/validator/test_weight_setter.py
@@ -149,14 +149,14 @@ class TestWeightSetterThread:
 
         mock_subtensor.set_weights.assert_called()
         weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
-        _, burn_u16 = compute_pinned_weights(0.25, 0.75, tail_sum=0)
-        assert weights[0] == burn_u16
+        # Top missing AND emission_wt=1.0 → all to burn fallback.
+        assert weights[0] == 65535
         assert all(w == 0 for w in weights[1:])
 
     def test_fallback_top_miner_full_emission(
         self, mock_backend_client, mock_subtensor, mock_metagraph, mock_wallet
     ):
-        """emission_weight == 1.0 → top miner gets full top_u16, burn slot full burn_u16."""
+        """emission_weight=1.0 → 100% to top, 0% to burn (literal share)."""
         setter = WeightSetterThread(
             backend_client=mock_backend_client,
             subtensor=mock_subtensor,
@@ -170,22 +170,22 @@ class TestWeightSetterThread:
         setter.stop()
 
         weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
-        top_u16, burn_u16 = compute_pinned_weights(0.25, 0.75, tail_sum=0)
-        assert weights[0] == burn_u16  # uid 0 = burn
-        assert weights[1] == top_u16  # 5GrwvaEF... index in fixture
+        top_u16, burn_u16 = compute_pinned_weights(1.0, 0.0, tail_sum=0)
+        assert weights[0] == burn_u16  # 0 — no burn share
+        assert weights[1] == top_u16  # 65535 — full top share
         assert weights[2] == 0
 
-    def test_fallback_emission_weight_partial(
+    def test_fallback_emission_weight_quarter(
         self, mock_backend_client, mock_subtensor, mock_metagraph, mock_wallet
     ):
-        """emission_weight=0.5 scales top slot to half top_u16; burn slot keeps full share."""
+        """emission_weight=0.25 → 25% top / 75% burn (matches pre-rewrite behaviour)."""
         mock_backend_client.get_top_miner.return_value = TopAgentResponse(
             suite_id=789,
             top_agent_version_id=UUID("87654321-4321-4321-4321-210987654321"),
             top_miner_hotkey="5GrwvaEF...",
             top_score=0.92,
             computed_at=datetime.now(),
-            emission_weight=0.5,
+            emission_weight=0.25,
         )
         setter = WeightSetterThread(
             backend_client=mock_backend_client,
@@ -201,8 +201,9 @@ class TestWeightSetterThread:
 
         weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
         top_u16, burn_u16 = compute_pinned_weights(0.25, 0.75, tail_sum=0)
-        assert weights[0] == burn_u16
-        assert weights[1] == round(top_u16 * 0.5)
+        # Burn pinned at u16::MAX, top derived = 21845 → 25/75 split.
+        assert weights[0] == burn_u16  # 65535
+        assert weights[1] == top_u16  # 21845
 
     def test_continues_on_error(
         self, mock_backend_client, mock_subtensor, mock_metagraph, mock_wallet
@@ -383,7 +384,8 @@ class TestWeightSetterThread:
 
         mock_subtensor.set_weights.assert_called()
         weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
-        top_u16, burn_u16 = compute_pinned_weights(0.25, 0.75, tail_sum=0)
+        # Default fixture: emission_weight unset → 1.0 → 100% top, 0% burn.
+        top_u16, burn_u16 = compute_pinned_weights(1.0, 0.0, tail_sum=0)
         assert weights[0] == burn_u16
         assert weights[1] == top_u16  # 5GrwvaEF... fixture top miner
 
@@ -431,10 +433,12 @@ class TestWeightSetterThread:
 
         mock_subtensor.set_weights.assert_called()
         weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
-        top_u16, burn_u16 = compute_pinned_weights(0.25, 0.75, tail_sum=0)
-        # Fallback vector: only burn slot + top-miner slot get weight,
-        # race finishers (uids 2..7) all stay at 0 because the race
-        # path was suppressed by shadow_mode.
+        # Default fixture: emission_weight unset → 1.0 → fallback puts
+        # full top share in uid 1, zero in burn.
+        top_u16, burn_u16 = compute_pinned_weights(1.0, 0.0, tail_sum=0)
+        # Fallback vector: only top-miner slot gets weight here; race
+        # finishers (uids 2..7) all stay at 0 because the race path was
+        # suppressed by shadow_mode.
         assert weights[0] == burn_u16
         assert weights[1] == top_u16
         assert all(w == 0 for w in weights[2:])

--- a/subnet/validator/weight_setter.py
+++ b/subnet/validator/weight_setter.py
@@ -187,18 +187,24 @@ class WeightSetterThread:
         """Legacy fallback: top miner gets one slot, rest goes to burn uid.
 
         Used while the subnet has no completed race yet, or when the race
-        endpoint is unavailable. Honours Backend's `emission_weight` so the
-        same operator-knob still controls the top/burn split during the
-        transition window.
+        endpoint is unavailable.
+
+        `emission_weight` from Backend is the LITERAL top share, matching
+        pre-rewrite semantics: 0.25 means 25% top / 75% burn, 1.0 means
+        100% top / 0% burn. Backend's value drives the split, the
+        validator's `t_top`/`t_burn` configuration is only consulted by
+        the race-based path.
         """
         n = len(self.metagraph.hotkeys)
         if n == 0:
             return [], []
 
-        # No race tail in the fallback path, so tail_sum=0 — the pinned
-        # weights collapse to the simple two-slot ratio.
+        # `compute_pinned_weights` pins the larger share at u16::MAX and
+        # derives the smaller — same algorithm as the race path, just
+        # parameterised by Backend's emission_wt instead of the static
+        # t_top/t_burn config.
         top_u16, burn_u16 = compute_pinned_weights(
-            self.t_top, self.t_burn, tail_sum=0
+            emission_wt, 1.0 - emission_wt, tail_sum=0
         )
 
         weights = [0] * n
@@ -211,16 +217,15 @@ class WeightSetterThread:
                 f"Top miner {top_miner_hotkey} not found in metagraph, "
                 "burning all emissions to uid 0"
             )
+            # Route everything to burn so we still set weights, even if
+            # emission_wt=1.0 left burn_u16 at 0.
+            weights[0] = 65535
             return list(range(n)), weights
 
-        # `emission_weight` < 1 means Backend asked for a smaller-than-
-        # configured top share (e.g. challenger margin not yet earned).
-        # Scale the top u16 by it; the burn slot keeps its full share.
-        scaled_top = int(round(top_u16 * emission_wt))
         if top_idx == 0:
-            weights[0] += scaled_top
+            weights[0] += top_u16
         else:
-            weights[top_idx] = scaled_top
+            weights[top_idx] = top_u16
 
         return list(range(n)), weights
 


### PR DESCRIPTION
## Description

Caught while validating shadow output on staging. Backend has been sending emission_weight=0.250 (the long-standing value meaning "25% to top, 75% to burn"). Pre-PR120 the validator obeyed that literal split. The PR120 rewrite re-interpreted emission_weight as a multiplier on top of the already-pinned t_top/t_burn (0.25/0.75) config, so 0.250 produced 21845 * 0.25 = 5461 → an effective **7.7% top / 92.3% burn split**, well below the intended 25%.

Restore the literal interpretation: feed emission_wt directly into compute_pinned_weights so 1.0 = 100% top, 0.25 = 25% top. The static t_top/t_burn validator config now only governs the race-based path; Backend's emission_weight remains the operator knob for the legacy fallback path.

## Changes Made

- _build_weights_top_miner_fallback: pin pinned-weights from emission_wt, not from static t_top/t_burn config.
- Same function: when the top miner is missing from the metagraph and emission_wt=1.0 would have left burn_u16=0, set burn slot to u16::MAX so we still submit a valid vector.
- Tests rewritten:
  - test_fallback_top_miner_full_emission: emission_weight=1.0 → 100% top / 0% burn (literal share).
  - test_fallback_emission_weight_partial → renamed test_fallback_emission_weight_quarter: emission_weight=0.25 → 25% top / 75% burn, matches pre-PR120 behaviour.
  - test_fallback_burns_when_top_miner_not_in_metagraph: top missing → all 65535 to uid 0.
  - Two shadow-mode tests updated to expect the new literal-share fallback vector.

## Issue Link

- Related to: ORO-1008
- Closes:

## Testing

### Manual Testing
After v1.0.78 deploys to staging:
- On-chain weights for uid 0+1 on 469 should match emission_weight literal share (currently expected ~25% top / 75% burn given backend's 0.250).
- Shadow log unchanged.

**Test Results:**
Pending staging deploy.

### Automated Testing
48 weight-related tests pass.

**Test Command(s):**
\`\`\`bash
.venv/bin/python -m pytest subnet/tests/validator/test_weight_setter.py subnet/tests/validator/test_weight_distribution.py -q
\`\`\`

## Documentation

- [x] Code comments added/updated
- [ ] README updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
Inline docstring on _build_weights_top_miner_fallback documents that emission_weight is the literal top share.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

Confirmed in staging chain inspection that v1.0.77 was submitting (0, 65535), (6, 5461) — 7.7/92.3 split — when Backend was returning emission_weight=0.250 expecting 25/75. After this fix the same Backend value yields (0, 65535), (6, 21845) — the intended 25/75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)