### PR TITLE
feat(judge): support OpenRouter as inference provider for reasoning scoring

### DIFF
--- a/src/agent/reasoning_scorer.py
+++ b/src/agent/reasoning_scorer.py
@@ -34,19 +34,28 @@ logger = logging.getLogger(__name__)
 
 PROXY_URL = "http://proxy:80"
 
-# Chutes TEE judges (must use -TEE suffix for proxy allowlist).
-# Ordered by load via the Chutes utilization API on every selection.
+# Per-provider judge model lists. Same models, different naming conventions:
+# Chutes uses TEE-suffixed names (required by proxy allowlist on the Chutes
+# upstream); OpenRouter uses lowercase author/model names.
 #
-# These four models score reasoning trajectories near-identically under
-# the decision-tree prompt below — same trajectory is rated within a
-# single bin across all four. Other Chutes models tested either gave
-# uncorrelated scores, sat outside the consensus distribution, or had
-# insufficient capacity to support a steady judge rotation.
-JUDGE_MODELS = [
-    "zai-org/GLM-5.1-TEE",
-    "google/gemma-4-31B-turbo-TEE",
-    "zai-org/GLM-5-TEE",
-]
+# These models score reasoning trajectories near-identically under the
+# decision-tree prompt below — same trajectory is rated within a single bin
+# across all of them.
+JUDGE_MODELS_BY_PROVIDER: dict[str, list[str]] = {
+    "chutes": [
+        "zai-org/GLM-5.1-TEE",
+        "google/gemma-4-31B-turbo-TEE",
+        "zai-org/GLM-5-TEE",
+    ],
+    "openrouter": [
+        "z-ai/glm-5.1",
+        "google/gemma-4-31b-it",
+        "z-ai/glm-5",
+    ],
+}
+
+# Kept for back-compat with any external caller that referenced the old name.
+JUDGE_MODELS = JUDGE_MODELS_BY_PROVIDER["chutes"]
 
 CHUTES_UTILIZATION_URL = "https://api.chutes.ai/chutes/utilization"
 CHUTES_UTILIZATION_TIMEOUT = 5
@@ -57,21 +66,21 @@ _MODEL_ORDER_CACHE_TTL_SECONDS = 30
 _model_order_cache: tuple[float, list[str]] | None = None
 
 
-def _select_models_by_utilization() -> list[str]:
-    """Query Chutes utilization API and return JUDGE_MODELS sorted by load.
+def _select_models_for_provider(provider: str) -> list[str]:
+    """Return the judge model list for the given provider.
 
