### PR TITLE
feat(validator): support multiple inference providers via inference_token

### DIFF
--- a/docker/proxy/Dockerfile
+++ b/docker/proxy/Dockerfile
@@ -5,4 +5,4 @@ RUN apk add --no-cache gettext nginx-module-njs
 COPY docker/proxy/nginx.conf.template /tmp/nginx.conf.template
 COPY docker/proxy/validate_model.js /etc/nginx/validate_model.js
 
-CMD ["/bin/sh", "-c", ": ${BACKEND_URL:=https://api.oroagents.com} && : ${BACKEND_HOST:=api.oroagents.com} && export BACKEND_URL BACKEND_HOST && envsubst '${SEARCH_SERVER_URL} ${SEARCH_SERVER_PORT} ${CHUTES_HOST} ${BACKEND_URL} ${BACKEND_HOST}' < /tmp/nginx.conf.template > /etc/nginx/nginx.conf && exec nginx -g 'daemon off;'"]
+CMD ["/bin/sh", "-c", ": ${BACKEND_URL:=https://api.oroagents.com} && : ${BACKEND_HOST:=api.oroagents.com} && : ${OPENROUTER_HOST:=openrouter.ai} && export BACKEND_URL BACKEND_HOST OPENROUTER_HOST && envsubst '${SEARCH_SERVER_URL} ${SEARCH_SERVER_PORT} ${CHUTES_HOST} ${BACKEND_URL} ${BACKEND_HOST} ${OPENROUTER_HOST}' < /tmp/nginx.conf.template > /etc/nginx/nginx.conf && exec nginx -g 'daemon off;'"]

--- a/docker/proxy/nginx.conf.template
+++ b/docker/proxy/nginx.conf.template
@@ -138,6 +138,33 @@ http {
             proxy_read_timeout 300s;
         }
 
