### PR TITLE
fix(proxy): forward ?provider= arg to Backend allowlist endpoint

### DIFF
--- a/docker/proxy/nginx.conf.template
+++ b/docker/proxy/nginx.conf.template
@@ -89,7 +89,11 @@ http {
             internal;
 
             resolver 1.1.1.1 ipv6=off valid=300s;
-            set $backend_models_url ${BACKEND_URL}/v1/public/inference/models;
+            # Forward the ?provider= arg from the njs subrequest. proxy_pass
+            # with a variable URL drops the original query string, so without
+            # this the Backend always returns the Chutes (default) allowlist
+            # and the OR cache silently stores Chutes-named models.
+            set $backend_models_url ${BACKEND_URL}/v1/public/inference/models?provider=$arg_provider;
             proxy_method GET;
             proxy_pass $backend_models_url;
             proxy_ssl_server_name on;


### PR DESCRIPTION
## Description

Every OpenRouter-routed inference request was rejected by `validate_model.js` with `Model not allowed for openrouter: <some-model>` — even though the model was listed in the Backend's OpenRouter allowlist response.

Root cause: `nginx.conf.template` defines the `/_backend_models` internal location with:

```
set $backend_models_url ${BACKEND_URL}/v1/public/inference/models;
proxy_pass $backend_models_url;
```

When `proxy_pass` is given a variable URL, nginx does NOT append the original request's query string. The njs subrequest from `getAllowlist()` passes `args: "provider=" + provider`, but it gets dropped on the way upstream. The Backend's endpoint defaults to its primary allowlist when no `provider=` arg is present, so the proxy cached the wrong models under the OpenRouter cache key. Every OR-bound request then failed validate.js's `indexOf` check against the cached (wrong) list.

## Changes Made

- Append `?provider=$arg_provider` to `$backend_models_url` so nginx forwards the subrequest's provider arg through to the Backend
- Inline comment explaining the proxy_pass + variable trap so the next person doesn't strip it as redundant

## Testing

### Manual Testing

Pre-fix: every OR call failed at validate.js with the wrong-allowlist 403. Post-fix: validate.js accepts OR model names from the right allowlist; requests reach OR.

**Test Results:** N/A — single nginx variable change.

### Automated Testing

nginx config is templated at container start; smoke test is "the proxy container starts and responds 200 to /health".


## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:** Inline comment added explaining the proxy_pass + variable trap.
## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

N/A