### PR TITLE
fix(validator): exact t_top share + remove fallback path (ORO-1008)

### DIFF
--- a/subnet/tests/validator/test_weight_setter.py
+++ b/subnet/tests/validator/test_weight_setter.py
@@ -1,18 +1,14 @@
 import time
-from datetime import datetime
 from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
 import pytest
-
-from oro_sdk.models import TopAgentResponse
 
 from validator.weight_distribution import compute_pinned_weights
 from validator.weight_setter import WeightSetterThread
 
 
 def _empty_history():
-    """A `get_race_history` response with no races — drives the fallback path."""
     history = MagicMock()
     history.races = []
     return history
@@ -57,15 +53,8 @@ def _race_detail(qualifiers: list[dict]):
 
 
 class TestWeightSetterThread:
-    """Integration tests for WeightSetterThread.
-
-    Uses fixtures from conftest.py.
-    """
-
     @pytest.fixture
     def mock_backend_client(self, mock_backend_client_with_top_miner):
-        """Top-miner fixture extended with an empty race history so tests
-        that don't set up a race fall through to the fallback path."""
         mock_backend_client_with_top_miner.get_race_history.return_value = (
             _empty_history()
         )
@@ -122,19 +111,12 @@ class TestWeightSetterThread:
                 t_burn=0.5,  # sum > 1
             )
 
-    # --- top-miner fallback (no completed race) ---
+    # --- race-based path (only path remaining) ---
 
