### PR TITLE
feat: provider-aware default agent + local test rig (Chutes + OpenRouter)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,11 +4,20 @@
 
 # === MINER LOCAL TESTING ===
 
-# Chutes API key for LLM inference when testing agents locally.
-# Only needed for: docker compose run test --agent-file agent.py
+# Set ONE inference provider's API key for testing agents locally.
+# The test runner picks whichever key is set; if both are set, use
+# INFERENCE_PROVIDER below to choose. Only needed for:
+#   docker compose run test --agent-file agent.py
 # Not needed for validators (miner tokens are forwarded automatically).
-# Get one at: https://chutes.ai/
+
+# Chutes API key. Get one at: https://chutes.ai/
 CHUTES_API_KEY=
+
+# OpenRouter API key. Get one at: https://openrouter.ai/keys
+OPENROUTER_API_KEY=
+
+# Optional override when both keys are set. One of: chutes, openrouter
+INFERENCE_PROVIDER=
 
 # === OPTIONAL (defaults shown) ===
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -213,6 +213,8 @@ services:
       - SANDBOX_IMAGE=${SANDBOX_IMAGE:-ghcr.io/oro-ai/oro/sandbox:${IMAGE_TAG:-stable}}
       - SANDBOX_NETWORK=sandbox-network
       - CHUTES_API_KEY=${CHUTES_API_KEY:-}
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - INFERENCE_PROVIDER=${INFERENCE_PROVIDER:-}
     # Use the venv interpreter — bare `python` is the system Python and
     # has no project dependencies installed (e.g. `requests`).
     entrypoint: [".venv/bin/python", "-m", "subnet.test_runner"]

--- a/docs/miner-guide.md
+++ b/docs/miner-guide.md
@@ -9,8 +9,10 @@ To test your agent locally before submitting, use the ORO test harness:
 ```bash
 git clone https://github.com/ORO-AI/oro.git
 cd oro
-cp .env.example .env   # Add your CHUTES_API_KEY
+cp .env.example .env   # Set CHUTES_API_KEY or OPENROUTER_API_KEY
 ```