-    Models reported with zero active instances are excluded. Chutes can
-    descale a model to 0 when idle; the utilization API then reports
-    utilization_current=0.0 (no traffic → no load), which would otherwise
-    make the ascending sort prefer it. Every call routed to a 0-instance
-    model fails, and those failures count toward the judge-infra-failure
-    threshold in the validator.
-
-    Returns models sorted by utilization_current (ascending = least loaded
-    first), excluding any with active_instance_count == 0. Falls back to
-    the static JUDGE_MODELS list on any API failure, or if filtering would
-    leave no models. Result is cached for ``_MODEL_ORDER_CACHE_TTL_SECONDS``.
+    For chutes, query the utilization API to skip 0-instance models and sort
+    by load (cached for ``_MODEL_ORDER_CACHE_TTL_SECONDS``). OpenRouter has
+    no equivalent utilization signal, so we return the static list.
     """
+    models = JUDGE_MODELS_BY_PROVIDER.get(provider)
+    if not models:
+        logger.warning(f"No judge models configured for provider={provider}; using chutes")
+        models = JUDGE_MODELS_BY_PROVIDER["chutes"]
+
+    if provider != "chutes":
+        return list(models)
+
     global _model_order_cache
     now = time.monotonic()
     if _model_order_cache and now - _model_order_cache[0] < _MODEL_ORDER_CACHE_TTL_SECONDS:
@@ -82,7 +91,7 @@ def _select_models_by_utilization() -> list[str]:
     try:
         resp = requests.get(CHUTES_UTILIZATION_URL, timeout=CHUTES_UTILIZATION_TIMEOUT)
         if resp.status_code != 200:
-            result = list(JUDGE_MODELS)
+            result = list(models)
         else:
             entries_by_name = {e["name"]: e for e in resp.json()}
 
@@ -94,13 +103,13 @@ def _select_models_by_utilization() -> list[str]:
                 count = e.get("active_instance_count") if e else None
                 return count is None or count > 0
 
-            available = [m for m in JUDGE_MODELS if is_available(m)]
+            available = [m for m in models if is_available(m)]
             if not available:
                 logger.warning(
                     "All judge models report zero active instances on Chutes; "
                     "falling back to static model list"
                 )
-                result = list(JUDGE_MODELS)
+                result = list(models)
             else:
                 result = sorted(
                     available,
@@ -111,13 +120,13 @@ def _select_models_by_utilization() -> list[str]:
                     for m in result
                 ]
                 msg = "Judge model order by utilization: " + ", ".join(log_parts)
-                skipped = [m for m in JUDGE_MODELS if m not in available]
+                skipped = [m for m in models if m not in available]
                 if skipped:
                     msg += f" | skipped (0 instances): {', '.join(skipped)}"
                 logger.info(msg)
     except Exception as e:
         logger.warning(f"Failed to fetch Chutes utilization, using static model list: {e}")
-        result = list(JUDGE_MODELS)
+        result = list(models)
 
     _model_order_cache = (now, result)
     return list(result)
@@ -601,6 +610,7 @@ def score_reasoning_quality(
     api_key: str,
     proxy_url: str = PROXY_URL,
     max_retries: int = 8,
+    provider: str = "chutes",
 ) -> JudgeResult:
     """Score reasoning quality of an agent trajectory using an LLM judge.
 
@@ -625,7 +635,7 @@ def score_reasoning_quality(
     url = f"{proxy_url.rstrip('/')}/inference/chat/completions"
     headers = {"Authorization": f"Bearer {api_key}"}
 
-    models = _select_models_by_utilization()
+    models = _select_models_for_provider(provider)
     # Models that returned an unparseable 200 in this eval. Skipped on
     # subsequent rotation steps so a single broken model (e.g. Chutes
     # serving empty `content` for one TEE variant while reporting healthy

--- a/subnet/tests/test_reasoning_scorer.py
+++ b/subnet/tests/test_reasoning_scorer.py
@@ -6,7 +6,7 @@ import pytest
 
 from reasoning_scorer import (
     _format_proxy_call,
-    _select_models_by_utilization,
+    _select_models_for_provider,
     _summarize_proxy_calls,
     score_reasoning_quality,
     format_trajectory_for_judge,
@@ -365,7 +365,7 @@ class TestSelectModelsByUtilization:
             for i, m in enumerate(JUDGE_MODELS)
         ]
         with patch("reasoning_scorer.requests.get", return_value=self._mock_response(entries)):
-            result = _select_models_by_utilization()
+            result = _select_models_for_provider("chutes")
         assert result == list(reversed(JUDGE_MODELS))
 
     def test_missing_model_treated_as_fully_loaded(self):
@@ -373,19 +373,19 @@ class TestSelectModelsByUtilization:
         # they sort to the end.
         entries = [{"name": JUDGE_MODELS[-1], "utilization_current": 0.1}]
         with patch("reasoning_scorer.requests.get", return_value=self._mock_response(entries)):
-            result = _select_models_by_utilization()
+            result = _select_models_for_provider("chutes")
         assert result[0] == JUDGE_MODELS[-1]
 
     def test_api_failure_returns_static_list(self):
         with patch("reasoning_scorer.requests.get", side_effect=Exception("boom")):
-            result = _select_models_by_utilization()
+            result = _select_models_for_provider("chutes")
         assert result == JUDGE_MODELS
 
     def test_non_200_returns_static_list(self):
         resp = MagicMock()
         resp.status_code = 500
         with patch("reasoning_scorer.requests.get", return_value=resp):
-            result = _select_models_by_utilization()
+            result = _select_models_for_provider("chutes")
         assert result == JUDGE_MODELS
 
     def test_zero_active_instances_excluded(self):
@@ -400,7 +400,7 @@ class TestSelectModelsByUtilization:
             for m in healthy
         ]
         with patch("reasoning_scorer.requests.get", return_value=self._mock_response(entries)):
