### PR TITLE
fix(validator): null reasoning_score when judge handed an empty dialogue

### DIFF
--- a/subnet/tests/validator/test_progress_reporter_envelope.py
+++ b/subnet/tests/validator/test_progress_reporter_envelope.py
@@ -145,8 +145,13 @@ class TestEnvelopeParsing:
         out = tmp_path / "output.jsonl"
         with open(out, "a") as f:
             f.write("not json\n")
-        _write_envelope(out, problem_id=_P1, status="FAILED", dialogue=None,
-                        error={"type": "RuntimeError", "message": "x"})
+        _write_envelope(
+            out,
+            problem_id=_P1,
+            status="FAILED",
+            dialogue=None,
+            error={"type": "RuntimeError", "message": "x"},
+        )
         reporter._read_and_dispatch()
         assert reporter._results[_P1].status == ProblemStatus.FAILED
 
@@ -171,3 +176,66 @@ class TestSweepNarrowing:
         assert reporter._results[_P1].status == ProblemStatus.TIMED_OUT
         assert reporter._results[_P2].status == ProblemStatus.TIMED_OUT
         assert reporter._results[_P3].status == ProblemStatus.TIMED_OUT
+
+
+class TestReasoningJudgeEmptySentinel:
+    """Empty-dialogue sentinel from the reasoning judge must null out the
+    score so the problem is excluded from reasoning-coefficient aggregation
+    rather than counted as a real zero against the miner."""
+
+    def _make_reporter_with_judge(self, reporter, judge_return):
+        reporter._chutes_access_token = "test-token"
+        reporter._judge_circuit_open = False
+        from unittest.mock import patch
+
+        return patch(
+            "src.agent.reasoning_scorer.score_reasoning_quality",
+            return_value=judge_return,
+        )
+
+    def test_empty_sentinel_returns_null_score(self, reporter):
+        # score_reasoning_quality returns this when called with an empty
+        # dialogue (or one the formatter strips to empty).
+        empty_sentinel = {
+            "score": 0.0,
+            "explanation": "",
+            "model": "",
+            "inference_failed": 0,
+            "inference_total": 0,
+        }
+        with self._make_reporter_with_judge(reporter, empty_sentinel):
+            result = reporter._run_reasoning_judge(dialogue=[], problem_id="p1")
+        assert result["reasoning_score"] is None
+        assert result["reasoning_model"] == ""
+
+    def test_real_judged_zero_is_preserved(self, reporter):
+        # A real judge call that returned 0.0 — model set, inference_total>=1.
+        # Must NOT be nulled; this is a legitimate score the miner earned.
+        real_zero = {
+            "score": 0.0,
+            "explanation": "Trajectory does not justify the answer.",
+            "model": "zai-org/GLM-5.1-TEE",
+            "inference_failed": 0,
+            "inference_total": 1,
+        }
+        with self._make_reporter_with_judge(reporter, real_zero):
+            result = reporter._run_reasoning_judge(
+                dialogue=[{"role": "u", "content": "x"}], problem_id="p1"
+            )
+        assert result["reasoning_score"] == 0.0
+        assert result["reasoning_model"] == "zai-org/GLM-5.1-TEE"
+
+    def test_normal_judge_result_preserved(self, reporter):
+        ok = {
+            "score": 0.85,
+            "explanation": "Good reasoning.",
+            "model": "zai-org/GLM-5-TEE",
+            "inference_failed": 0,
+            "inference_total": 1,
+        }
+        with self._make_reporter_with_judge(reporter, ok):
+            result = reporter._run_reasoning_judge(
+                dialogue=[{"role": "u", "content": "x"}], problem_id="p1"
+            )
+        assert result["reasoning_score"] == 0.85
+        assert result["reasoning_model"] == "zai-org/GLM-5-TEE"

--- a/subnet/validator/progress_reporter.py
+++ b/subnet/validator/progress_reporter.py
@@ -22,7 +22,11 @@ from bittensor.utils.btlogging import logging
 
 from src.agent.problem_scorer import ProblemScorer, clear_product_cache
 from src.agent.sandbox_status import SandboxProblemStatus
-from src.agent.scoring import is_problem_successful, compute_aggregate, reasoning_coefficient
+from src.agent.scoring import (
+    is_problem_successful,
+    compute_aggregate,
+    reasoning_coefficient,
+)
 from src.agent.types import (
     AggregateScore,
     ProblemDict,
@@ -130,7 +134,9 @@ class ProgressReporter:
                     category = "product"
 
                 if query and reward:
-                    attach_title_embeddings(reward, problem.get("reward_title_embeddings"))
+                    attach_title_embeddings(
+                        reward, problem.get("reward_title_embeddings")
+                    )
                     category_rewards.setdefault(category, {})[query] = reward
 
                 if category == "voucher":
@@ -301,7 +307,9 @@ class ProgressReporter:
                 )
 
             # Check idle timeout: no new output and no in-flight scoring