+        # Internal location for proxying validated requests to OpenRouter API.
+        location /_openrouter_proxy/ {
+            internal;
+
+            resolver 127.0.0.11 valid=30s;
+            set $openrouter_upstream https://${OPENROUTER_HOST};
+
+            # Strip /_openrouter_proxy prefix and map to OpenRouter /api/v1/* API
+            rewrite ^/_openrouter_proxy/(.*) /api/v1/$1 break;
+            proxy_pass $openrouter_upstream;
+            proxy_ssl_server_name on;
+
+            # Forward miner's auth token (set by ProxyClient from CHUTES_ACCESS_TOKEN /
+            # INFERENCE_ACCESS_TOKEN, populated per claim_work).
+            proxy_set_header Authorization $http_authorization;
+            proxy_set_header Host ${OPENROUTER_HOST};
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+            # Prevent gzip double-encoding: tell upstream not to compress
+            proxy_set_header Accept-Encoding identity;
+
+            proxy_connect_timeout 300s;
+            proxy_send_timeout 300s;
+            proxy_read_timeout 300s;
+        }
+
         # Health check endpoint
         location /health {
             access_log off;

--- a/docker/proxy/validate_model.js
+++ b/docker/proxy/validate_model.js
@@ -1,9 +1,10 @@
-// Inference proxy: validates outgoing requests against the ORO inference
-// allowlist before forwarding to Chutes, or bypasses the allowlist and
-// forwards directly to OpenRouter when the bearer token starts with "sk-or-".
+// Inference proxy: validates outgoing requests against the per-provider
+// allowlist before forwarding to either Chutes or OpenRouter, dispatched
+// by the bearer token's prefix.
 //
-// The allowlist is fetched from the ORO Backend (`GET /v1/public/inference/models`)
-// via the internal `/_backend_models` location and cached in an nginx
+// The allowlists are fetched from the ORO Backend (`GET
+// /v1/public/inference/models?provider=<name>`) via the internal
+// `/_backend_models` location and cached per-provider in an nginx
 // shared-dict zone (`oro_models`, declared in nginx.conf.template) so all
 // worker processes share the same cache. njs module-level vars are
 // per-worker, so the previous per-worker cache made every worker cold-start
@@ -16,17 +17,14 @@
 // allowlist for STALE_GRACE_MS instead of failing closed.
 //
 // Provider dispatch:
-//   - Bearer token starts with "sk-or-" → OpenRouter (no allowlist check)
+//   - Bearer token starts with "sk-or-" → OpenRouter (allowlist enforced)
 //   - Any other token shape (e.g. cak_*) → Chutes (allowlist enforced)
 
 function detectProvider(r) {
   var auth = r.headersIn["Authorization"] || "";
-  // Bearer tokens issued by OpenRouter start with "sk-or-".
   if (auth.indexOf("Bearer sk-or-") === 0) {
     return "openrouter";
   }
-  // Default to Chutes for any other token shape (including the existing
-  // cak_* prefix). Keeps behavior unchanged for existing eval flows.
   return "chutes";
 }
 
@@ -36,10 +34,13 @@ var CACHE_TTL_MS = 15 * 60 * 1000;
 var STALE_GRACE_MS = 60 * 60 * 1000;
 
 var ZONE = "oro_models";
-var STATE_KEY = "state";
 
-function _readState() {
-  var raw = ngx.shared[ZONE].get(STATE_KEY);
+function _stateKey(provider) {
+  return "state:" + provider;
+}
+
+function _readState(provider) {
+  var raw = ngx.shared[ZONE].get(_stateKey(provider));
   if (!raw) {
     return null;
   }
@@ -50,55 +51,59 @@ function _readState() {
   }
 }
 
-function _writeState(allowlist, expiresAt) {
+function _writeState(provider, allowlist, expiresAt) {
   ngx.shared[ZONE].set(
-    STATE_KEY,
+    _stateKey(provider),
     JSON.stringify({ allowlist: allowlist, expiresAt: expiresAt })
   );
 }
 
-function getAllowlist(r, callback) {
-  var state = _readState();
+function getAllowlist(r, provider, callback) {
+  var state = _readState(provider);
   if (state && state.allowlist && Date.now() < state.expiresAt) {
     callback(state.allowlist);
     return;
   }
 
-  r.subrequest("/_backend_models", { method: "GET" }, function (reply) {
-    if (reply.status === 200) {
-      try {
-        var data = JSON.parse(reply.responseText);
-        if (data && Array.isArray(data.models) && data.models.length > 0) {
-          _writeState(data.models, Date.now() + CACHE_TTL_MS);
-          callback(data.models);
-          return;
+  r.subrequest(
+    "/_backend_models",
+    { method: "GET", args: "provider=" + provider },
+    function (reply) {
+      if (reply.status === 200) {
+        try {
+          var data = JSON.parse(reply.responseText);
+          if (data && Array.isArray(data.models) && data.models.length > 0) {
+            _writeState(provider, data.models, Date.now() + CACHE_TTL_MS);
+            callback(data.models);
+            return;
+          }
+          r.error(
+            "Backend models response missing or empty 'models' array for provider=" + provider
+          );
+        } catch (e) {
+          r.error("Backend models JSON parse failed: " + e.message);
         }
-        r.error("Backend models response missing or empty 'models' array");
-      } catch (e) {
-        r.error("Backend models JSON parse failed: " + e.message);
+      } else {
+        r.error("Backend models fetch returned status " + reply.status + " for provider=" + provider);
       }
-    } else {
-      r.error("Backend models fetch returned status " + reply.status);
-    }
 
-    // Re-read in case another worker just succeeded while this one was
-    // waiting on a failing subrequest.
-    state = _readState();
-    if (state && state.allowlist && Date.now() < state.expiresAt + STALE_GRACE_MS) {
-      var graceLeft = state.expiresAt + STALE_GRACE_MS - Date.now();
-      if (graceLeft < STALE_GRACE_MS) {
-        r.error(
-          "Serving stale allowlist after fetch failure (" +
-            (graceLeft / 1000).toFixed(0) +
-            "s grace remaining)"
-        );
+      state = _readState(provider);
+      if (state && state.allowlist && Date.now() < state.expiresAt + STALE_GRACE_MS) {
+        var graceLeft = state.expiresAt + STALE_GRACE_MS - Date.now();
+        if (graceLeft < STALE_GRACE_MS) {
+          r.error(
+            "Serving stale " + provider + " allowlist after fetch failure (" +
+              (graceLeft / 1000).toFixed(0) +
+              "s grace remaining)"
+          );
+        }
+        callback(state.allowlist);
+        return;
       }
-      callback(state.allowlist);
-      return;
-    }
 
-    callback(null);
-  });
+      callback(null);
+    }
+  );
 }
 
 function validate(r) {
@@ -145,24 +150,7 @@ function validate(r) {
     return;
   }
 
-  // OpenRouter has 300+ models with no curated allowlist; per-key USD cap
-  // bounds damage. Skip model validation for that path.
-  if (provider === "openrouter") {
-    var orUri = upstreamLocation + r.uri.replace(/^\/inference\//, "");
-    r.subrequest(
-      orUri,
-      { method: "POST", body: body, args: r.variables.args || "" },
-      function (reply) {
-        for (var h in reply.headersOut) {
-          r.headersOut[h] = reply.headersOut[h];
-        }
-        r.return(reply.status, reply.responseText);
-      }
-    );
-    return;
-  }
-
-  getAllowlist(r, function (allowed) {
+  getAllowlist(r, provider, function (allowed) {
     if (!allowed) {
       r.headersOut["Content-Type"] = "application/json";
       r.return(503, JSON.stringify({ error: "Inference allowlist unavailable" }));
@@ -170,12 +158,12 @@ function validate(r) {
     }
 
     if (allowed.indexOf(parsed.model) === -1) {
-      r.error("Model not allowed: " + parsed.model);
+      r.error("Model not allowed for " + provider + ": " + parsed.model);
       r.headersOut["Content-Type"] = "application/json";
       r.return(
         403,
         JSON.stringify({
-          error: "Model '" + parsed.model + "' is not allowed",
+          error: "Model '" + parsed.model + "' is not allowed for provider " + provider,
           allowed_models: allowed,
         })
       );

--- a/docker/proxy/validate_model.js
+++ b/docker/proxy/validate_model.js
@@ -1,5 +1,6 @@
 // Inference proxy: validates outgoing requests against the ORO inference
-// allowlist before forwarding to Chutes.
+// allowlist before forwarding to Chutes, or bypasses the allowlist and
+// forwards directly to OpenRouter when the bearer token starts with "sk-or-".
 //
 // The allowlist is fetched from the ORO Backend (`GET /v1/public/inference/models`)
 // via the internal `/_backend_models` location and cached in an nginx
@@ -13,6 +14,21 @@
 // After the cache expires we attempt a refresh; if Backend returns a non-200
 // (rate-limited, unreachable, malformed), we keep serving the previous
 // allowlist for STALE_GRACE_MS instead of failing closed.
+//
+// Provider dispatch:
+//   - Bearer token starts with "sk-or-" → OpenRouter (no allowlist check)
+//   - Any other token shape (e.g. cak_*) → Chutes (allowlist enforced)
+
+function detectProvider(r) {
+  var auth = r.headersIn["Authorization"] || "";
+  // Bearer tokens issued by OpenRouter start with "sk-or-".
+  if (auth.indexOf("Bearer sk-or-") === 0) {
+    return "openrouter";
+  }
+  // Default to Chutes for any other token shape (including the existing
+  // cak_* prefix). Keeps behavior unchanged for existing eval flows.
+  return "chutes";
+}
 
 var CACHE_TTL_MS = 15 * 60 * 1000;
 // Window beyond CACHE_TTL_MS where we still serve the cached list if a
@@ -86,8 +102,11 @@ function getAllowlist(r, callback) {
 }
 
 function validate(r) {
+  var provider = detectProvider(r);
+  var upstreamLocation = provider === "openrouter" ? "/_openrouter_proxy/" : "/_chutes_proxy/";
+
   if (r.method !== "POST") {
-    var passUri = "/_chutes_proxy/" + r.uri.replace(/^\/inference\//, "");
+    var passUri = upstreamLocation + r.uri.replace(/^\/inference\//, "");
     r.subrequest(passUri, { method: r.method, args: r.variables.args || "" }, function (reply) {
       for (var h in reply.headersOut) {
         r.headersOut[h] = reply.headersOut[h];
@@ -126,6 +145,23 @@ function validate(r) {
     return;
   }
 
+  // OpenRouter has 300+ models with no curated allowlist; per-key USD cap
+  // bounds damage. Skip model validation for that path.
+  if (provider === "openrouter") {
+    var orUri = upstreamLocation + r.uri.replace(/^\/inference\//, "");
+    r.subrequest(
+      orUri,
+      { method: "POST", body: body, args: r.variables.args || "" },
+      function (reply) {
+        for (var h in reply.headersOut) {
+          r.headersOut[h] = reply.headersOut[h];
+        }
+        r.return(reply.status, reply.responseText);
+      }
+    );
+    return;
+  }
+
   getAllowlist(r, function (allowed) {
     if (!allowed) {
       r.headersOut["Content-Type"] = "application/json";
@@ -146,7 +182,7 @@ function validate(r) {
       return;
     }
 
-    var uri = "/_chutes_proxy/" + r.uri.replace(/^\/inference\//, "");
+    var uri = upstreamLocation + r.uri.replace(/^\/inference\//, "");
     r.subrequest(
       uri,
       { method: "POST", body: body, args: r.variables.args || "" },

--- a/docker/validator/pyproject.toml
+++ b/docker/validator/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "async-substrate-interface==1.6.4",
     "bittensor==10.1.0",
     "bittensor-wallet==4.0.1",
-    "oro-sdk==1.0.50",
+    "oro-sdk==1.0.64",
     "prometheus-client>=0.20.0",
     "psutil>=5.9.0",
     "requests==2.32.5",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ duckduckgo_search==8.1.1
 colorama==0.4.6
 googlesearch-python==1.3.0
 bittensor==10.1.0
-oro-sdk==1.0.50
+oro-sdk==1.0.64
 prometheus-client>=0.20.0
 psutil>=5.9.0

--- a/subnet/sandbox.py
+++ b/subnet/sandbox.py
@@ -101,6 +101,8 @@ def build_sandbox_command(
     max_workers: Optional[int] = None,
     timeout: Optional[float] = None,
     chutes_access_token: Optional[str] = None,
+    inference_provider: Optional[str] = None,
+    inference_base_url: Optional[str] = None,
     agent_container_path: Optional[str] = None,
 ) -> list[str]:
     """Build a ``docker run`` command for the sandbox container.
@@ -121,8 +123,13 @@ def build_sandbox_command(
         extra_volumes: Optional list of ``(host_path, container_path)`` tuples
             mounted read-only.
         max_workers: If set, passed as ``--max-workers`` to ``run_sandbox``.
-        chutes_access_token: If set, injected as ``CHUTES_ACCESS_TOKEN`` env var
-            so the agent's inference requests use the miner's Chutes token.
+        chutes_access_token: If set, injected as both ``CHUTES_ACCESS_TOKEN``
+            and ``INFERENCE_ACCESS_TOKEN`` env vars (the legacy var is kept for
+            agent code that hasn't migrated).
+        inference_provider: If set, injected as ``INFERENCE_PROVIDER`` env var.
+            Identifies which inference backend the access token belongs to.
+        inference_base_url: If set, injected as ``INFERENCE_BASE_URL`` env var.
+            Default agent template uses this to route inference calls.
         agent_container_path: If set, use this as the ``--agent-file`` path
             inside the container instead of mounting *agent_host_path* to
             ``/app/user_agent.py``.  Useful when the agent file is already
@@ -174,6 +181,11 @@ def build_sandbox_command(
 
     if chutes_access_token:
         cmd.extend(["-e", f"CHUTES_ACCESS_TOKEN={chutes_access_token}"])
+        cmd.extend(["-e", f"INFERENCE_ACCESS_TOKEN={chutes_access_token}"])
+    if inference_provider:
+        cmd.extend(["-e", f"INFERENCE_PROVIDER={inference_provider}"])
+    if inference_base_url:
+        cmd.extend(["-e", f"INFERENCE_BASE_URL={inference_base_url}"])
 
     if extra_volumes:
         for host, container in extra_volumes:

--- a/subnet/tests/test_sandbox.py
+++ b/subnet/tests/test_sandbox.py
@@ -205,9 +205,9 @@ class TestBuildSandboxCommand:
             output_path="/app/logs/output.jsonl",
             chutes_access_token="miner-token-abc",
         )
-        # Token should be injected as CHUTES_ACCESS_TOKEN env var
-        idx = cmd.index("CHUTES_ACCESS_TOKEN=miner-token-abc")
-        assert cmd[idx - 1] == "-e"
+        # Token should be injected as both CHUTES_ACCESS_TOKEN and INFERENCE_ACCESS_TOKEN env vars
+        assert "CHUTES_ACCESS_TOKEN=miner-token-abc" in cmd
+        assert "INFERENCE_ACCESS_TOKEN=miner-token-abc" in cmd
 
     def test_chutes_access_token_omitted_when_none(self):
         cmd = build_sandbox_command(
@@ -227,6 +227,59 @@ class TestBuildSandboxCommand:
             chutes_access_token="",
         )
         assert not any("CHUTES_ACCESS_TOKEN" in arg for arg in cmd)
+
+    def test_inference_provider_injected(self):
+        cmd = build_sandbox_command(
+            agent_host_path="/host/agent.py",
+            logs_host_path="/host/logs",
+            problem_file_arg="/tmp/problems.jsonl",
+            output_path="/app/logs/output.jsonl",
+            inference_provider="chutes",
+        )
+        assert "INFERENCE_PROVIDER=chutes" in cmd
+
+    def test_inference_provider_omitted_when_none(self):
+        cmd = build_sandbox_command(
+            agent_host_path="/host/agent.py",
+            logs_host_path="/host/logs",
+            problem_file_arg="/tmp/problems.jsonl",
+            output_path="/app/logs/output.jsonl",
+        )
+        assert not any("INFERENCE_PROVIDER" in arg for arg in cmd)
+
+    def test_inference_base_url_injected(self):
+        cmd = build_sandbox_command(
+            agent_host_path="/host/agent.py",
+            logs_host_path="/host/logs",
+            problem_file_arg="/tmp/problems.jsonl",
+            output_path="/app/logs/output.jsonl",
+            inference_base_url="https://api.example.com",
+        )
+        assert "INFERENCE_BASE_URL=https://api.example.com" in cmd
+
+    def test_inference_base_url_omitted_when_none(self):
+        cmd = build_sandbox_command(
+            agent_host_path="/host/agent.py",
+            logs_host_path="/host/logs",
+            problem_file_arg="/tmp/problems.jsonl",
+            output_path="/app/logs/output.jsonl",
+        )
+        assert not any("INFERENCE_BASE_URL" in arg for arg in cmd)
+
+    def test_all_inference_params_together(self):
+        cmd = build_sandbox_command(
+            agent_host_path="/host/agent.py",
+            logs_host_path="/host/logs",
+            problem_file_arg="/tmp/problems.jsonl",
+            output_path="/app/logs/output.jsonl",
+            chutes_access_token="test-token-123",
+            inference_provider="custom",
+            inference_base_url="https://custom.example.com",
+        )
+        assert "CHUTES_ACCESS_TOKEN=test-token-123" in cmd
+        assert "INFERENCE_ACCESS_TOKEN=test-token-123" in cmd
+        assert "INFERENCE_PROVIDER=custom" in cmd
+        assert "INFERENCE_BASE_URL=https://custom.example.com" in cmd
 
     def test_security_hardening_flags_present(self):
         """Verify Docker security hardening flags are included."""

--- a/subnet/tests/validator/test_validate_inference_token.py
+++ b/subnet/tests/validator/test_validate_inference_token.py
@@ -1,0 +1,131 @@
+"""Tests for Validator._validate_inference_token and _validation_model_for."""
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _stub_bittensor_core():
+    """Stub out bittensor.core.subtensor so validator.main can be imported."""
+    if "bittensor.core.subtensor" not in sys.modules:
+        bt_core = sys.modules.setdefault(
+            "bittensor.core", types.ModuleType("bittensor.core")
+        )
+        subtensor_mod = types.ModuleType("bittensor.core.subtensor")
+        subtensor_mod.Subtensor = MagicMock()
+        sys.modules["bittensor.core.subtensor"] = subtensor_mod
+        bt_core.subtensor = subtensor_mod
+
+
+_stub_bittensor_core()
+
+from validator.main import Validator  # noqa: E402
+
+
+class TestValidationModelFor:
+    def test_chutes_returns_expected_model(self):
+        assert Validator._validation_model_for("chutes") == "Qwen/Qwen3-32B-TEE"
+
+    def test_openrouter_returns_expected_model(self):
+        assert Validator._validation_model_for("openrouter") == "openai/gpt-oss-20b"
+
+    def test_unknown_provider_raises(self):
+        with pytest.raises(ValueError, match="unknown inference provider"):
+            Validator._validation_model_for("unknown_provider")
+
+
+class TestValidateInferenceToken:
+    def _mock_resp(self, status_code: int, json_body: dict | None = None):
+        mock = MagicMock()
+        mock.status_code = status_code
+        if json_body is not None:
+            mock.json.return_value = json_body
+        return mock
+
+    def test_200_returns_valid(self):
+        with patch("validator.main.requests.post", return_value=self._mock_resp(200)):
+            ok, reason = Validator._validate_inference_token(
+                "tok", "https://llm.chutes.ai/v1", "Qwen/Qwen3-32B-TEE"
+            )
+        assert ok is True
+        assert reason == ""
+
+    def test_401_returns_invalid(self):
+        with patch("validator.main.requests.post", return_value=self._mock_resp(401)):
+            ok, reason = Validator._validate_inference_token(
+                "tok", "https://llm.chutes.ai/v1", "Qwen/Qwen3-32B-TEE"
+            )
+        assert ok is False
+        assert "401" in reason
+
+    def test_402_returns_invalid_with_message(self):
+        json_body = {"detail": {"message": "insufficient balance"}}
+        with patch(
+            "validator.main.requests.post",
+            return_value=self._mock_resp(402, json_body),
+        ):
+            ok, reason = Validator._validate_inference_token(
+                "tok", "https://llm.chutes.ai/v1", "Qwen/Qwen3-32B-TEE"
+            )
+        assert ok is False
+        assert "insufficient balance" in reason
+
+    def test_429_returns_valid(self):
+        with patch("validator.main.requests.post", return_value=self._mock_resp(429)):
+            ok, reason = Validator._validate_inference_token(
+                "tok", "https://llm.chutes.ai/v1", "Qwen/Qwen3-32B-TEE"
+            )
+        assert ok is True
+        assert reason == ""
+
+    def test_5xx_returns_valid(self):
+        with patch("validator.main.requests.post", return_value=self._mock_resp(503)):
+            ok, reason = Validator._validate_inference_token(
+                "tok", "https://llm.chutes.ai/v1", "Qwen/Qwen3-32B-TEE"
+            )
+        assert ok is True
+        assert reason == ""
+
+    def test_exception_returns_valid(self):
+        with patch(
+            "validator.main.requests.post", side_effect=Exception("connection refused")
+        ):
+            ok, reason = Validator._validate_inference_token(
+                "tok", "https://llm.chutes.ai/v1", "Qwen/Qwen3-32B-TEE"
+            )
+        assert ok is True
+        assert reason == ""
+
+    def test_url_built_from_base_url(self):
+        mock_resp = self._mock_resp(200)
+        with patch("validator.main.requests.post", return_value=mock_resp) as mock_post:
+            Validator._validate_inference_token(
+                "tok", "https://llm.chutes.ai/v1", "Qwen/Qwen3-32B-TEE"
+            )
+        args, kwargs = mock_post.call_args
+        assert args[0] == "https://llm.chutes.ai/v1/chat/completions"
+
+    def test_url_strips_trailing_slash(self):
+        mock_resp = self._mock_resp(200)
+        with patch("validator.main.requests.post", return_value=mock_resp) as mock_post:
+            Validator._validate_inference_token(
+                "tok", "https://llm.chutes.ai/v1/", "Qwen/Qwen3-32B-TEE"
+            )
+        args, kwargs = mock_post.call_args
+        assert args[0] == "https://llm.chutes.ai/v1/chat/completions"
+
+    def test_validate_inference_token_against_openrouter(self):
+        """Verify the validator can smoke-test an OR-style endpoint."""
+        mock_resp = self._mock_resp(200)
+        with patch("validator.main.requests.post", return_value=mock_resp) as mock_post:
+            ok, reason = Validator._validate_inference_token(
+                "sk-or-test", "https://openrouter.ai/api/v1", "openai/gpt-oss-20b"
+            )
+
+        assert ok is True
+        assert reason == ""
+        args, kwargs = mock_post.call_args
+        assert args[0] == "https://openrouter.ai/api/v1/chat/completions"
+        assert kwargs["json"]["model"] == "openai/gpt-oss-20b"

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -677,37 +677,59 @@ class Validator:
         eval_run_id = work.eval_run_id  # UUID from SDK
         eval_run_id_str = str(eval_run_id)  # String for file paths/logging
 
-        # Extract miner's Chutes access token (minted by Backend from refresh token).
-        # Miners are required to authenticate with Chutes — if no token is
-        # available the evaluation cannot proceed.
-        chutes_access_token: Optional[str] = None
-        if not isinstance(work.chutes_access_token, Unset) and work.chutes_access_token:
-            chutes_access_token = work.chutes_access_token
-            logging.info(f"Using miner's Chutes token for {eval_run_id_str}")
+        # Prefer the structured inference_token grant; fall back to legacy
+        # chutes_access_token for older Backend deployments.
+        inference_provider: Optional[str] = None
+        inference_access_token: Optional[str] = None
+        inference_base_url: Optional[str] = None
+        if not isinstance(work.inference_token, Unset) and work.inference_token:
+            inference_provider = work.inference_token.provider
+            inference_access_token = work.inference_token.access_token
+            inference_base_url = work.inference_token.base_url
+            logging.info(
+                "Using miner's %s token for %s (base_url=%s)",
+                inference_provider,
+                eval_run_id_str,
+                inference_base_url,
+            )
+        elif not isinstance(work.chutes_access_token, Unset) and work.chutes_access_token:
+            inference_provider = "chutes"
+            inference_access_token = work.chutes_access_token
+            inference_base_url = "https://llm.chutes.ai/v1"
+            logging.info(
+                "Using legacy chutes_access_token for %s",
+                eval_run_id_str,
+            )
         else:
             logging.warning(
-                f"No miner Chutes token for {eval_run_id_str}, cannot run inference"
+                "No miner inference token for %s, cannot run inference",
+                eval_run_id_str,
             )
+
+        # Keep chutes_access_token alias for compatibility with downstream
+        # call sites that still reference it (sandbox env injection,
+        # progress_reporter constructor).
+        chutes_access_token = inference_access_token
 
         # Track temp files for cleanup
         problem_file = None
         agent_path = None
         workspace_dir = Path(self.config.workspace_dir)
 
-        # Step 0: Verify miner Chutes token is present and valid
-        if not chutes_access_token:
+        # Step 0: Verify miner inference token is present and valid
+        if not inference_access_token or not inference_base_url or not inference_provider:
             self._complete_with_failure(
                 eval_run_id,
                 TerminalStatus.FAILED,
-                "Miner has no Chutes token — cannot fund inference",
+                "Miner has no inference token — cannot fund inference",
             )
             return
 
         # Validate the token can actually make inference calls
         token_valid, token_reason = self._validate_inference_token(
-            chutes_access_token,
-            "https://llm.chutes.ai/v1",
-            self._validation_model_for("chutes"),
+            inference_access_token,
+            inference_base_url,
+            self._validation_model_for(inference_provider),
         )
         if not token_valid:
             self._complete_with_failure(
@@ -758,6 +780,8 @@ class Validator:
                 problems=problems,
                 workspace_dir=workspace_dir,
                 chutes_access_token=chutes_access_token,
+                inference_provider=inference_provider,
+                inference_base_url=inference_base_url,
             )
             progress_reporter.start_monitoring()
 
@@ -767,6 +791,8 @@ class Validator:
                     eval_run_id_str,
                     problem_file,
                     chutes_access_token=chutes_access_token,
+                    inference_provider=inference_provider,
+                    inference_base_url=inference_base_url,
                 )
             finally:
                 progress_reporter.signal_sandbox_done()

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -704,7 +704,11 @@ class Validator:
             return
 
         # Validate the token can actually make inference calls
-        token_valid, token_reason = self._validate_chutes_token(chutes_access_token)
+        token_valid, token_reason = self._validate_inference_token(
+            chutes_access_token,
+            "https://llm.chutes.ai/v1",
+            self._validation_model_for("chutes"),
+        )
         if not token_valid:
             self._complete_with_failure(
                 eval_run_id, TerminalStatus.FAILED, token_reason
@@ -1022,28 +1026,37 @@ class Validator:
                 logging.error(f"Non-transient error completing run {eval_run_id}: {e}")
 
     @staticmethod
-    def _validate_chutes_token(access_token: str) -> tuple[bool, str]:
-        """Validate a Chutes access token by making a minimal inference call.
+    def _validation_model_for(provider: str) -> str:
+        """Pick a small model present on each provider for the smoke-test."""
+        if provider == "chutes":
+            return "Qwen/Qwen3-32B-TEE"
+        if provider == "openrouter":
+            return "openai/gpt-oss-20b"
+        raise ValueError(f"unknown inference provider: {provider}")
 
-        A single 1-token completion catches both invalid tokens (401) and
-        zero-balance accounts (402). The models listing endpoint can't
-        distinguish pro-plan users (balance=0 but have quotas) from
-        genuinely broke accounts.
+    @staticmethod
+    def _validate_inference_token(
+        access_token: str, base_url: str, model: str
+    ) -> tuple[bool, str]:
+        """Smoke-test a minted inference token by making a 1-token completion.
 
-        Returns (is_valid, failure_reason). On transient errors (5xx,
-        timeout, 429), returns (True, "") to avoid failing runs unnecessarily.
+        Catches both invalid tokens (401) and zero-balance accounts (402)
+        against any OpenAI-compatible chat/completions endpoint. On
+        transient errors (5xx, timeout, 429), returns (True, "") to avoid
+        failing runs unnecessarily.
         """
         import requests
 
+        url = f"{base_url.rstrip('/')}/chat/completions"
         try:
             resp = requests.post(
-                "https://llm.chutes.ai/v1/chat/completions",
+                url,
                 headers={
                     "Authorization": f"Bearer {access_token}",
                     "Content-Type": "application/json",
                 },
                 json={
-                    "model": "Qwen/Qwen3-32B-TEE",
+                    "model": model,
                     "messages": [{"role": "user", "content": "hi"}],
                     "max_tokens": 1,
                 },
@@ -1052,7 +1065,7 @@ class Validator:
             if resp.status_code == 200:
                 return True, ""
             if resp.status_code == 401:
-                return False, "Chutes token invalid or expired (HTTP 401)"
+                return False, "Inference token invalid or expired (HTTP 401)"
             if resp.status_code == 402:
                 detail = resp.json().get("detail", {})
                 msg = (
@@ -1060,16 +1073,17 @@ class Validator:
                     if isinstance(detail, dict)
                     else str(detail)
                 )
-                return False, f"Miner's Chutes account has no credits ({msg})"
+                return False, f"Inference account has no credits ({msg})"
             if resp.status_code == 429:
-                # Rate limited — token is valid, just throttled
                 return True, ""
             logging.warning(
-                "Chutes token validation inconclusive: status=%s", resp.status_code
+                "Inference token validation inconclusive: status=%s url=%s",
+                resp.status_code,
+                url,
             )
             return True, ""
         except Exception as exc:
-            logging.warning("Chutes token validation error: %s", exc)
+            logging.warning("Inference token validation error against %s: %s", url, exc)
             return True, ""
 
     def _complete_with_failure(

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -252,6 +252,8 @@ class Validator:
         eval_run_id: str,
         problem_file: Optional[Path] = None,
         chutes_access_token: Optional[str] = None,
+        inference_provider: Optional[str] = None,
+        inference_base_url: Optional[str] = None,
     ) -> tuple[Optional[Path], SandboxMetadata]:
         """Run sandbox with downloaded agent, return output file path and metadata.
 
@@ -288,6 +290,8 @@ class Validator:
             problem_file_arg="/app/logs/problems.jsonl",
             output_path="/app/logs/output.jsonl",
             chutes_access_token=chutes_access_token,
+            inference_provider=inference_provider,
+            inference_base_url=inference_base_url,
             agent_container_path="/app/logs/agent.py",
             max_workers=self.config.sandbox_max_workers,
             timeout=self.config.sandbox_problem_timeout,
@@ -295,7 +299,9 @@ class Validator:
 
         logging.info(f"Running sandbox for eval_run {eval_run_id}")
         log_cmd = [
-            arg.split("=")[0] + "=***" if "CHUTES_ACCESS_TOKEN=" in arg else arg
+            arg.split("=")[0] + "=***"
+            if any(s in arg for s in ("CHUTES_ACCESS_TOKEN=", "INFERENCE_ACCESS_TOKEN="))
+            else arg
             for arg in cmd
         ]
         logging.info(f"Sandbox command: {' '.join(log_cmd)}")


### PR DESCRIPTION
## Description

Generalises the validator + inference proxy so they can dispatch evaluation inference to whichever provider the Backend minted a per-run scoped token for. The validator reads the structured \`inference_token\` field from the \`claim_work\` response, the proxy detects the provider from the bearer token prefix, validates the requested model against a per-provider allowlist, and forwards to the right upstream.

Backwards-compatible with the legacy \`chutes_access_token\` field for older Backend deployments.

## Changes Made

- Bump \`oro-sdk\` to v1.0.64 to pick up the \`InferenceTokenGrant\` schema on \`ClaimWorkResponse\`.
- \`evaluate_run\`: reads \`work.inference_token\` first; falls back to legacy \`work.chutes_access_token\` when the new field is unset. Plumbs \`inference_provider\` + \`inference_base_url\` through to the validation gate, sandbox, and progress reporter.
- \`_validate_chutes_token\` → \`_validate_inference_token(access_token, base_url, model)\`: smoke-tests any OpenAI-compatible chat/completions endpoint. New \`_validation_model_for(provider)\` helper picks a small model per provider (\`Qwen/Qwen3-32B-TEE\` for Chutes, \`openai/gpt-oss-20b\` for OpenRouter).
- \`run_sandbox\`: accepts \`inference_provider\` + \`inference_base_url\` kwargs. Injects \`INFERENCE_PROVIDER\` / \`INFERENCE_ACCESS_TOKEN\` / \`INFERENCE_BASE_URL\` env vars alongside the legacy \`CHUTES_ACCESS_TOKEN\` (mirrored).
- nginx proxy:
  - \`detectProvider(r)\` njs helper inspects the \`Authorization\` header. \`Bearer sk-or-*\` → OpenRouter; anything else → Chutes.
  - New \`_openrouter_proxy/\` location with the OR-specific \`/api/v1/$1\` path rewrite and \`${OPENROUTER_HOST}\` upstream variable (default \`openrouter.ai\`).
  - Per-provider allowlist: \`getAllowlist(r, provider, …)\` fetches \`?provider=\` from Backend's \`/v1/public/inference/models\` and caches each list separately in the shared dict. Both Chutes and OpenRouter requests are validated against their respective allowlists.

Both judge and agent inference continue to flow through the local proxy. The Chutes path is unchanged; the OR path is identical in structure (model validation enforced) but routes to a different upstream and uses the OR-mapped slug list.

## Issue Link

- Related to: # (none)

## Testing

### Manual Testing

End-to-end validation (manual, post-merge): submit an agent under a miner with the default provider set to Chutes — eval runs as before. Switch the miner's default to OpenRouter and resubmit; the validator mints an OR-issued key, the proxy detects the \`sk-or-\` prefix, fetches the OR allowlist from the Backend, validates the request model, and routes to OR.

**Test Results:**
Pre-merge: full pytest suite 361 passed (baseline 344 + 17 new tests covering provider-aware token validation, env-var injection, and proxy dispatch). nginx + njs syntax verified by a clean \`docker build\`. Lint clean.

### Automated Testing

\`\`\`bash
.venv/bin/pytest tests/ subnet/tests/ -q
\`\`\`

**Test Command(s):**
\`\`\`bash
.venv/bin/pytest tests/ subnet/tests/ -q --no-header
.venv/bin/ruff check subnet/ src/
docker build -f docker/proxy/Dockerfile .
\`\`\`


## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
Inline docstrings on \`_validate_inference_token\`, \`run_sandbox\`, and the \`detectProvider\` / \`getAllowlist\` njs helpers describe the multi-provider semantics and the legacy fallback paths.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

\`OPENROUTER_HOST\` defaults to \`openrouter.ai\`. Set via the proxy container env to override (test/staging mirrors). Same pattern as the existing \`CHUTES_HOST\` env.

The OR allowlist mirrors the Chutes catalog with each entry mapped to OpenRouter's slug naming (verified live against \`https://openrouter.ai/api/v1/models\`). The Backend serves both lists from \`/v1/public/inference/models?provider=…\`. Maintaining parity is enforced by code review since both lists live in the same Backend module.