-            result = _select_models_by_utilization()
+            result = _select_models_for_provider("chutes")
         assert descaled not in result
         assert set(result) == set(healthy)
 
@@ -413,7 +413,7 @@ class TestSelectModelsByUtilization:
             for m in JUDGE_MODELS
         ]
         with patch("reasoning_scorer.requests.get", return_value=self._mock_response(entries)):
-            result = _select_models_by_utilization()
+            result = _select_models_for_provider("chutes")
         assert result == list(JUDGE_MODELS)
 
     def test_missing_active_instance_count_field_treated_as_available(self):
@@ -424,7 +424,7 @@ class TestSelectModelsByUtilization:
             for i, m in enumerate(JUDGE_MODELS)
         ]
         with patch("reasoning_scorer.requests.get", return_value=self._mock_response(entries)):
-            result = _select_models_by_utilization()
+            result = _select_models_for_provider("chutes")
         assert set(result) == set(JUDGE_MODELS)
 
 
@@ -445,9 +445,9 @@ class TestSelectModelsByUtilizationCache:
         with patch(
             "reasoning_scorer.requests.get", return_value=self._mock_response(entries)
         ) as mock_get:
-            first = _select_models_by_utilization()
-            second = _select_models_by_utilization()
-            third = _select_models_by_utilization()
+            first = _select_models_for_provider("chutes")
+            second = _select_models_for_provider("chutes")
+            third = _select_models_for_provider("chutes")
 
         assert mock_get.call_count == 1
         assert first == second == third
@@ -463,10 +463,10 @@ class TestSelectModelsByUtilizationCache:
             ],
         ) as mock_get:
             with patch("reasoning_scorer.time.monotonic", return_value=0.0):
-                first = _select_models_by_utilization()
+                first = _select_models_for_provider("chutes")
             # 31s later — past the 30s TTL.
             with patch("reasoning_scorer.time.monotonic", return_value=31.0):
-                second = _select_models_by_utilization()
+                second = _select_models_for_provider("chutes")
 
         assert mock_get.call_count == 2
         assert first[0] == JUDGE_MODELS[0]
@@ -480,9 +480,9 @@ class TestSelectModelsByUtilizationCache:
         with patch(
             "reasoning_scorer.requests.get", return_value=self._mock_response(entries)
         ):
-            first = _select_models_by_utilization()
+            first = _select_models_for_provider("chutes")
             first.pop(0)
-            second = _select_models_by_utilization()
+            second = _select_models_for_provider("chutes")
         assert len(second) == len(JUDGE_MODELS)
 
     def test_failure_result_is_cached(self):
@@ -492,8 +492,8 @@ class TestSelectModelsByUtilizationCache:
         with patch(
             "reasoning_scorer.requests.get", side_effect=Exception("boom")
         ) as mock_get:
-            first = _select_models_by_utilization()
-            second = _select_models_by_utilization()
+            first = _select_models_for_provider("chutes")
+            second = _select_models_for_provider("chutes")
 
         assert mock_get.call_count == 1
         assert first == second == list(JUDGE_MODELS)

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -782,6 +782,7 @@ class Validator:
                 problems=problems,
                 workspace_dir=workspace_dir,
                 chutes_access_token=chutes_access_token,
+                inference_provider=inference_provider,
             )
             progress_reporter.start_monitoring()
 

--- a/subnet/validator/progress_reporter.py
+++ b/subnet/validator/progress_reporter.py
@@ -64,6 +64,7 @@ class ProgressReporter:
         poll_interval: float = 1.0,
         scoring_timeout: float = 900.0,
         chutes_access_token: Optional[str] = None,