-            pending_futures = sum(1 for f in self._scoring_futures.values() if not f.done())
+            pending_futures = sum(
+                1 for f in self._scoring_futures.values() if not f.done()
+            )
             if (
                 self._hard_deadline is not None
                 and last_activity_at is not None
@@ -344,7 +352,9 @@ class ProgressReporter:
 
             # Log progress periodically after sandbox exits
             if self._hard_deadline is not None and newly_dispatched == 0:
-                elapsed = int(time.time() - (self._hard_deadline - self.scoring_timeout))
+                elapsed = int(
+                    time.time() - (self._hard_deadline - self.scoring_timeout)
+                )
                 logging.info(
                     f"Scored {result_count}/{self._total_problems} problems "
                     f"({pending_futures} in-flight), "
@@ -459,7 +469,9 @@ class ProgressReporter:
             with self._lock:
                 meta = self._envelope_meta.get(str(problem_id))
             execution_time = (
-                meta.execution_time if meta is not None else extra_info.get("execution_time")
+                meta.execution_time
+                if meta is not None
+                else extra_info.get("execution_time")
             )
             query = problem.get("query") or extra_info.get("query")
             category = problem.get("category", "product").lower()
@@ -523,7 +535,9 @@ class ProgressReporter:
         }
 
         with self._lock:
-            should_judge = bool(self._chutes_access_token and not self._judge_circuit_open)
+            should_judge = bool(
+                self._chutes_access_token and not self._judge_circuit_open
+            )
 
         if not should_judge:
             return empty
@@ -535,8 +549,30 @@ class ProgressReporter:
                 dialogue, api_key=self._chutes_access_token
             )
 
+            # Empty-sentinel detection: score_reasoning_quality returns
+            # score=0.0 / model="" / inference_total=0 when handed an empty
+            # dialogue (or one that the judge formatter strips to empty).
+            # Treat that as an infra-class skip — record reasoning_score=None
+            # so the problem is excluded from reasoning-coefficient
+            # aggregation rather than zero-rating the miner. Real judged
+            # zeros (model set, inference_total >= 1) are preserved.
+            if (
+                judge_result["score"] == 0.0
+                and judge_result["model"] == ""
+                and judge_result["inference_total"] == 0
+            ):
+                logging.warning(
+                    f"Reasoning judge skipped (empty dialogue) for problem "
+                    f"{problem_id}; recording reasoning_score=None."
+                )
+                return empty
+
             with self._lock:
-                if judge_result["inference_total"] > 0 and judge_result["inference_failed"] == judge_result["inference_total"]:
+                if (
+                    judge_result["inference_total"] > 0
+                    and judge_result["inference_failed"]
+                    == judge_result["inference_total"]
+                ):
                     self._consecutive_judge_failures += 1
                     if self._consecutive_judge_failures >= 3:
                         self._judge_circuit_open = True
@@ -609,7 +645,9 @@ class ProgressReporter:
                 score=r.score,
                 reasoning_score=r.reasoning_score,
                 score_components_summary=scs,
-                inference_failure_count=r.inference_failures if r.inference_total > 0 else None,
+                inference_failure_count=r.inference_failures
+                if r.inference_total > 0
+                else None,
                 inference_total=r.inference_total if r.inference_total > 0 else None,
                 execution_time=r.execution_time,
             )
@@ -641,7 +679,9 @@ class ProgressReporter:
             for pid in unscored:
                 self._results[pid] = ProblemResult(
                     problem_id=pid,
-                    category=self._id_to_problem[pid].get("category", "product").lower(),
+                    category=self._id_to_problem[pid]
+                    .get("category", "product")
+                    .lower(),
                     status=ProblemStatus.TIMED_OUT,
                     score=0.0,
                 )


### PR DESCRIPTION
## Description

`score_reasoning_quality` in `src/agent/reasoning_scorer.py` returns a sentinel `{score: 0.0, model: "", inference_total: 0}` when called with an empty dialogue (or one that the judge formatter strips to empty). The validator currently records that `0.0` as a real reasoning score and feeds it into the miner's reasoning-coefficient aggregation, which is unfair — the judge never actually rated the trajectory, but the miner's `final_score = success_rate × reasoning_coefficient` gets dragged down as if it had.

Detect the sentinel in `_run_reasoning_judge` and return the existing `empty` dict (`reasoning_score=None`) so the problem is excluded from aggregation. This mirrors the treatment already used when the judge circuit breaker is open or no Chutes token is available.

## Changes Made

- `subnet/validator/progress_reporter.py`: in `_run_reasoning_judge`, after the call to `score_reasoning_quality`, check for the empty-sentinel signature (`score=0.0 AND model="" AND inference_total=0`) and short-circuit to the `empty` return dict with a warning log line. A real judged zero has `inference_total >= 1` and a non-empty model, so it is preserved as-is.
- `subnet/tests/validator/test_progress_reporter_envelope.py`: three new test cases covering (a) empty sentinel → null score, (b) real judged zero preserved, (c) normal judged result preserved.

## Issue Link

- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing
N/A — pure unit-test change. The behavior under test fires only when `score_reasoning_quality` returns the empty sentinel, which is the exact case the patch handles.

**Test Results:**
13 tests in `test_progress_reporter_envelope.py` pass (the 10 existing + 3 new). Full `test_reasoning_scorer.py` (48 tests) also clean.

### Automated Testing

**Test Command(s):**
```bash
.venv/bin/pytest subnet/tests/validator/test_progress_reporter_envelope.py subnet/tests/test_reasoning_scorer.py -v
```


## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
Inline comment block at the new branch in `_run_reasoning_judge` explains the sentinel discriminator and why the patch returns `empty` instead of the judge result. No external docs touched.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

Discriminator rationale: the judge formatter at `src/agent/reasoning_scorer.py:617-623` returns the empty sentinel only when `dialogue` is falsy or `format_trajectory_for_judge(dialogue)` returns an empty string — both happen *before* any inference call, so `inference_total` is guaranteed to be 0. A real judge run that scored the trajectory zero has `inference_total >= 1` and a model name set, so the discriminator cleanly separates "skipped" from "scored zero".

This patch addresses the fairness half of a recurring upload/dialogue-loss pattern. The second half — making the per-problem trajectory artifact retrievable when this fires — is upload-side and out of scope for this PR.