-    def test_fallback_burns_when_top_miner_not_in_metagraph(
+    def test_no_race_skips_submission(
         self, mock_backend_client, mock_subtensor, mock_metagraph, mock_wallet
     ):
-        mock_backend_client.get_top_miner.return_value = TopAgentResponse(
-            suite_id=789,
-            top_agent_version_id=UUID("87654321-4321-4321-4321-210987654321"),
-            top_miner_hotkey="5UnknownHotkey...",
-            top_score=0.92,
-            computed_at=datetime.now(),
-            emission_weight=1.0,
-        )
+        """No completed race in history → skip the tick, do not submit weights."""
         setter = WeightSetterThread(
             backend_client=mock_backend_client,
             subtensor=mock_subtensor,
@@ -147,77 +129,15 @@ class TestWeightSetterThread:
         time.sleep(0.15)
         setter.stop()
 
-        mock_subtensor.set_weights.assert_called()
-        weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
-        # Top missing AND emission_wt=1.0 → all to burn fallback.
-        assert weights[0] == 65535
-        assert all(w == 0 for w in weights[1:])
+        mock_subtensor.set_weights.assert_not_called()
 
-    def test_fallback_top_miner_full_emission(
+    def test_continues_on_backend_error(
         self, mock_backend_client, mock_subtensor, mock_metagraph, mock_wallet
     ):
-        """emission_weight=1.0 → 100% to top, 0% to burn (literal share)."""
-        setter = WeightSetterThread(
-            backend_client=mock_backend_client,
-            subtensor=mock_subtensor,
-            metagraph=mock_metagraph,
-            wallet=mock_wallet,
-            netuid=1,
-            interval_seconds=0.1,
-        )
-        setter.start()
-        time.sleep(0.15)
-        setter.stop()
-
-        weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
-        top_u16, burn_u16 = compute_pinned_weights(1.0, 0.0, tail_sum=0)
-        assert weights[0] == burn_u16  # 0 — no burn share
-        assert weights[1] == top_u16  # 65535 — full top share
-        assert weights[2] == 0
-
-    def test_fallback_emission_weight_quarter(
-        self, mock_backend_client, mock_subtensor, mock_metagraph, mock_wallet
-    ):
-        """emission_weight=0.25 → 25% top / 75% burn (matches pre-rewrite behaviour)."""
-        mock_backend_client.get_top_miner.return_value = TopAgentResponse(
-            suite_id=789,
-            top_agent_version_id=UUID("87654321-4321-4321-4321-210987654321"),
-            top_miner_hotkey="5GrwvaEF...",
-            top_score=0.92,
-            computed_at=datetime.now(),
-            emission_weight=0.25,
-        )
-        setter = WeightSetterThread(
-            backend_client=mock_backend_client,
-            subtensor=mock_subtensor,
-            metagraph=mock_metagraph,
-            wallet=mock_wallet,
-            netuid=1,
-            interval_seconds=0.1,
-        )
-        setter.start()
-        time.sleep(0.15)
-        setter.stop()
-
-        weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
-        top_u16, burn_u16 = compute_pinned_weights(0.25, 0.75, tail_sum=0)
-        # Burn pinned at u16::MAX, top derived = 21845 → 25/75 split.
-        assert weights[0] == burn_u16  # 65535
-        assert weights[1] == top_u16  # 21845
-
-    def test_continues_on_error(
-        self, mock_backend_client, mock_subtensor, mock_metagraph, mock_wallet
-    ):
-        mock_backend_client.get_top_miner.side_effect = [
+        """Transient race fetch error skips the tick but doesn't crash the loop."""
+        mock_backend_client.get_race_history.side_effect = [
             Exception("Network error"),
-            TopAgentResponse(
-                suite_id=789,
-                top_agent_version_id=UUID("87654321-4321-4321-4321-210987654321"),
-                top_miner_hotkey="5GrwvaEF...",
-                top_score=0.92,
-                computed_at=datetime.now(),
-                emission_weight=1.0,
-            ),
+            _empty_history(),
         ]
         setter = WeightSetterThread(
             backend_client=mock_backend_client,
@@ -231,16 +151,15 @@ class TestWeightSetterThread:
         time.sleep(0.25)
         setter.stop()
 
-        assert mock_backend_client.get_top_miner.call_count >= 2
-
-    # --- race-based path ---
+        assert mock_backend_client.get_race_history.call_count >= 2
 
     def test_race_path_distributes_to_top_half(
         self, mock_backend_client, mock_subtensor, mock_wallet
     ):
-        """With a completed race of 6 finishers, the top 3 (floor(6/2)) get
-        non-zero u16 weights and the bottom 3 get 0."""
-        # 6 finishers, scores descending; metagraph indexes them after the burn uid.
+        """6 finishers, all in metagraph: top 3 (floor(6/2)) get u16; bottom 3 zero.
+        With every protected finisher present, no drift correction needed —
+        top_u16 lands at 25% of the submitted vector exactly.
+        """
         finishers = [
             {"miner_hotkey": f"5HK{i}", "agent_version_id": str(uuid4()), "race_score": 0.9 - i * 0.05}
             for i in range(6)
@@ -267,56 +186,22 @@ class TestWeightSetterThread:
         setter.stop()
 
         weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
-        # K=3, tail = [2, 1] → tail_sum = 3.
+        # K=3, tail (ranks 2..3) = [2, 1] → tail_sum_actual = 3.
         top_u16, burn_u16 = compute_pinned_weights(0.25, 0.75, tail_sum=3)
-        # Burn slot.
         assert weights[0] == burn_u16
-        # Rank 1 finisher — uid 1 in this metagraph.
         assert weights[1] == top_u16
-        # Ranks 2..K (K=3) — taper K-1, K-2 = 2, 1.
         assert weights[2] == 2
         assert weights[3] == 1
-        # Bottom half — zero.
         assert weights[4] == 0
         assert weights[5] == 0
         assert weights[6] == 0
 
-    def test_race_path_falls_back_when_no_completed_race_in_history(
-        self, mock_backend_client, mock_subtensor, mock_metagraph, mock_wallet
-    ):
-        """Every race in history is in-progress → fall back to top-miner path.
-
-        Only happens on a fresh subnet or after a race-system rollback.
-        """
-        mock_backend_client.get_race_history.return_value = _history_with_races(
-            [
-                _race_with_status(uuid4(), "QUALIFYING_OPEN"),
-                _race_with_status(uuid4(), "RACE_RUNNING"),
-            ]
-        )
-
-        setter = WeightSetterThread(
-            backend_client=mock_backend_client,
-            subtensor=mock_subtensor,
-            metagraph=mock_metagraph,
-            wallet=mock_wallet,
-            netuid=1,
-            interval_seconds=0.1,
-        )
-        setter.start()
-        time.sleep(0.15)
-        setter.stop()
-
-        # `get_race_detail` should never be called when no race is complete.
-        mock_backend_client.get_race_detail.assert_not_called()
-        mock_backend_client.get_top_miner.assert_called()
-
     def test_race_path_skips_in_progress_and_uses_prior_completed_race(
         self, mock_backend_client, mock_subtensor, mock_wallet
     ):
-        """Newest race is `QUALIFYING_OPEN` (current cycle) — we still want
-        last race's finishers protected. Walk the history and use the most
-        recent `RACE_COMPLETE`.
+        """Newest race is in-progress — walk history and use the most recent
+        RACE_COMPLETE so the prior race's finishers stay protected during
+        the current cycle.
         """
         finishers = [
             {"miner_hotkey": f"5HK{i}", "agent_version_id": str(uuid4()), "race_score": 0.9 - i * 0.05}
@@ -335,7 +220,6 @@ class TestWeightSetterThread:
                 _race_with_status(completed_id, "RACE_COMPLETE"),
             ]
         )
-        # Detail call should target the completed race, not the in-progress one.
         mock_backend_client.get_race_detail.return_value = _race_detail(finishers)
 
         setter = WeightSetterThread(
@@ -350,72 +234,31 @@ class TestWeightSetterThread:
         time.sleep(0.15)
         setter.stop()
 
-        # Loop may tick more than once at this interval; what matters is
-        # the call always targeted the completed race id, never the
-        # in-progress one.
         assert mock_backend_client.get_race_detail.call_count >= 1
         for call in mock_backend_client.get_race_detail.call_args_list:
             assert call.args == (completed_id,) or call.kwargs == {"race_id": completed_id}
         weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
-        # K=3, tail = [2, 1] → tail_sum = 3.
         top_u16, _ = compute_pinned_weights(0.25, 0.75, tail_sum=3)
-        assert weights[1] == top_u16  # rank-1 finisher protected
+        assert weights[1] == top_u16
 
-    def test_shadow_mode_no_race_uses_fallback(
-        self, mock_backend_client, mock_subtensor, mock_metagraph, mock_wallet
-    ):
-        """shadow_mode=True with no completed race: still submits via fallback.
-
-        Shadow mode must never silently stop weight setting; the legacy
-        top-miner path stays live so prod doesn't lose vTrust on deploy.
-        """
-        setter = WeightSetterThread(
-            backend_client=mock_backend_client,
-            subtensor=mock_subtensor,
-            metagraph=mock_metagraph,
-            wallet=mock_wallet,
-            netuid=1,
-            interval_seconds=0.1,
-            shadow_mode=True,
-        )
-        setter.start()
-        time.sleep(0.15)
-        setter.stop()
-
-        mock_subtensor.set_weights.assert_called()
-        weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
-        # Default fixture: emission_weight unset → 1.0 → 100% top, 0% burn.
-        top_u16, burn_u16 = compute_pinned_weights(1.0, 0.0, tail_sum=0)
-        assert weights[0] == burn_u16
-        assert weights[1] == top_u16  # 5GrwvaEF... fixture top miner
-
-    def test_shadow_mode_with_race_submits_fallback_vector(
+    def test_drift_correction_when_protected_finishers_deregistered(
         self, mock_backend_client, mock_subtensor, mock_wallet
     ):
-        """shadow_mode=True with a completed race: submits the legacy
-        top-miner vector (NOT the race-based one), even though a race
-        result is available. New algorithm only runs in live mode.
+        """When some protected finishers are missing from the metagraph,
+        top_u16 / burn_u16 are recomputed from the *actual* tail_sum so the
+        top miner's normalised share stays at exactly t_top.
         """
+        # 6 finishers; rank 2 (5HK1) and rank 3 (5HK2) are deregistered →
+        # protected set drops from 3 (K=floor(6/2)) to 1 in the metagraph.
         finishers = [
-            {
-                "miner_hotkey": f"5Hotkey{i}",
-                "agent_version_id": str(uuid4()),
-                "race_score": 0.9 - i * 0.1,
-            }
+            {"miner_hotkey": f"5HK{i}", "agent_version_id": str(uuid4()), "race_score": 0.9 - i * 0.05}
             for i in range(6)
         ]
-
         metagraph = MagicMock()
-        metagraph.hotkeys = [
-            "5BurnUid",
-            "5GrwvaEF...",  # fallback top-miner fixture hotkey
-        ] + [f["miner_hotkey"] for f in finishers]
+        metagraph.hotkeys = ["5BurnUid", "5HK0"]  # only burn + rank 1
         metagraph.uids = list(range(len(metagraph.hotkeys)))
 
-        completed_id = uuid4()
-        mock_backend_client.get_race_history.return_value = _race_complete_history(
-            completed_id
-        )
+        mock_backend_client.get_race_history.return_value = _race_complete_history(uuid4())
         mock_backend_client.get_race_detail.return_value = _race_detail(finishers)
 
         setter = WeightSetterThread(
@@ -425,20 +268,17 @@ class TestWeightSetterThread:
             wallet=mock_wallet,
             netuid=1,
             interval_seconds=0.1,
-            shadow_mode=True,
         )
         setter.start()
         time.sleep(0.15)
         setter.stop()
 
-        mock_subtensor.set_weights.assert_called()
         weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
-        # Default fixture: emission_weight unset → 1.0 → fallback puts
-        # full top share in uid 1, zero in burn.
-        top_u16, burn_u16 = compute_pinned_weights(1.0, 0.0, tail_sum=0)
-        # Fallback vector: only top-miner slot gets weight here; race
-        # finishers (uids 2..7) all stay at 0 because the race path was
-        # suppressed by shadow_mode.
+        # Tail dereg'd → tail_sum_actual = 0 → recompute pins top, burn.
+        top_u16, burn_u16 = compute_pinned_weights(0.25, 0.75, tail_sum=0)
         assert weights[0] == burn_u16
         assert weights[1] == top_u16
-        assert all(w == 0 for w in weights[2:])
+        # Submitted top share matches t_top exactly.
+        total = sum(weights)
+        top_share = weights[1] / total
+        assert abs(top_share - 0.25) < 1e-3

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -481,16 +481,6 @@ class Validator:
         UPDATE_CHECK_INTERVAL = 300
         self._last_update_check = 0
 
-        # Shadow mode is the default for the new top-50% distribution while
-        # we exercise it on real validators. Operators must explicitly opt in
-        # to live submission via ORO_WEIGHT_SETTER_LIVE=true once they've
-        # verified the proposed weight vectors in logs.
-        live_mode = os.environ.get("ORO_WEIGHT_SETTER_LIVE", "false").lower() in (
-            "true",
-            "1",
-            "yes",
-        )
-        shadow_mode = not live_mode
         weight_setter = WeightSetterThread(
             backend_client=self.backend_client,
             subtensor=self.subtensor,
@@ -498,12 +488,10 @@ class Validator:
             wallet=self.wallet,
             netuid=self.config.netuid,
             interval_seconds=self.config.weight_update_interval,
-            shadow_mode=shadow_mode,
         )
         weight_setter.start()
         logging.info(
-            f"Weight setter started (interval: {self.config.weight_update_interval}s, "
-            f"shadow_mode={shadow_mode})"
+            f"Weight setter started (interval: {self.config.weight_update_interval}s)"
         )
 
         try:

--- a/subnet/validator/weight_distribution.py
+++ b/subnet/validator/weight_distribution.py
@@ -202,25 +202,45 @@ def build_metagraph_weight_vector(
     if n_meta == 0:
         return [], []
 
-    # Materialise once — `qualifiers` may be a one-shot iterable, and we
-    # need its length here and again inside `compute_hotkey_weights`.
     finishers = list(qualifiers)
-    tail_sum = _tail_sum_for(len(finishers) // 2)
-    _, burn_u16 = compute_pinned_weights(t_top, t_burn, tail_sum)
-
     hotkey_weights = compute_hotkey_weights(finishers, t_top, t_burn)
+    if not hotkey_weights:
+        # No protected entries (race too small for K >= 1) — burn everything.
+        weights = [0] * n_meta
+        weights[0] = U16_MAX
+        return list(range(n_meta)), weights
 
     weights = [0] * n_meta
     hotkey_to_idx = {hk: i for i, hk in enumerate(metagraph_hotkeys)}
+    ranked = rank_finishers(finishers)
+    top_hk = ranked[0].miner_hotkey
+    top_idx: int | None = None
+    tail_sum_actual = 0
     for hk, w in hotkey_weights.items():
         idx = hotkey_to_idx.get(hk)
         if idx is None:
             continue
-        weights[idx] = w
+        if hk == top_hk:
+            top_idx = idx
+        else:
+            weights[idx] = w
+            tail_sum_actual += w
 
-    # Burn uid 0 may coincidentally collide with a top-half hotkey on very
-    # small testnet metagraphs — the burn weight is additive so the slot
-    # is never accidentally zeroed by the top-half pass.
-    weights[0] += burn_u16
+    # Recompute pinned weights from the *actual* tail sum (after dropping
+    # deregistered finishers) so the top miner lands at exactly t_top of
+    # the submitted vector. Without this, missing tail u16 entries inflate
+    # both top and burn shares proportionally.
+    top_u16, burn_u16 = compute_pinned_weights(t_top, t_burn, tail_sum_actual)
+    if top_idx is not None:
+        # Burn uid 0 may collide with the rank-1 hotkey on very small
+        # testnet metagraphs; weights are additive on uid 0.
+        if top_idx == 0:
+            weights[0] = top_u16 + burn_u16
+        else:
+            weights[top_idx] = top_u16
+            weights[0] = burn_u16
+    else:
+        # Top miner deregistered — pin burn slot only.
+        weights[0] = burn_u16
 
     return list(range(n_meta)), weights

--- a/subnet/validator/weight_setter.py
+++ b/subnet/validator/weight_setter.py
@@ -5,8 +5,9 @@ Builds a deterministic top-50% race-finisher weight vector via
 chain. Determinism across validators is load-bearing for Yuma consensus on
 subnet 15 (`kappa = 0.5`).
 
-Falls back to the prior top-miner-only behaviour while no completed race
-is available (early subnet boot, race system temporarily unavailable).
+When no completed race is available (fresh subnet, race-system rollback,
+backend outage) the tick is skipped — weight setting waits for the next
+tick rather than submitting a stale or non-race vector.
 """
 
 import threading
@@ -80,7 +81,6 @@ class WeightSetterThread:
         interval_seconds: int = 300,
         t_top: float = 0.25,
         t_burn: float = 0.75,
-        shadow_mode: bool = False,
     ):
         self.backend_client = backend_client
         self.subtensor = subtensor
@@ -90,7 +90,6 @@ class WeightSetterThread:
         self.interval_seconds = interval_seconds
         self.t_top = t_top
         self.t_burn = t_burn
-        self.shadow_mode = shadow_mode
 
         # Fail fast on misconfiguration — the validator process should not
         # start setting weights with invalid ratios. tail_sum=0 is the
@@ -136,8 +135,8 @@ class WeightSetterThread:
 
         Returns None only when there is no completed race in the recent
         history (fresh subnet, recovery from race-system rollback). The
-        caller then falls back to the top-miner path so weight setting
-        is never silently skipped.
+        caller skips weight submission for this tick rather than falling
+        back to a stale vector.
         """
         history = self.backend_client.get_race_history(
             limit=self._RACE_HISTORY_SCAN_LIMIT
@@ -181,54 +180,6 @@ class WeightSetterThread:
             t_burn=self.t_burn,
         )
 
-    def _build_weights_top_miner_fallback(
-        self, top_miner_hotkey: str, emission_wt: float
-    ) -> tuple[list[int], list[int]]:
-        """Legacy fallback: top miner gets one slot, rest goes to burn uid.
-
-        Used while the subnet has no completed race yet, or when the race
-        endpoint is unavailable.
-
-        `emission_weight` from Backend is the LITERAL top share, matching
-        pre-rewrite semantics: 0.25 means 25% top / 75% burn, 1.0 means
-        100% top / 0% burn. Backend's value drives the split, the
-        validator's `t_top`/`t_burn` configuration is only consulted by
-        the race-based path.
-        """
-        n = len(self.metagraph.hotkeys)
-        if n == 0:
-            return [], []
-
-        # `compute_pinned_weights` pins the larger share at u16::MAX and
-        # derives the smaller — same algorithm as the race path, just
-        # parameterised by Backend's emission_wt instead of the static
-        # t_top/t_burn config.
-        top_u16, burn_u16 = compute_pinned_weights(
-            emission_wt, 1.0 - emission_wt, tail_sum=0
-        )
-
-        weights = [0] * n
-        weights[0] = burn_u16
-
-        try:
-            top_idx = self.metagraph.hotkeys.index(top_miner_hotkey)
-        except ValueError:
-            logging.warning(
-                f"Top miner {top_miner_hotkey} not found in metagraph, "
-                "burning all emissions to uid 0"
-            )
-            # Route everything to burn so we still set weights, even if
-            # emission_wt=1.0 left burn_u16 at 0.
-            weights[0] = 65535
-            return list(range(n)), weights
-
-        if top_idx == 0:
-            weights[0] += top_u16
-        else:
-            weights[top_idx] = top_u16
-
-        return list(range(n)), weights
-
     def _submit_weights(self, uids: list[int], weights: list[int]) -> None:
         """Push `uids` / `weights` to the chain. No retries — the loop's
         next tick will retry on transient blockchain failures."""
@@ -240,69 +191,33 @@ class WeightSetterThread:
             wait_for_inclusion=True,
         )
 
-    def _log_shadow_race_vector(self, finishers: list[RankedFinisher]) -> None:
-        """Compute the would-be race-based vector and log it without submitting.
-
-        Used in shadow mode to verify the new distribution against real race
-        results while the legacy top-miner fallback continues to set weights
-        on chain — so a deploy can't accidentally stop weight setting.
-        """
-        uids, weights = self._build_weights_from_race(finishers)
-        non_zero = [(u, w) for u, w in zip(uids, weights) if w > 0]
-        logging.info(
-            f"[SHADOW] race-based vector (not submitted) "
-            f"netuid={self.netuid} N={len(finishers)} "
-            f"non_zero={len(non_zero)} total_u16={sum(weights)} "
-            f"vector={non_zero}"
-        )
-
     def _tick(self) -> None:
-        """One iteration of the loop.
-
-        Shadow mode: always submit via the legacy top-miner fallback so prod
-        keeps setting weights, but additionally log the race-based vector
-        that *would* have been submitted for offline verification.
-
-        Live mode: submit the race-based vector when a completed race is
-        available, otherwise fall back to top-miner.
-        """
+        """One iteration of the loop — race-based weight submission."""
         self.metagraph.sync()
 
         finishers: Optional[list[RankedFinisher]] = None
         try:
             finishers = self._fetch_race_finishers()
         except BackendError as e:
-            # Don't crash the loop — fall back to the top-miner path so a
-            # race-endpoint outage doesn't stop weight setting.
+            # Don't crash the loop — skip this tick; the next one retries.
             if e.is_transient:
-                logging.warning(f"Race fetch transient error, using fallback: {e}")
+                logging.warning(f"Race fetch transient error, skipping tick: {e}")
             else:
-                logging.error(f"Race fetch error, using fallback: {e}")
+                logging.error(f"Race fetch error, skipping tick: {e}")
+            return
 
-        if finishers and not self.shadow_mode:
-            uids, weights = self._build_weights_from_race(finishers)
-            non_zero = sum(1 for w in weights if w > 0)
-            logging.info(
-                f"Race-based weight vector: N={len(finishers)} finishers, "
-                f"{non_zero} non-zero metagraph slots"
+        if not finishers:
+            logging.warning(
+                "No completed race available — skipping weight submission for this tick"
             )
-        else:
-            if finishers and self.shadow_mode:
-                self._log_shadow_race_vector(finishers)
-            top = self.backend_client.get_top_miner()
-            emission_wt = (
-                top.emission_weight
-                if isinstance(top.emission_weight, (int, float))
-                else 1.0
-            )
-            logging.info(
-                f"Using top-miner weight path "
-                f"(top={top.top_miner_hotkey}, emission_weight={emission_wt:.3f}, "
-                f"shadow_mode={self.shadow_mode})"
-            )
-            uids, weights = self._build_weights_top_miner_fallback(
-                top.top_miner_hotkey, emission_wt=emission_wt
-            )
+            return
+
+        uids, weights = self._build_weights_from_race(finishers)
+        non_zero = sum(1 for w in weights if w > 0)
+        logging.info(
+            f"Race-based weight vector: N={len(finishers)} finishers, "
+            f"{non_zero} non-zero metagraph slots"
+        )
 
         if not weights:
             logging.warning("Skipping weight update (empty metagraph)")


### PR DESCRIPTION
## Description

Two finishing changes for the top-50% weight distribution after staging-shadow logs validated the algorithm against real race data:

1. **Exact t_top share.** When protected finishers are deregistered between race close and weight set, their tail u16 entries vanish from the submitted vector. Previously top_u16 / burn_u16 were derived from the assumed full tail_sum, so their normalised shares inflated proportionally (race 20 saw top at 25.99% instead of 25.00%). Recompute pinned weights from the **post-filter** tail_sum so the top miner lands at exactly t_top regardless of dereg count. K (size of the protected set) is still derived from the full finisher count, preserving the original protection semantics.

2. **Remove fallback / shadow.** The legacy top-miner fallback, the shadow-mode flag, and the ORO_WEIGHT_SETTER_LIVE env var are gone. Race-based path is the only path. When no completed race is available (fresh subnet, backend outage), skip the tick and let the next one retry — no more silently submitting a stale or non-race vector.

## Changes Made

- weight_distribution.build_metagraph_weight_vector: filter into metagraph first, sum tail_sum_actual, then call compute_pinned_weights to derive top_u16 / burn_u16 from the actual placed tail. Top miner deregistered → submit only burn slot.
- weight_setter._tick: race-only path. No more top-miner fetch, no shadow log branch. Backend error or no-completed-race → skip + warn.
- Drop _build_weights_top_miner_fallback, _log_shadow_race_vector, shadow_mode parameter.
- main.py: drop ORO_WEIGHT_SETTER_LIVE env var read.
- Tests: removed all fallback / shadow / top-miner cases. Added test_drift_correction_when_protected_finishers_deregistered which verifies top share = exactly 25% even with all tail entries dereg'd.

## Issue Link

- Related to: ORO-1008
- Closes: ORO-1008

## Testing

### Manual Testing
After v1.0.79 deploys to staging:
- Boot log: `Weight setter started (interval: 300s)` (no shadow_mode mention).
- Each tick: `Race-based weight vector: N=N finishers, M non-zero metagraph slots` then `Successfully set weights`.
- On-chain: top u16 share equal to t_top of total submitted u16 (within rounding).
- No more `[SHADOW]` lines, no more `Using top-miner weight path` lines.

**Test Results:**
Pending staging deploy.

### Automated Testing
44 weight tests pass.

**Test Command(s):**
\`\`\`bash
.venv/bin/python -m pytest subnet/tests/validator/test_weight_setter.py subnet/tests/validator/test_weight_distribution.py -q
\`\`\`

## Documentation

- [x] Code comments added/updated
- [ ] README updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
Inline comments on the post-filter recompute and on `_tick`'s skip-on-no-race branch.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

After this lands + v1.0.79 promotes, prod will switch from the old 25/75 fallback to race-based weights for the first time. Confidence comes from the staging-shadow comparison against race 20 where the algorithm produced the expected vector across both ORO instances byte-identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)