+
+The test harness supports both Chutes and OpenRouter for inference. Set whichever key you have. If you set both, pick one with `INFERENCE_PROVIDER=chutes` or `INFERENCE_PROVIDER=openrouter`.
 
 ```bash
 # Test with the default agent

--- a/src/agent/agent.py
+++ b/src/agent/agent.py
@@ -28,6 +28,23 @@ logger = logging.getLogger(__name__)
 
 MAX_STEPS = 25
 
+# Per-provider default model. Naming conventions differ across providers
+# (Chutes uses TEE-suffixed author/Model; OpenRouter uses lowercase
+# author/model), so the agent picks the right name based on the
+# INFERENCE_PROVIDER env var injected by the validator sandbox.
+_DEFAULT_MODEL_BY_PROVIDER: Dict[str, str] = {
+    "chutes": "deepseek-ai/DeepSeek-V3.2-TEE",
+    "openrouter": "deepseek/deepseek-v3.2",
+}
+
+
+def _default_model_for_provider() -> str:
+    provider = getenv("INFERENCE_PROVIDER", "chutes")
+    return _DEFAULT_MODEL_BY_PROVIDER.get(
+        provider, _DEFAULT_MODEL_BY_PROVIDER["chutes"]
+    )
+
+
 _proxy = ProxyClient(timeout=120, max_retries=2)
 
 @Tool
@@ -618,7 +635,7 @@ def agent_main(problem_data: Dict) -> List[Dict]:
     """
     steps = []
     query = problem_data.get("query", "")
-    model = getenv("SANDBOX_MODEL", "deepseek-ai/DeepSeek-V3.2-TEE")
+    model = getenv("SANDBOX_MODEL") or _default_model_for_provider()
 
     logger.info(f"[ReAct] Processing query: {query}")
 

--- a/subnet/test_runner.py
+++ b/subnet/test_runner.py
@@ -45,8 +45,38 @@ def _write_jsonl(problems: list[dict], output_path: Path) -> None:
             f.write(json.dumps(p) + "\n")
 
 
+_CHUTES_INFERENCE_BASE_URL = "https://llm.chutes.ai/v1"
+_OPENROUTER_INFERENCE_BASE_URL = "https://openrouter.ai/api/v1"
+
+
+def _resolve_inference_credentials() -> tuple[str | None, str | None, str | None]:
+    """Resolve (api_key, provider, base_url) for the local test rig.
+
+    Honors an explicit INFERENCE_PROVIDER override; otherwise infers from
+    which key env var is set. Returns (None, None, None) if neither is set.
+    """
+    or_key = os.environ.get("OPENROUTER_API_KEY")
+    chutes_key = os.environ.get("CHUTES_API_KEY")
+
+    explicit = os.environ.get("INFERENCE_PROVIDER")
+    if explicit == "openrouter" and or_key:
+        return or_key, "openrouter", _OPENROUTER_INFERENCE_BASE_URL
+    if explicit == "chutes" and chutes_key:
+        return chutes_key, "chutes", _CHUTES_INFERENCE_BASE_URL
+
+    if or_key:
+        return or_key, "openrouter", _OPENROUTER_INFERENCE_BASE_URL
+    if chutes_key:
+        return chutes_key, "chutes", _CHUTES_INFERENCE_BASE_URL
+    return None, None, None
+
+
 def _score_output(
-    output_file: Path, problems: list[dict], chutes_key: str | None = None, skip_reasoning: bool = False
+    output_file: Path,
+    problems: list[dict],
+    api_key: str | None = None,
+    provider: str | None = None,
+    skip_reasoning: bool = False,
 ) -> float:
     """Score agent output using ProblemScorer and reasoning judge.
 
@@ -143,8 +173,8 @@ def _score_output(
 
     success_rate = agg["success_rate"]
 
-    # Reasoning quality scoring (uses same Chutes token as sandbox)
-    if skip_reasoning or not chutes_key:
+    # Reasoning quality scoring (uses same inference token as sandbox)
+    if skip_reasoning or not api_key:
         return success_rate
 
     print()
@@ -155,7 +185,9 @@ def _score_output(
     for i, dialogue in enumerate(dialogues):
         query = scores[i]["query"]
         short_query = query[:55] + "..." if len(query) > 55 else query
-        result = score_reasoning_quality(dialogue, api_key=chutes_key)
+        result = score_reasoning_quality(
+            dialogue, api_key=api_key, provider=provider or "chutes"
+        )
         reasoning_scores.append(result["score"])
         total_failed += result["inference_failed"]
         total_calls += result["inference_total"]
@@ -254,7 +286,8 @@ def run_test(
     print("Starting sandbox...")
 
     # Build docker run command
-    chutes_key = os.environ.get("CHUTES_API_KEY")
+    api_key, provider, base_url = _resolve_inference_credentials()
+    print(f"Provider: {provider or '(none)'}")
     cmd = build_sandbox_command(
         agent_host_path=host_agent,
         logs_host_path=host_logs,
@@ -262,7 +295,9 @@ def run_test(
         output_path=f"/app/logs/sandbox_output_{eval_id}.jsonl",
         extra_volumes=[(host_problem, "/tmp/test_problems.jsonl")],
         max_workers=max_workers,
-        chutes_access_token=chutes_key,
+        chutes_access_token=api_key,
+        inference_provider=provider,
+        inference_base_url=base_url,
     )
 
     try:
@@ -286,7 +321,13 @@ def run_test(
     # Score using ProblemScorer (HTTP calls to search-server, no pyserini)
     print()
     print("Scoring results...")
-    return _score_output(output_file, problems, chutes_key=chutes_key, skip_reasoning=skip_reasoning)
+    return _score_output(
+        output_file,
+        problems,
+        api_key=api_key,
+        provider=provider,
+        skip_reasoning=skip_reasoning,
+    )
 
 
 def main():
@@ -319,19 +360,21 @@ def main():
     parser.add_argument(
         "--skip-reasoning",
         action="store_true",
-        help="Skip reasoning quality scoring to save Chutes API calls",
+        help="Skip reasoning quality scoring to save inference API calls",
     )
 
     args = parser.parse_args()
 
-    # Fail fast on a missing/empty Chutes key — without one the agent's
-    # inference calls hit the proxy, get 429'd, and silently retry for
-    # ~3 minutes before the run aborts.
-    if not os.environ.get("CHUTES_API_KEY"):
+    # Fail fast on a missing inference key — without one the agent's
+    # inference calls fail and the run aborts with empty output.
+    api_key, provider, _ = _resolve_inference_credentials()
+    if not api_key:
         print(
-            "Error: CHUTES_API_KEY is not set.\n"
-            "  Set it in your shell or copy .env.example to .env and fill it in.\n"
-            "  Get a key at https://chutes.ai/",
+            "Error: no inference API key set.\n"
+            "  Set one of CHUTES_API_KEY or OPENROUTER_API_KEY in your shell\n"
+            "  or copy .env.example to .env and fill it in.\n"
+            "  Get a Chutes key at https://chutes.ai/ or an OpenRouter key at\n"
+            "  https://openrouter.ai/.",
             file=sys.stderr,
         )
         sys.exit(2)


### PR DESCRIPTION
## Description

Two related changes that together let miners run the local test rig (`docker compose run test --agent-file ...`) against either Chutes or OpenRouter without forking the agent template.

**1. Default agent picks model name from `INFERENCE_PROVIDER` env var**

The default agent had a single hardcoded `SANDBOX_MODEL` fallback — `deepseek-ai/DeepSeek-V3.2-TEE` — which is a Chutes-style name. When the validator sandbox runs the agent with `INFERENCE_PROVIDER=openrouter`, the agent ignored that env var and sent the Chutes-suffixed name, so OpenRouter returned 400 ("unknown model") on every inference call.

Add a per-provider default-model map and resolve from `INFERENCE_PROVIDER` at runtime. `SANDBOX_MODEL` still overrides if set, so miners with custom forks keep their existing override knob.

Mapping:
- `chutes` → `deepseek-ai/DeepSeek-V3.2-TEE`
- `openrouter` → `deepseek/deepseek-v3.2`
- unknown provider → Chutes default (safe fallback)

**2. Local test rig accepts either provider**

`subnet/test_runner.py` was hardcoded to `CHUTES_API_KEY`: it set `chutes_access_token` only, never passed `inference_provider` / `inference_base_url` to `build_sandbox_command`, and called `score_reasoning_quality` with no `provider=` kwarg. Miners couldn't test against OR through the standalone harness.

Add `_resolve_inference_credentials()`: honors an explicit `INFERENCE_PROVIDER=chutes|openrouter` override, otherwise infers from whichever key env var is set. Wires provider + base URL into the sandbox env vars and the reasoning judge. The harness now matches the multi-provider plumbing the validator already uses, so local results mirror what runs in production.

## Changes Made

- `src/agent/agent.py`: add `_DEFAULT_MODEL_BY_PROVIDER` dict + `_default_model_for_provider()` helper; replace `getenv("SANDBOX_MODEL", "deepseek-ai/DeepSeek-V3.2-TEE")` with `getenv("SANDBOX_MODEL") or _default_model_for_provider()`
- `subnet/test_runner.py`: add `_resolve_inference_credentials()`; pass provider + base_url through to sandbox + judge; update fail-fast check to accept either key
- `docker-compose.yml`: pass `OPENROUTER_API_KEY` and `INFERENCE_PROVIDER` to the test container alongside `CHUTES_API_KEY`
- `.env.example`: document the new env vars and how to choose when both are set
- `docs/miner-guide.md`: short note on dual-provider support

## Testing

### Manual Testing

Resolver behavior verified:
- No env keys → `(None, None, None)` → fail-fast with helpful message
- `CHUTES_API_KEY` only → chutes provider + chutes base URL
- `OPENROUTER_API_KEY` only → openrouter provider + openrouter base URL
- Both set, no override → openrouter (key precedence)
- Both set, `INFERENCE_PROVIDER=chutes` → chutes
- Both set, `INFERENCE_PROVIDER=openrouter` → openrouter

Default agent model resolution verified the same four ways (no env / chutes / openrouter / unknown). End-to-end through a real OR run is pending.

### Automated Testing

**Test Command(s):**
```bash
python3 -c "import ast; ast.parse(open('subnet/test_runner.py').read())"
python3 -c "import ast; ast.parse(open('src/agent/agent.py').read())"
```


## Documentation

- [x] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [x] Other documentation updated (please specify):

**Documentation Changes:** `.env.example` and `docs/miner-guide.md` updated to cover the dual-provider option.
## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

N/A