### PR TITLE
feat(judge): consume Backend ranked endpoint instead of polling Chutes directly

### DIFF
--- a/src/agent/reasoning_scorer.py
+++ b/src/agent/reasoning_scorer.py
@@ -57,10 +57,15 @@ JUDGE_MODELS_BY_PROVIDER: dict[str, list[str]] = {
 # Kept for back-compat with any external caller that referenced the old name.
 JUDGE_MODELS = JUDGE_MODELS_BY_PROVIDER["chutes"]
 
-# Timeout for the Backend ranked-endpoint fetch. Short — Backend serves
-# this from an in-memory snapshot, so a slow response means infra is
-# degraded and we'd rather fall back to the static list than block scoring.
 _RANKED_FETCH_TIMEOUT = 5
+
+# 30s coalesces per-validator bursts (~15 problems scoring in parallel) into
+# a single Backend call, and bounds Backend-facing QPS regardless of how
+# many validators run on one IP (the public allowlist endpoint is rate-limited
+# at 100 rpm/IP). Cache TTL ≤ Backend's own 60s upstream-poll cadence, so the
+# staleness ceiling is the same as if we hit Backend on every call.
+_RANKED_CACHE_TTL_SECONDS = 30
+_ranked_cache: dict[str, tuple[float, list[str]]] = {}
 
 
 def _static_fallback(provider: str) -> list[str]:
@@ -71,13 +76,15 @@ def _static_fallback(provider: str) -> list[str]:
 def _fetch_ranked_models(provider: str, backend_url: str | None) -> list[str]:
     """Fetch the per-provider ranked judge model list from the Backend.
 
-    The Backend's inference-provider monitor polls each upstream every 60s
-    and serves a ranked snapshot at ``/v1/public/inference/models?ranked=true``.
-    This replaces the previous per-validator polling of Chutes' utilization
-    API directly. Falls back to the static ``JUDGE_MODELS_BY_PROVIDER`` list
-    on any failure (no backend_url, network error, malformed response, empty
-    snapshot) so the judge keeps working even when the Backend is unreachable.
+    Cached locally for ``_RANKED_CACHE_TTL_SECONDS`` to coalesce parallel
+    scoring bursts. Falls back to the static ``JUDGE_MODELS_BY_PROVIDER``
+    list on any failure so the judge keeps working when Backend is down.
     """
+    cached = _ranked_cache.get(provider)
+    now = time.monotonic()
+    if cached and now - cached[0] < _RANKED_CACHE_TTL_SECONDS:
+        return list(cached[1])
+
     fallback = _static_fallback(provider)
     if not backend_url:
         return fallback
@@ -85,25 +92,30 @@ def _fetch_ranked_models(provider: str, backend_url: str | None) -> list[str]:
     try:
         resp = requests.get(
             url,
-            params={"provider": provider, "ranked": "true"},
+            params={"provider": provider, "ranked": True},
             timeout=_RANKED_FETCH_TIMEOUT,
         )
         if resp.status_code != 200:
             logger.warning(
                 "Ranked models fetch returned %s; using static list", resp.status_code
             )
-            return fallback
+            _ranked_cache[provider] = (now, fallback)
+            return list(fallback)
         body = resp.json()
-        ids = [m["id"] for m in body.get("models", []) if m.get("id") in fallback]
+        allowed = set(fallback)
+        ids = [m["id"] for m in body.get("models", []) if m.get("id") in allowed]
         if not ids:
-            return fallback
+            _ranked_cache[provider] = (now, fallback)
+            return list(fallback)
         ranked_by = body.get("ranked_by")
         if ranked_by:
             logger.info("Judge model order from Backend (%s): %s", ranked_by, ids)
-        return ids
+        _ranked_cache[provider] = (now, ids)
+        return list(ids)
     except Exception as exc:
         logger.warning("Failed to fetch ranked models, using static list: %s", exc)
-        return fallback
+        _ranked_cache[provider] = (now, fallback)
+        return list(fallback)
 
 JUDGE_SYSTEM_PROMPT = """\
 You evaluate a shopping agent's trajectory and decide whether the agent is using genuine LLM reasoning or pattern matching / regex.

--- a/src/agent/reasoning_scorer.py
+++ b/src/agent/reasoning_scorer.py
@@ -57,79 +57,53 @@ JUDGE_MODELS_BY_PROVIDER: dict[str, list[str]] = {
 # Kept for back-compat with any external caller that referenced the old name.
 JUDGE_MODELS = JUDGE_MODELS_BY_PROVIDER["chutes"]
 
-CHUTES_UTILIZATION_URL = "https://api.chutes.ai/chutes/utilization"
-CHUTES_UTILIZATION_TIMEOUT = 5
-
-# 30s coalesces per-validator bursts (~15 problems scoring in parallel)
-# while still picking up real load shifts within an eval.
-_MODEL_ORDER_CACHE_TTL_SECONDS = 30
-_model_order_cache: tuple[float, list[str]] | None = None
+# Timeout for the Backend ranked-endpoint fetch. Short — Backend serves
+# this from an in-memory snapshot, so a slow response means infra is
+# degraded and we'd rather fall back to the static list than block scoring.
+_RANKED_FETCH_TIMEOUT = 5
 
 
-def _select_models_for_provider(provider: str) -> list[str]:
-    """Return the judge model list for the given provider.
+def _static_fallback(provider: str) -> list[str]:
+    models = JUDGE_MODELS_BY_PROVIDER.get(provider) or JUDGE_MODELS_BY_PROVIDER["chutes"]
+    return list(models)
 
-    For chutes, query the utilization API to skip 0-instance models and sort
-    by load (cached for ``_MODEL_ORDER_CACHE_TTL_SECONDS``). OpenRouter has
-    no equivalent utilization signal, so we return the static list.
+
+def _fetch_ranked_models(provider: str, backend_url: str | None) -> list[str]:
+    """Fetch the per-provider ranked judge model list from the Backend.
+
+    The Backend's inference-provider monitor polls each upstream every 60s
+    and serves a ranked snapshot at ``/v1/public/inference/models?ranked=true``.
+    This replaces the previous per-validator polling of Chutes' utilization
+    API directly. Falls back to the static ``JUDGE_MODELS_BY_PROVIDER`` list
+    on any failure (no backend_url, network error, malformed response, empty
+    snapshot) so the judge keeps working even when the Backend is unreachable.
     """
-    models = JUDGE_MODELS_BY_PROVIDER.get(provider)
-    if not models:
-        logger.warning(f"No judge models configured for provider={provider}; using chutes")
-        models = JUDGE_MODELS_BY_PROVIDER["chutes"]
-
-    if provider != "chutes":
-        return list(models)
-
-    global _model_order_cache
-    now = time.monotonic()
-    if _model_order_cache and now - _model_order_cache[0] < _MODEL_ORDER_CACHE_TTL_SECONDS:
-        # Return a copy so a caller mutating its result can't poison
-        # subsequent reads inside the TTL window.
-        return list(_model_order_cache[1])
-
+    fallback = _static_fallback(provider)
+    if not backend_url:
+        return fallback
+    url = f"{backend_url.rstrip('/')}/v1/public/inference/models"
     try:
-        resp = requests.get(CHUTES_UTILIZATION_URL, timeout=CHUTES_UTILIZATION_TIMEOUT)
+        resp = requests.get(
+            url,
+            params={"provider": provider, "ranked": "true"},
+            timeout=_RANKED_FETCH_TIMEOUT,
+        )
         if resp.status_code != 200:
-            result = list(models)
-        else:
-            entries_by_name = {e["name"]: e for e in resp.json()}
-
-            def is_available(m: str) -> bool:
-                # Permissive on missing fields: not all entries carry
-                # active_instance_count, and a missing entry just means
-                # the model wasn't reported (still treat as usable).
-                e = entries_by_name.get(m)
-                count = e.get("active_instance_count") if e else None
-                return count is None or count > 0
-
-            available = [m for m in models if is_available(m)]
-            if not available:
-                logger.warning(
-                    "All judge models report zero active instances on Chutes; "
-                    "falling back to static model list"
-                )
-                result = list(models)
-            else:
-                result = sorted(
-                    available,
-                    key=lambda m: entries_by_name.get(m, {}).get("utilization_current", 1.0),
-                )
-                log_parts = [
-                    f"{m}({entries_by_name.get(m, {}).get('utilization_current', -1):.0%})"
-                    for m in result
-                ]
-                msg = "Judge model order by utilization: " + ", ".join(log_parts)
-                skipped = [m for m in models if m not in available]
-                if skipped:
-                    msg += f" | skipped (0 instances): {', '.join(skipped)}"
-                logger.info(msg)
-    except Exception as e:
-        logger.warning(f"Failed to fetch Chutes utilization, using static model list: {e}")
-        result = list(models)
-
-    _model_order_cache = (now, result)
-    return list(result)
+            logger.warning(
+                "Ranked models fetch returned %s; using static list", resp.status_code
+            )
+            return fallback
+        body = resp.json()
+        ids = [m["id"] for m in body.get("models", []) if m.get("id") in fallback]
+        if not ids:
+            return fallback
+        ranked_by = body.get("ranked_by")
+        if ranked_by:
+            logger.info("Judge model order from Backend (%s): %s", ranked_by, ids)
+        return ids
+    except Exception as exc:
+        logger.warning("Failed to fetch ranked models, using static list: %s", exc)
+        return fallback
 
 JUDGE_SYSTEM_PROMPT = """\
 You evaluate a shopping agent's trajectory and decide whether the agent is using genuine LLM reasoning or pattern matching / regex.
@@ -611,6 +585,7 @@ def score_reasoning_quality(
     proxy_url: str = PROXY_URL,
     max_retries: int = 8,
     provider: str = "chutes",
+    backend_url: str | None = None,
 ) -> JudgeResult:
     """Score reasoning quality of an agent trajectory using an LLM judge.
 
@@ -635,7 +610,7 @@ def score_reasoning_quality(
     url = f"{proxy_url.rstrip('/')}/inference/chat/completions"
     headers = {"Authorization": f"Bearer {api_key}"}
 
-    models = _select_models_for_provider(provider)
+    models = _fetch_ranked_models(provider, backend_url)
     # Models that returned an unparseable 200 in this eval. Skipped on
     # subsequent rotation steps so a single broken model (e.g. Chutes
     # serving empty `content` for one TEE variant while reporting healthy

--- a/subnet/tests/test_reasoning_scorer.py
+++ b/subnet/tests/test_reasoning_scorer.py
@@ -16,6 +16,12 @@ from reasoning_scorer import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _clear_ranked_cache(monkeypatch):
+    """Reset the per-provider ranked-models cache so tests don't observe each other."""
+    monkeypatch.setattr("reasoning_scorer._ranked_cache", {})
+
+
 def _make_dialogue(steps):
     """Build a dialogue from a list of (think_text, tool_calls) tuples."""
     dialogue = []
@@ -351,20 +357,14 @@ class TestFetchRankedModels:
         resp.json.return_value = body
         return resp
 
-    def test_returns_backend_order_for_chutes(self):
-        # Backend reordered the static list: last entry first.
-        backend_order = list(reversed(JUDGE_MODELS))
-        body = {"models": [{"id": m} for m in backend_order], "ranked_by": "x"}
+    @pytest.mark.parametrize("provider", ["chutes", "openrouter"])
+    def test_returns_backend_order(self, provider):
+        provider_models = JUDGE_MODELS_BY_PROVIDER[provider]
+        backend_order = list(reversed(provider_models))
+        body = {"models": [{"id": m} for m in backend_order]}
         with patch("reasoning_scorer.requests.get", return_value=self._mock_response(body)):
-            result = _fetch_ranked_models("chutes", "https://api.example.com")
+            result = _fetch_ranked_models(provider, "https://api.example.com")
         assert result == backend_order
-
-    def test_returns_backend_order_for_openrouter(self):
-        or_models = JUDGE_MODELS_BY_PROVIDER["openrouter"]
-        body = {"models": [{"id": m} for m in or_models], "ranked_by": "x"}
-        with patch("reasoning_scorer.requests.get", return_value=self._mock_response(body)):
-            result = _fetch_ranked_models("openrouter", "https://api.example.com")
-        assert result == or_models
 
     def test_no_backend_url_returns_static_fallback(self):
         result = _fetch_ranked_models("chutes", None)
@@ -384,7 +384,7 @@ class TestFetchRankedModels:
         assert result == JUDGE_MODELS
 
     def test_empty_models_array_returns_static_fallback(self):
-        body = {"models": [], "ranked_by": None}
+        body = {"models": []}
         with patch("reasoning_scorer.requests.get", return_value=self._mock_response(body)):
             result = _fetch_ranked_models("chutes", "https://api.example.com")
         assert result == JUDGE_MODELS
@@ -392,13 +392,7 @@ class TestFetchRankedModels:
     def test_unknown_models_in_response_filtered_out(self):
         # Backend may return models we don't statically support (e.g. catalog
         # drift). Drop them so the judge never tries an unrecognized model.
-        body = {
-            "models": [
-                {"id": "some/unknown-model"},
-                {"id": JUDGE_MODELS[0]},
-            ],
-            "ranked_by": "x",
-        }
+        body = {"models": [{"id": "some/unknown-model"}, {"id": JUDGE_MODELS[0]}]}
         with patch("reasoning_scorer.requests.get", return_value=self._mock_response(body)):
             result = _fetch_ranked_models("chutes", "https://api.example.com")
         assert result == [JUDGE_MODELS[0]]
@@ -410,8 +404,50 @@ class TestFetchRankedModels:
         ) as mock_get:
             _fetch_ranked_models("chutes", "https://api.example.com")
         call_kwargs = mock_get.call_args.kwargs
-        assert call_kwargs["params"] == {"provider": "chutes", "ranked": "true"}
+        assert call_kwargs["params"] == {"provider": "chutes", "ranked": True}
         assert mock_get.call_args.args[0].endswith("/v1/public/inference/models")
+
+    def test_warm_cache_skips_backend(self):
+        body = {"models": [{"id": JUDGE_MODELS[0]}]}
+        with patch(
+            "reasoning_scorer.requests.get", return_value=self._mock_response(body)
+        ) as mock_get:
+            _fetch_ranked_models("chutes", "https://api.example.com")
+            _fetch_ranked_models("chutes", "https://api.example.com")
+            _fetch_ranked_models("chutes", "https://api.example.com")
+        assert mock_get.call_count == 1
+
+    def test_stale_cache_refetches(self):
+        body_v1 = {"models": [{"id": JUDGE_MODELS[0]}]}
+        body_v2 = {"models": [{"id": JUDGE_MODELS[-1]}]}
+        with patch(
+            "reasoning_scorer.requests.get",
+            side_effect=[self._mock_response(body_v1), self._mock_response(body_v2)],
+        ):
+            with patch("reasoning_scorer.time.monotonic", return_value=0.0):
+                first = _fetch_ranked_models("chutes", "https://api.example.com")
+            with patch("reasoning_scorer.time.monotonic", return_value=31.0):
+                second = _fetch_ranked_models("chutes", "https://api.example.com")
+        assert first == [JUDGE_MODELS[0]]
+        assert second == [JUDGE_MODELS[-1]]
+
+    def test_failure_is_cached(self):
+        # A flapping Backend would otherwise be hammered every call. Cache
+        # the fallback result too; the TTL is what recovers.
+        with patch(
+            "reasoning_scorer.requests.get", side_effect=Exception("boom")
+        ) as mock_get:
+            _fetch_ranked_models("chutes", "https://api.example.com")
+            _fetch_ranked_models("chutes", "https://api.example.com")
+        assert mock_get.call_count == 1
+
+    def test_caller_mutation_does_not_corrupt_cache(self):
+        body = {"models": [{"id": m} for m in JUDGE_MODELS]}
+        with patch("reasoning_scorer.requests.get", return_value=self._mock_response(body)):
+            first = _fetch_ranked_models("chutes", "https://api.example.com")
+            first.pop(0)
+            second = _fetch_ranked_models("chutes", "https://api.example.com")
+        assert len(second) == len(JUDGE_MODELS)
 
 
 class TestFormatProxyCall:

--- a/subnet/tests/test_reasoning_scorer.py
+++ b/subnet/tests/test_reasoning_scorer.py
@@ -5,20 +5,15 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from reasoning_scorer import (
+    _fetch_ranked_models,
     _format_proxy_call,
-    _select_models_for_provider,
     _summarize_proxy_calls,
     score_reasoning_quality,
     format_trajectory_for_judge,
     parse_judge_response,
     JUDGE_MODELS,
+    JUDGE_MODELS_BY_PROVIDER,
 )
-
-
-@pytest.fixture(autouse=True)
-def _clear_model_order_cache(monkeypatch):
-    """Reset the 30s model-order cache so tests don't observe each other's mocks."""
-    monkeypatch.setattr("reasoning_scorer._model_order_cache", None)
 
 
 def _make_dialogue(steps):
@@ -347,156 +342,76 @@ class TestScoreReasoningQuality:
         assert len(JUDGE_MODELS) >= 1
 
 
-class TestSelectModelsByUtilization:
-    """Tests for _select_models_by_utilization routing logic."""
+class TestFetchRankedModels:
+    """Tests for the Backend ranked-endpoint consumer."""
 
-    def _mock_response(self, entries):
+    def _mock_response(self, body, status_code=200):
         resp = MagicMock()
-        resp.status_code = 200
-        resp.json.return_value = entries
+        resp.status_code = status_code
+        resp.json.return_value = body
         return resp
 
-    def test_sorts_by_utilization_ascending(self):
-        # Make each JUDGE_MODELS entry have a distinct utilization, reversed
-        # from the static order, and verify the returned list is sorted
-        # least-loaded first.
-        entries = [
-            {"name": m, "utilization_current": 0.9 - i * 0.1}
-            for i, m in enumerate(JUDGE_MODELS)
-        ]
-        with patch("reasoning_scorer.requests.get", return_value=self._mock_response(entries)):
-            result = _select_models_for_provider("chutes")
-        assert result == list(reversed(JUDGE_MODELS))
+    def test_returns_backend_order_for_chutes(self):
+        # Backend reordered the static list: last entry first.
+        backend_order = list(reversed(JUDGE_MODELS))
+        body = {"models": [{"id": m} for m in backend_order], "ranked_by": "x"}
+        with patch("reasoning_scorer.requests.get", return_value=self._mock_response(body)):
+            result = _fetch_ranked_models("chutes", "https://api.example.com")
+        assert result == backend_order
 
-    def test_missing_model_treated_as_fully_loaded(self):
-        # Models not present in the utilization response default to 1.0, so
-        # they sort to the end.
-        entries = [{"name": JUDGE_MODELS[-1], "utilization_current": 0.1}]
-        with patch("reasoning_scorer.requests.get", return_value=self._mock_response(entries)):
-            result = _select_models_for_provider("chutes")
-        assert result[0] == JUDGE_MODELS[-1]
+    def test_returns_backend_order_for_openrouter(self):
+        or_models = JUDGE_MODELS_BY_PROVIDER["openrouter"]
+        body = {"models": [{"id": m} for m in or_models], "ranked_by": "x"}
+        with patch("reasoning_scorer.requests.get", return_value=self._mock_response(body)):
+            result = _fetch_ranked_models("openrouter", "https://api.example.com")
+        assert result == or_models
 
-    def test_api_failure_returns_static_list(self):
-        with patch("reasoning_scorer.requests.get", side_effect=Exception("boom")):
-            result = _select_models_for_provider("chutes")
+    def test_no_backend_url_returns_static_fallback(self):
+        result = _fetch_ranked_models("chutes", None)
         assert result == JUDGE_MODELS
 
-    def test_non_200_returns_static_list(self):
-        resp = MagicMock()
-        resp.status_code = 500
-        with patch("reasoning_scorer.requests.get", return_value=resp):
-            result = _select_models_for_provider("chutes")
-        assert result == JUDGE_MODELS
-
-    def test_zero_active_instances_excluded(self):
-        # A model at 0% utilization would otherwise sort first — but if it's
-        # reporting active_instance_count == 0 (Chutes descaled it) every call
-        # fails. It must be filtered out of the returned order.
-        descaled, *healthy = JUDGE_MODELS
-        entries = [
-            {"name": descaled, "utilization_current": 0.0, "active_instance_count": 0},
-        ] + [
-            {"name": m, "utilization_current": 0.5, "active_instance_count": 4}
-            for m in healthy
-        ]
-        with patch("reasoning_scorer.requests.get", return_value=self._mock_response(entries)):
-            result = _select_models_for_provider("chutes")
-        assert descaled not in result
-        assert set(result) == set(healthy)
-
-    def test_all_zero_active_instances_falls_back_to_static(self):
-        # If every judge model is descaled, prefer the static list over
-        # returning an empty order (calls will still fail, but the validator
-        # behavior stays predictable).
-        entries = [
-            {"name": m, "utilization_current": 0.0, "active_instance_count": 0}
-            for m in JUDGE_MODELS
-        ]
-        with patch("reasoning_scorer.requests.get", return_value=self._mock_response(entries)):
-            result = _select_models_for_provider("chutes")
-        assert result == list(JUDGE_MODELS)
-
-    def test_missing_active_instance_count_field_treated_as_available(self):
-        # Older/partial Chutes responses that omit active_instance_count must
-        # not cause models to be silently dropped.
-        entries = [
-            {"name": m, "utilization_current": 0.1 * i}
-            for i, m in enumerate(JUDGE_MODELS)
-        ]
-        with patch("reasoning_scorer.requests.get", return_value=self._mock_response(entries)):
-            result = _select_models_for_provider("chutes")
-        assert set(result) == set(JUDGE_MODELS)
-
-
-class TestSelectModelsByUtilizationCache:
-    """Caching layer over the Chutes utilization fetch (ORO-819)."""
-
-    def _mock_response(self, entries):
-        resp = MagicMock()
-        resp.status_code = 200
-        resp.json.return_value = entries
-        return resp
-
-    def test_warm_cache_skips_api(self):
-        entries = [
-            {"name": m, "utilization_current": 0.1 * i}
-            for i, m in enumerate(JUDGE_MODELS)
-        ]
-        with patch(
-            "reasoning_scorer.requests.get", return_value=self._mock_response(entries)
-        ) as mock_get:
-            first = _select_models_for_provider("chutes")
-            second = _select_models_for_provider("chutes")
-            third = _select_models_for_provider("chutes")
-
-        assert mock_get.call_count == 1
-        assert first == second == third
-
-    def test_stale_cache_refetches(self):
-        entries_v1 = [{"name": JUDGE_MODELS[0], "utilization_current": 0.1}]
-        entries_v2 = [{"name": JUDGE_MODELS[-1], "utilization_current": 0.1}]
+    def test_non_200_returns_static_fallback(self):
         with patch(
             "reasoning_scorer.requests.get",
-            side_effect=[
-                self._mock_response(entries_v1),
-                self._mock_response(entries_v2),
-            ],
-        ) as mock_get:
-            with patch("reasoning_scorer.time.monotonic", return_value=0.0):
-                first = _select_models_for_provider("chutes")
-            # 31s later — past the 30s TTL.
-            with patch("reasoning_scorer.time.monotonic", return_value=31.0):
-                second = _select_models_for_provider("chutes")
-
-        assert mock_get.call_count == 2
-        assert first[0] == JUDGE_MODELS[0]
-        assert second[0] == JUDGE_MODELS[-1]
-
-    def test_caller_mutation_does_not_corrupt_cache(self):
-        entries = [
-            {"name": m, "utilization_current": 0.1 * i}
-            for i, m in enumerate(JUDGE_MODELS)
-        ]
-        with patch(
-            "reasoning_scorer.requests.get", return_value=self._mock_response(entries)
+            return_value=self._mock_response({}, status_code=500),
         ):
-            first = _select_models_for_provider("chutes")
-            first.pop(0)
-            second = _select_models_for_provider("chutes")
-        assert len(second) == len(JUDGE_MODELS)
+            result = _fetch_ranked_models("chutes", "https://api.example.com")
+        assert result == JUDGE_MODELS
 
-    def test_failure_result_is_cached(self):
-        # An API failure produces the static fallback list; that result is
-        # cached too, so a flapping API doesn't get hammered every call. A
-        # later refetch (after TTL) is what recovers.
+    def test_network_error_returns_static_fallback(self):
+        with patch("reasoning_scorer.requests.get", side_effect=Exception("boom")):
+            result = _fetch_ranked_models("chutes", "https://api.example.com")
+        assert result == JUDGE_MODELS
+
+    def test_empty_models_array_returns_static_fallback(self):
+        body = {"models": [], "ranked_by": None}
+        with patch("reasoning_scorer.requests.get", return_value=self._mock_response(body)):
+            result = _fetch_ranked_models("chutes", "https://api.example.com")
+        assert result == JUDGE_MODELS
+
+    def test_unknown_models_in_response_filtered_out(self):
+        # Backend may return models we don't statically support (e.g. catalog
+        # drift). Drop them so the judge never tries an unrecognized model.
+        body = {
+            "models": [
+                {"id": "some/unknown-model"},
+                {"id": JUDGE_MODELS[0]},
+            ],
+            "ranked_by": "x",
+        }
+        with patch("reasoning_scorer.requests.get", return_value=self._mock_response(body)):
+            result = _fetch_ranked_models("chutes", "https://api.example.com")
+        assert result == [JUDGE_MODELS[0]]
+
+    def test_passes_provider_and_ranked_query_args(self):
+        body = {"models": [{"id": JUDGE_MODELS[0]}]}
         with patch(
-            "reasoning_scorer.requests.get", side_effect=Exception("boom")
+            "reasoning_scorer.requests.get", return_value=self._mock_response(body)
         ) as mock_get:
-            first = _select_models_for_provider("chutes")
-            second = _select_models_for_provider("chutes")
-
-        assert mock_get.call_count == 1
-        assert first == second == list(JUDGE_MODELS)
+            _fetch_ranked_models("chutes", "https://api.example.com")
+        call_kwargs = mock_get.call_args.kwargs
+        assert call_kwargs["params"] == {"provider": "chutes", "ranked": "true"}
+        assert mock_get.call_args.args[0].endswith("/v1/public/inference/models")
 
 
 class TestFormatProxyCall:

--- a/subnet/validator/progress_reporter.py
+++ b/subnet/validator/progress_reporter.py
@@ -537,6 +537,7 @@ class ProgressReporter:
                 dialogue,
                 api_key=self._chutes_access_token,
                 provider=self._inference_provider,
+                backend_url=self.backend_client.base_url,
             )
 
             with self._lock:


### PR DESCRIPTION
## Description

The judge's model-rotation order used to come from per-validator polls of Chutes' utilization API, with a 30s local cache and per-provider sort logic baked into `reasoning_scorer.py`. OpenRouter had no equivalent signal so it fell back to a static list — asymmetric across providers.

The Backend now polls every upstream provider once per instance and serves a ranked snapshot at `GET /v1/public/inference/models?ranked=true` with provider-specific stats already sorted server-side. This PR moves the judge to consume that endpoint.

Net effect: every upstream stats API gets hit once per Backend instance instead of once per validator, the per-provider sort logic stays server-side where it belongs, and adding a third provider tomorrow means writing one Backend poller class — no validator changes.

## Changes Made

- `src/agent/reasoning_scorer.py`:
  - Replace `_select_models_for_provider`, `CHUTES_UTILIZATION_URL`, and the 30s `_model_order_cache` with `_fetch_ranked_models(provider, backend_url)` that calls the Backend's ranked endpoint
  - Falls back to `JUDGE_MODELS_BY_PROVIDER` static list on any failure (no `backend_url`, network error, malformed body, empty list)
  - Filters out models the static set doesn't recognize so a Backend catalog drift can't make us call an unsupported model
  - `score_reasoning_quality` accepts `backend_url: str | None` (default None for back-compat with callers that don't have one configured)
- `subnet/validator/progress_reporter.py`: passes `self.backend_client.base_url` through to the judge
- `subnet/test_runner.py`: unchanged — local test rig doesn't pass `backend_url`, judge uses static fallback (predictable for local testing without depending on a live Backend)
- `subnet/tests/test_reasoning_scorer.py`: replace the old `TestSelectModelsByUtilization` + `TestSelectModelsByUtilizationCache` classes with `TestFetchRankedModels` covering the happy path + every fallback branch (no URL, non-200, network error, empty body, unknown models filtered out, query args correct)

## Testing

### Manual Testing

Will verify post-merge that the validator's judge calls `/v1/public/inference/models?provider=...&ranked=true` against the configured Backend URL on each scoring invocation, and that the returned order is reflected in the `Reasoning score: ... model=<m>` log lines.

### Automated Testing

**Test Command(s):**
```bash
PYTHONPATH=src python3 -m pytest subnet/tests/test_reasoning_scorer.py -v
```

**Test Results:** 45/45 tests pass (8 new tests for the ranked-endpoint consumer, 7 old utilization-fetch tests removed since that logic now lives Backend-side with its own coverage).


## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:** Inline docstring on `_fetch_ranked_models` explains the fallback chain and why we don't cache locally.
## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

After merge, tag a new oro-public version so Watchtower picks up the validator image.