+        inference_provider: Optional[str] = None,
         max_scoring_workers: int = DEFAULT_SCORING_WORKERS,
     ):
         self.backend_client = backend_client
@@ -74,6 +75,7 @@ class ProgressReporter:
         self.poll_interval = poll_interval
         self.scoring_timeout = scoring_timeout
         self._chutes_access_token = chutes_access_token
+        self._inference_provider = inference_provider or "chutes"
 
         self._stop_event = threading.Event()
         self._hard_deadline: Optional[float] = None
@@ -532,7 +534,9 @@ class ProgressReporter:
             from src.agent.reasoning_scorer import score_reasoning_quality
 
             judge_result = score_reasoning_quality(
-                dialogue, api_key=self._chutes_access_token
+                dialogue,
+                api_key=self._chutes_access_token,
+                provider=self._inference_provider,
             )
 
             with self._lock:


### PR DESCRIPTION
## Description

The reasoning judge in `ProgressReporter` was Chutes-only: hardcoded `JUDGE_MODELS` list with TEE-suffixed names, Chutes utilization API queried for load-based ordering, no awareness of `inference_provider`. When a miner's `default_inference_provider` was openrouter, the proxy correctly detected the `sk-or-v1` token and routed to OR, but the judge sent Chutes-named models like `zai-org/GLM-5.1-TEE` which OR rejects (and the proxy's allowlist also rejects after the per-provider allowlist fix landed). The agent's `reasoning_scorer` interpreted the resulting 403 as auth failure and aborted, tripping the circuit breaker after 3 problems and failing the eval.

This PR adds per-provider model lists, a per-provider selector (Chutes uses utilization API; OR uses static order — OR has no equivalent aggregate load signal yet), and threads `inference_provider` through `ProgressReporter -> score_reasoning_quality`. The OR model names are the lowercase-author equivalents already on OR's catalog and present in the Backend's `ALLOWED_OPENROUTER_MODELS` allowlist.

A follow-up will replace the static OR rotation with real load-based ordering from OR's per-endpoint `/api/v1/models/<id>/endpoints` stats once the Backend exposes a centralized ranking endpoint.

## Changes Made

- `src/agent/reasoning_scorer.py`: replace `JUDGE_MODELS` with `JUDGE_MODELS_BY_PROVIDER` dict (chutes + openrouter); rename `_select_models_by_utilization` to `_select_models_for_provider`; OR returns the static list (no utilization signal yet); `score_reasoning_quality` accepts a `provider` kwarg defaulting to `"chutes"` for back-compat
- `subnet/validator/progress_reporter.py`: accept `inference_provider` in `__init__`; pass it through to `score_reasoning_quality`
- `subnet/validator/main.py`: re-add `inference_provider=` kwarg to the `ProgressReporter()` call (was dropped in #136 because the receiver didn't accept it)
- `subnet/tests/test_reasoning_scorer.py`: update import + call sites for the renamed selector

## Testing

### Manual Testing

Verified locally with a real OR-funded eval:

- Pre-fix: judge logs show `Judge auth failure (403) with zai-org/GLM-5-TEE` -> circuit breaker trips -> eval FAILED with 3/3 judge calls failing
- Post-fix: judge calls flow through proxy -> OR with model `z-ai/glm-5.1` -> 200 responses; `Reasoning score: 0.90 ... model=z-ai/glm-5.1` lines for every problem
- Same validator on the Chutes path is unchanged (defaults `provider="chutes"` if caller doesn't set it)

**Test Results:**

```
Reasoning score: 0.90 (problem=..., model=z-ai/glm-5.1)
Reasoning score: 0.70 (problem=..., model=z-ai/glm-5.1)
Reasoning score: 0.90 (problem=..., model=z-ai/glm-5.1)
... (all 200s, no auth failures)
```

### Automated Testing

48/48 in `subnet/tests/test_reasoning_scorer.py` pass after the rename.

**Test Command(s):**
```bash
PYTHONPATH=src python3 -m pytest subnet/tests/test_reasoning_scorer.py -v
```


## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:** Inline docstrings updated for the per-provider selector.
## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

N/A