### PR TITLE
fix(proxy): disable IPv6 resolution for OpenRouter upstream

### DIFF
--- a/docker/proxy/nginx.conf.template
+++ b/docker/proxy/nginx.conf.template
@@ -142,7 +142,10 @@ http {
         location /_openrouter_proxy/ {
             internal;
 
-            resolver 127.0.0.11 valid=30s;
+            # ipv6=off: openrouter.ai resolves to Cloudflare AAAA records the
+            # Docker bridge can't reach; without this nginx tries IPv6 first
+            # and every request fails with "Network unreachable".
+            resolver 127.0.0.11 ipv6=off valid=30s;
             set $openrouter_upstream https://${OPENROUTER_HOST};
 
             # Strip /_openrouter_proxy prefix and map to OpenRouter /api/v1/* API


### PR DESCRIPTION
## Description

Live test on staging revealed every OpenRouter inference request from a sandbox container failing with `connect() to [2606:4700::6812:273]:443 failed (101: Network unreachable)`. nginx returned 400 to the agent on every call.

Root cause: `openrouter.ai` is Cloudflare-fronted and returns AAAA records. The Docker bridge network can't reach IPv6 addresses, but the OR proxy block's resolver line had no `ipv6=off`, so nginx tried IPv6 first on every upstream connection and failed.

The Chutes proxy block (line 118) uses the same resolver config without `ipv6=off` and works fine — but `llm.chutes.ai` returns no AAAA records, so nginx never tries IPv6 there. OR is the only upstream where this matters.

## Changes Made

- Add `ipv6=off` to the `resolver` directive in the `/_openrouter_proxy/` location block in `docker/proxy/nginx.conf.template`
- Comment explaining why (so the next person doesn't strip it as redundant)

## Issue Link

- Related to: ORO-1039 (parent, Done)

## Testing

### Manual Testing

Confirmed live on staging proxy logs (i-0017e8a2f060e9a5c) — every OR-routed request was failing with the IPv6 unreachable error before this change. Will verify post-merge that requests now reach OR successfully.

```bash
docker logs shoppingbench-proxy 2>&1 | grep "Network unreachable"
# pre-fix: many entries
# post-fix: zero
```

**Test Results:** N/A — single nginx config flag.

### Automated Testing

nginx config templating happens at container start; smoke test is just "the proxy container starts".

**Test Command(s):**
```bash
# Verify template is valid
envsubst '$$OPENROUTER_HOST' < docker/proxy/nginx.conf.template | head -160 | tail -20
```


## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:** Inline comment added to the resolver line.
## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

Once merged, tag a new oro-public version and Watchtower will pick up the new proxy image on staging within ~5 min.