### PR TITLE
perf(judge): cache utilization-API result for 30s

### DIFF
--- a/src/agent/reasoning_scorer.py
+++ b/src/agent/reasoning_scorer.py
@@ -51,18 +51,10 @@ JUDGE_MODELS = [
 CHUTES_UTILIZATION_URL = "https://api.chutes.ai/chutes/utilization"
 CHUTES_UTILIZATION_TIMEOUT = 5
 
-# Briefly cache the resolved model order so concurrent reasoning-judge calls
-# don't each hit the utilization API. 30s is short enough that we react to
-# real load changes within roughly a single problem's eval window, but long
-# enough to absorb the per-validator burst (~15 problems landing in parallel).
+# 30s coalesces per-validator bursts (~15 problems scoring in parallel)
+# while still picking up real load shifts within an eval.
 _MODEL_ORDER_CACHE_TTL_SECONDS = 30
 _model_order_cache: tuple[float, list[str]] | None = None
-
-
-def _reset_model_order_cache() -> None:
-    """Clear the cached model order. Test-only — production code never calls this."""
-    global _model_order_cache
-    _model_order_cache = None
 
 
 def _select_models_by_utilization() -> list[str]:
@@ -78,73 +70,55 @@ def _select_models_by_utilization() -> list[str]:
     Returns models sorted by utilization_current (ascending = least loaded
     first), excluding any with active_instance_count == 0. Falls back to
     the static JUDGE_MODELS list on any API failure, or if filtering would
-    leave no models. Result is cached for ``_MODEL_ORDER_CACHE_TTL_SECONDS``
-    so concurrent callers don't each refetch.
+    leave no models. Result is cached for ``_MODEL_ORDER_CACHE_TTL_SECONDS``.
     """
     global _model_order_cache
     now = time.monotonic()
-    if (
-        _model_order_cache is not None
-        and now - _model_order_cache[0] < _MODEL_ORDER_CACHE_TTL_SECONDS
-    ):
-        return list(_model_order_cache[1])
+    if _model_order_cache and now - _model_order_cache[0] < _MODEL_ORDER_CACHE_TTL_SECONDS:
+        return _model_order_cache[1]
 
-    result = _fetch_model_order()
-    _model_order_cache = (now, result)
-    return list(result)
-
-
-def _fetch_model_order() -> list[str]:
-    """Issue the Chutes API call and produce the sorted model order.
-
-    Split out from ``_select_models_by_utilization`` so the caching layer
-    is the only place that owns cache state.
-    """
     try:
         resp = requests.get(CHUTES_UTILIZATION_URL, timeout=CHUTES_UTILIZATION_TIMEOUT)
         if resp.status_code != 200:
-            return list(JUDGE_MODELS)
+            result = list(JUDGE_MODELS)
+        else:
+            entries_by_name = {e["name"]: e for e in resp.json()}
 
-        entries_by_name = {e["name"]: e for e in resp.json()}
+            def is_available(m: str) -> bool:
+                # Permissive on missing fields: not all entries carry
+                # active_instance_count, and a missing entry just means
+                # the model wasn't reported (still treat as usable).
+                e = entries_by_name.get(m)
+                count = e.get("active_instance_count") if e else None
+                return count is None or count > 0
 
-        def is_available(m: str) -> bool:
-            e = entries_by_name.get(m)
-            if e is None:
-                # Not reported by the utilization API — be permissive.
-                return True
-            count = e.get("active_instance_count")
-            if count is None:
-                # Field not present on this entry — be permissive.
-                return True
-            return count > 0
-
-        available = [m for m in JUDGE_MODELS if is_available(m)]
-        if not available:
-            logger.warning(
-                "All judge models report zero active instances on Chutes; "
-                "falling back to static model list"
-            )
-            return list(JUDGE_MODELS)
-
-        result = sorted(
-            available,
-            key=lambda m: entries_by_name.get(m, {}).get("utilization_current", 1.0),
-        )
-
-        log_parts = [
-            f"{m}({entries_by_name.get(m, {}).get('utilization_current', -1):.0%})"
-            for m in result
-        ]
-        msg = "Judge model order by utilization: " + ", ".join(log_parts)
-        skipped = [m for m in JUDGE_MODELS if m not in available]
-        if skipped:
-            msg += f" | skipped (0 instances): {', '.join(skipped)}"
-        logger.info(msg)
-
-        return result
+            available = [m for m in JUDGE_MODELS if is_available(m)]
+            if not available:
+                logger.warning(
+                    "All judge models report zero active instances on Chutes; "
+                    "falling back to static model list"
+                )
+                result = list(JUDGE_MODELS)
+            else:
+                result = sorted(
+                    available,
+                    key=lambda m: entries_by_name.get(m, {}).get("utilization_current", 1.0),
+                )
+                log_parts = [
+                    f"{m}({entries_by_name.get(m, {}).get('utilization_current', -1):.0%})"
+                    for m in result
+                ]
+                msg = "Judge model order by utilization: " + ", ".join(log_parts)
+                skipped = [m for m in JUDGE_MODELS if m not in available]
+                if skipped:
+                    msg += f" | skipped (0 instances): {', '.join(skipped)}"
+                logger.info(msg)
     except Exception as e:
         logger.warning(f"Failed to fetch Chutes utilization, using static model list: {e}")
-        return list(JUDGE_MODELS)
+        result = list(JUDGE_MODELS)
+
+    _model_order_cache = (now, result)
+    return result
 
 JUDGE_SYSTEM_PROMPT = """\
 You evaluate a shopping agent's trajectory and decide whether the agent is using genuine LLM reasoning or pattern matching / regex.

--- a/src/agent/reasoning_scorer.py
+++ b/src/agent/reasoning_scorer.py
@@ -75,7 +75,9 @@ def _select_models_by_utilization() -> list[str]:
     global _model_order_cache
     now = time.monotonic()
     if _model_order_cache and now - _model_order_cache[0] < _MODEL_ORDER_CACHE_TTL_SECONDS:
-        return _model_order_cache[1]
+        # Return a copy so a caller mutating its result can't poison
+        # subsequent reads inside the TTL window.
+        return list(_model_order_cache[1])
 
     try:
         resp = requests.get(CHUTES_UTILIZATION_URL, timeout=CHUTES_UTILIZATION_TIMEOUT)
@@ -118,7 +120,7 @@ def _select_models_by_utilization() -> list[str]:
         result = list(JUDGE_MODELS)
 
     _model_order_cache = (now, result)
-    return result
+    return list(result)
 
 JUDGE_SYSTEM_PROMPT = """\
 You evaluate a shopping agent's trajectory and decide whether the agent is using genuine LLM reasoning or pattern matching / regex.

--- a/src/agent/reasoning_scorer.py
+++ b/src/agent/reasoning_scorer.py
@@ -51,6 +51,19 @@ JUDGE_MODELS = [
 CHUTES_UTILIZATION_URL = "https://api.chutes.ai/chutes/utilization"
 CHUTES_UTILIZATION_TIMEOUT = 5
 
+# Briefly cache the resolved model order so concurrent reasoning-judge calls
+# don't each hit the utilization API. 30s is short enough that we react to
+# real load changes within roughly a single problem's eval window, but long
+# enough to absorb the per-validator burst (~15 problems landing in parallel).
+_MODEL_ORDER_CACHE_TTL_SECONDS = 30
+_model_order_cache: tuple[float, list[str]] | None = None
+
+
+def _reset_model_order_cache() -> None:
+    """Clear the cached model order. Test-only — production code never calls this."""
+    global _model_order_cache
+    _model_order_cache = None
+
 
 def _select_models_by_utilization() -> list[str]:
     """Query Chutes utilization API and return JUDGE_MODELS sorted by load.
@@ -65,7 +78,27 @@ def _select_models_by_utilization() -> list[str]:
     Returns models sorted by utilization_current (ascending = least loaded
     first), excluding any with active_instance_count == 0. Falls back to
     the static JUDGE_MODELS list on any API failure, or if filtering would
-    leave no models.
+    leave no models. Result is cached for ``_MODEL_ORDER_CACHE_TTL_SECONDS``
+    so concurrent callers don't each refetch.
+    """
+    global _model_order_cache
+    now = time.monotonic()
+    if (
+        _model_order_cache is not None
+        and now - _model_order_cache[0] < _MODEL_ORDER_CACHE_TTL_SECONDS
+    ):
+        return list(_model_order_cache[1])
+
+    result = _fetch_model_order()
+    _model_order_cache = (now, result)
+    return list(result)
+
+
+def _fetch_model_order() -> list[str]:
+    """Issue the Chutes API call and produce the sorted model order.
+
+    Split out from ``_select_models_by_utilization`` so the caching layer
+    is the only place that owns cache state.
     """
     try:
         resp = requests.get(CHUTES_UTILIZATION_URL, timeout=CHUTES_UTILIZATION_TIMEOUT)

--- a/subnet/tests/test_reasoning_scorer.py
+++ b/subnet/tests/test_reasoning_scorer.py
@@ -6,7 +6,6 @@ import pytest
 
 from reasoning_scorer import (
     _format_proxy_call,
-    _reset_model_order_cache,
     _select_models_by_utilization,
     _summarize_proxy_calls,
     score_reasoning_quality,
@@ -17,16 +16,9 @@ from reasoning_scorer import (
 
 
 @pytest.fixture(autouse=True)
-def _clear_model_order_cache():
-    """Reset the per-process model-order cache between tests.
-
-    `_select_models_by_utilization` caches its result for 30s. Without
-    clearing, the second test in a run would observe the first test's
-    mocked response.
-    """
-    _reset_model_order_cache()
-    yield
-    _reset_model_order_cache()
+def _clear_model_order_cache(monkeypatch):
+    """Reset the 30s model-order cache so tests don't observe each other's mocks."""
+    monkeypatch.setattr("reasoning_scorer._model_order_cache", None)
 
 
 def _make_dialogue(steps):
@@ -479,23 +471,6 @@ class TestSelectModelsByUtilizationCache:
         assert mock_get.call_count == 2
         assert first[0] == JUDGE_MODELS[0]
         assert second[0] == JUDGE_MODELS[-1]
-
-    def test_caller_cannot_mutate_cached_result(self):
-        # The cache returns a fresh copy each call so a caller appending /
-        # popping doesn't poison the next reader.
-        entries = [
-            {"name": m, "utilization_current": 0.1 * i}
-            for i, m in enumerate(JUDGE_MODELS)
-        ]
-        with patch(
-            "reasoning_scorer.requests.get", return_value=self._mock_response(entries)
-        ):
-            first = _select_models_by_utilization()
-            first.clear()
-            second = _select_models_by_utilization()
-
-        assert second  # not empty after caller mutated their copy
-        assert len(second) == len(JUDGE_MODELS)
 
     def test_failure_result_is_cached(self):
         # An API failure produces the static fallback list; that result is

--- a/subnet/tests/test_reasoning_scorer.py
+++ b/subnet/tests/test_reasoning_scorer.py
@@ -2,8 +2,11 @@
 
 from unittest.mock import patch, MagicMock
 
+import pytest
+
 from reasoning_scorer import (
     _format_proxy_call,
+    _reset_model_order_cache,
     _select_models_by_utilization,
     _summarize_proxy_calls,
     score_reasoning_quality,
@@ -11,6 +14,19 @@ from reasoning_scorer import (
     parse_judge_response,
     JUDGE_MODELS,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_model_order_cache():
+    """Reset the per-process model-order cache between tests.
+
+    `_select_models_by_utilization` caches its result for 30s. Without
+    clearing, the second test in a run would observe the first test's
+    mocked response.
+    """
+    _reset_model_order_cache()
+    yield
+    _reset_model_order_cache()
 
 
 def _make_dialogue(steps):
@@ -418,6 +434,81 @@ class TestSelectModelsByUtilization:
         with patch("reasoning_scorer.requests.get", return_value=self._mock_response(entries)):
             result = _select_models_by_utilization()
         assert set(result) == set(JUDGE_MODELS)
+
+
+class TestSelectModelsByUtilizationCache:
+    """Caching layer over the Chutes utilization fetch (ORO-819)."""
+
+    def _mock_response(self, entries):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = entries
+        return resp
+
+    def test_warm_cache_skips_api(self):
+        entries = [
+            {"name": m, "utilization_current": 0.1 * i}
+            for i, m in enumerate(JUDGE_MODELS)
+        ]
+        with patch(
+            "reasoning_scorer.requests.get", return_value=self._mock_response(entries)
+        ) as mock_get:
+            first = _select_models_by_utilization()
+            second = _select_models_by_utilization()
+            third = _select_models_by_utilization()
+
+        assert mock_get.call_count == 1
+        assert first == second == third
+
+    def test_stale_cache_refetches(self):
+        entries_v1 = [{"name": JUDGE_MODELS[0], "utilization_current": 0.1}]
+        entries_v2 = [{"name": JUDGE_MODELS[-1], "utilization_current": 0.1}]
+        with patch(
+            "reasoning_scorer.requests.get",
+            side_effect=[
+                self._mock_response(entries_v1),
+                self._mock_response(entries_v2),
+            ],
+        ) as mock_get:
+            with patch("reasoning_scorer.time.monotonic", return_value=0.0):
+                first = _select_models_by_utilization()
+            # 31s later — past the 30s TTL.
+            with patch("reasoning_scorer.time.monotonic", return_value=31.0):
+                second = _select_models_by_utilization()
+
+        assert mock_get.call_count == 2
+        assert first[0] == JUDGE_MODELS[0]
+        assert second[0] == JUDGE_MODELS[-1]
+
+    def test_caller_cannot_mutate_cached_result(self):
+        # The cache returns a fresh copy each call so a caller appending /
+        # popping doesn't poison the next reader.
+        entries = [
+            {"name": m, "utilization_current": 0.1 * i}
+            for i, m in enumerate(JUDGE_MODELS)
+        ]
+        with patch(
+            "reasoning_scorer.requests.get", return_value=self._mock_response(entries)
+        ):
+            first = _select_models_by_utilization()
+            first.clear()
+            second = _select_models_by_utilization()
+
+        assert second  # not empty after caller mutated their copy
+        assert len(second) == len(JUDGE_MODELS)
+
+    def test_failure_result_is_cached(self):
+        # An API failure produces the static fallback list; that result is
+        # cached too, so a flapping API doesn't get hammered every call. A
+        # later refetch (after TTL) is what recovers.
+        with patch(
+            "reasoning_scorer.requests.get", side_effect=Exception("boom")
+        ) as mock_get:
+            first = _select_models_by_utilization()
+            second = _select_models_by_utilization()
+
+        assert mock_get.call_count == 1
+        assert first == second == list(JUDGE_MODELS)
 
 
 class TestFormatProxyCall:

--- a/subnet/tests/test_reasoning_scorer.py
+++ b/subnet/tests/test_reasoning_scorer.py
@@ -472,6 +472,19 @@ class TestSelectModelsByUtilizationCache:
         assert first[0] == JUDGE_MODELS[0]
         assert second[0] == JUDGE_MODELS[-1]
 
+    def test_caller_mutation_does_not_corrupt_cache(self):
+        entries = [
+            {"name": m, "utilization_current": 0.1 * i}
+            for i, m in enumerate(JUDGE_MODELS)
+        ]
+        with patch(
+            "reasoning_scorer.requests.get", return_value=self._mock_response(entries)
+        ):
+            first = _select_models_by_utilization()
+            first.pop(0)
+            second = _select_models_by_utilization()
+        assert len(second) == len(JUDGE_MODELS)
+
     def test_failure_result_is_cached(self):
         # An API failure produces the static fallback list; that result is
         # cached too, so a flapping API doesn't get hammered every call. A


### PR DESCRIPTION
## Description

The judge model selection runs `_select_models_by_utilization` once per reasoning-judge call. When many problems are scored in parallel, this becomes a burst of identical requests against the Chutes utilization endpoint — every caller waits on the same network round-trip and asks for the same data.

Cache the resolved sort order in a per-process `(timestamp, list)` so concurrent callers reuse a single fetch. TTL is 30s — short enough to react to real load shifts within an eval window, long enough to coalesce the per-problem burst.

The cache also retains the failure fallback (the static `JUDGE_MODELS` list) so a flapping API doesn't get hammered on every call. Recovery happens after the TTL elapses and the next caller refetches.

## Changes Made

- `src/agent/reasoning_scorer.py`:
  - Add `_MODEL_ORDER_CACHE_TTL_SECONDS = 30` and a module-level `_model_order_cache`.
  - Split the API fetch into `_fetch_model_order`; `_select_models_by_utilization` becomes a thin caching wrapper that returns a fresh copy of the cached list each call (so callers can't poison the cache by mutating).
  - Add `_reset_model_order_cache` for tests.
- `subnet/tests/test_reasoning_scorer.py`:
  - Autouse fixture clears the cache between tests so existing cases continue to observe their mocked responses.
  - New `TestSelectModelsByUtilizationCache` class covers warm cache, stale-after-TTL refetch, caller-mutation isolation, and failure-result caching.

## Issue Link

- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing

Ran the full reasoning-scorer test class plus the rest of the suite locally — all green except one pre-existing failure in `test_backend_client.py::test_claim_work_with_resource_metrics` that exists on `origin/main` unrelated to this change.

**Test Results:**

\`\`\`
.venv/bin/pytest subnet/tests/test_reasoning_scorer.py -q
48 passed in 2.59s

.venv/bin/pytest tests/ subnet/tests/ -q --ignore=subnet/tests/validator/test_auto_update.py --ignore=subnet/tests/validator/test_weight_setter.py --ignore=tests/integration/test_sandbox_isolation.py
347 passed, 1 failed (pre-existing on main)
\`\`\`

### Automated Testing

**Test Command(s):**
\`\`\`bash
.venv/bin/pytest subnet/tests/test_reasoning_scorer.py::TestSelectModelsByUtilizationCache -v
.venv/bin/ruff check src/agent/reasoning_scorer.py subnet/tests/test_reasoning_scorer.py
\`\`\`

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
Inline docstrings on the new helpers explain the TTL choice, the cache-state ownership split between `_select_models_by_utilization` and `_fetch_model_order`, and that `_reset_model_order_cache` is test-only.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

- TTL of 30s is a starting point; it can be tightened or relaxed based on observed contention rate. Returning a `list(...)` copy from the cache (rather than the cached list itself) costs a few nanoseconds per call and prevents subtle bugs if a future caller mutates its result.
- The cache also holds the fallback static-list result on API failures. That's deliberate — without it, a 5-second-timeout-per-call bug rate against a degraded Chutes would multiply the slowdown across every concurrent reasoning call. The 30s window means recovery is bounded.