### PR TITLE
fix(validator): award top emission slot to current top miner, not last race winner

### DIFF
--- a/subnet/tests/validator/test_weight_distribution.py
+++ b/subnet/tests/validator/test_weight_distribution.py
@@ -320,3 +320,159 @@ def test_build_metagraph_vector_empty_metagraph_returns_empty():
     )
     assert uids == []
     assert weights == []
+
+
+# --- top_hotkey override (current top via score-to-beat) ---
+
+
+def test_top_hotkey_none_matches_legacy_rank1_behavior():
+    """`top_hotkey=None` must produce byte-identical weights to passing
+    explicit rank-1 hotkey — the override is opt-in, not a behavior change."""
+    finishers = _make_finishers(20, seed=42)
+    ranked = rank_finishers(finishers)
+    rank1 = ranked[0].miner_hotkey
+
+    weights_none = compute_hotkey_weights(finishers, 0.25, 0.75, top_hotkey=None)
+    weights_explicit = compute_hotkey_weights(finishers, 0.25, 0.75, top_hotkey=rank1)
+    assert weights_none == weights_explicit
+
+
+def test_top_hotkey_override_promotes_non_winner_to_top_slot():
+    """When `top_hotkey` differs from rank-1, the override hotkey takes
+    the top u16 slot and the previous rank-1 falls into the tail."""
+    finishers = _make_finishers(20, seed=7)
+    ranked = rank_finishers(finishers)
+    rank1 = ranked[0].miner_hotkey
+    rank2 = ranked[1].miner_hotkey
+
+    weights = compute_hotkey_weights(finishers, 0.25, 0.75, top_hotkey=rank2)
+
+    # Rank2 (the new "current top") receives the top u16 slot.
+    top_u16 = max(weights.values())
+    assert weights[rank2] == top_u16
+    # Old rank-1 is still in the tail (top half of finishers, dereg-protected).
+    assert rank1 in weights
+    assert weights[rank1] != top_u16
+    # Old rank-1 takes the largest tail weight (M = K-1) since they are now
+    # rank-1 of the tail's existing rank order.
+    k = len(finishers) // 2
+    m = k - 1  # rank2 was in the protected set, so tail size = K - 1
+    assert weights[rank1] == m
+
+
+def test_top_hotkey_not_in_finishers_keeps_old_winner_in_tail():
+    """When `top_hotkey` is a brand-new hotkey not present in last-race
+    finishers, the override hotkey gets the top slot and the full top-K
+    of finishers (including old rank-1) populates the tail."""
+    finishers = _make_finishers(20, seed=11)
+    ranked = rank_finishers(finishers)
+    rank1 = ranked[0].miner_hotkey
+    new_top = "hk_brand_new_agent"
+
+    weights = compute_hotkey_weights(finishers, 0.25, 0.75, top_hotkey=new_top)
+
+    top_u16 = max(weights.values())
+    assert weights[new_top] == top_u16
+    # Old rank-1 takes the largest tail weight (M = K, full top-K tail).
+    k = len(finishers) // 2
+    assert weights[rank1] == k
+
+
+def test_top_hotkey_override_top_share_remains_t_top():
+    """The top miner's share of the chain-normalised vector stays at
+    exactly `t_top` regardless of whether the override pulls from inside
+    or outside the protected tail."""
+    finishers = _make_finishers(20, seed=99)
+    ranked = rank_finishers(finishers)
+
+    for top_hk in [ranked[0].miner_hotkey, ranked[5].miner_hotkey, "hk_outsider"]:
+        weights = compute_hotkey_weights(finishers, 0.25, 0.75, top_hotkey=top_hk)
+        # Burn slot is implicit (uid 0); compute it from compute_pinned_weights
+        # using the actual tail sum.
+        m = sum(1 for v in weights.values() if v != max(weights.values()))
+        tail_sum = m * (m + 1) // 2
+        top_u16, burn_u16 = compute_pinned_weights(0.25, 0.75, tail_sum)
+        total = top_u16 + burn_u16 + tail_sum
+        assert _share(top_u16, total) == pytest.approx(0.25, abs=2e-4)
+
+
+def test_build_metagraph_vector_top_hotkey_promoted_to_top_slot():
+    """End-to-end: `top_hotkey` lands at its metagraph index with the top
+    u16, and the burn slot at uid 0 still receives the burn share."""
+    finishers = _make_finishers(20, seed=3)
+    ranked = rank_finishers(finishers)
+    rank2_hk = ranked[1].miner_hotkey
+    metagraph_hotkeys = ["burn_uid"] + [f.miner_hotkey for f in finishers]
+
+    uids, weights = build_metagraph_weight_vector(
+        finishers,
+        metagraph_hotkeys=metagraph_hotkeys,
+        t_top=0.25,
+        t_burn=0.75,
+        top_hotkey=rank2_hk,
+    )
+    rank2_idx = metagraph_hotkeys.index(rank2_hk)
+    rank1_idx = metagraph_hotkeys.index(ranked[0].miner_hotkey)
+    # uid 0 is the burn slot (pinned at U16_MAX under t_top<t_burn) — exclude
+    # it when checking "top" among non-burn slots.
+    non_burn = [w if i != 0 else 0 for i, w in enumerate(weights)]
+
+    assert weights[rank2_idx] == max(non_burn)  # rank2 promoted to top
+    assert weights[rank1_idx] > 0  # old rank-1 still in tail
+    assert weights[rank1_idx] < weights[rank2_idx]
+    assert weights[0] > 0  # burn slot non-zero
+
+
+def test_build_metagraph_vector_top_hotkey_not_in_metagraph_falls_back():
+    """If `top_hotkey` deregistered between Backend designation and weight
+    set, fall back to rank-1 of last-race finishers (legacy behavior)."""
+    finishers = _make_finishers(20, seed=8)
+    ranked = rank_finishers(finishers)
+    rank1_hk = ranked[0].miner_hotkey
+    metagraph_hotkeys = ["burn_uid"] + [f.miner_hotkey for f in finishers]
+
+    uids, weights_with_missing = build_metagraph_weight_vector(
+        finishers,
+        metagraph_hotkeys=metagraph_hotkeys,
+        t_top=0.25,
+        t_burn=0.75,
+        top_hotkey="hk_deregistered",
+    )
+    uids_legacy, weights_legacy = build_metagraph_weight_vector(
+        finishers, metagraph_hotkeys=metagraph_hotkeys, t_top=0.25, t_burn=0.75
+    )
+
+    # Fallback path produces byte-identical output to the legacy
+    # (no-override) call — preserves Yuma determinism across validators.
+    assert weights_with_missing == weights_legacy
+    rank1_idx = metagraph_hotkeys.index(rank1_hk)
+    # rank-1 finisher takes the top slot (highest weight among non-burn uids).
+    non_burn = [w if i != 0 else 0 for i, w in enumerate(weights_with_missing)]
+    assert weights_with_missing[rank1_idx] == max(non_burn)
+
+
+def test_two_validators_with_top_override_emit_byte_identical_weights():
+    """Determinism property still holds when `top_hotkey` is supplied:
+    same `(top_hotkey, finishers, t_top, t_burn)` → byte-identical vectors."""
+    finishers = _make_finishers(50, seed=2026)
+    metagraph_hotkeys = ["burn_uid"] + [f.miner_hotkey for f in finishers]
+    top_hk = finishers[7].miner_hotkey  # arbitrary middle-rank hotkey
+
+    a_uids, a_weights = build_metagraph_weight_vector(
+        finishers,
+        metagraph_hotkeys=metagraph_hotkeys,
+        t_top=0.25,
+        t_burn=0.75,
+        top_hotkey=top_hk,
+    )
+    shuffled = list(finishers)
+    random.Random(123).shuffle(shuffled)
+    b_uids, b_weights = build_metagraph_weight_vector(
+        shuffled,
+        metagraph_hotkeys=metagraph_hotkeys,
+        t_top=0.25,
+        t_burn=0.75,
+        top_hotkey=top_hk,
+    )
+    assert a_uids == b_uids
+    assert a_weights == b_weights

--- a/subnet/validator/weight_distribution.py
+++ b/subnet/validator/weight_distribution.py
@@ -143,32 +143,49 @@ def compute_hotkey_weights(
     qualifiers: Iterable[RankedFinisher],
     t_top: float,
     t_burn: float,
+    top_hotkey: str | None = None,
 ) -> dict[str, int]:
-    """Compute hotkey → u16 weight for the top 50% of race finishers.
+    """Compute hotkey → u16 weight for the top emission slot + last-race
+    deregistration-protection tail.
+
+    The top slot (`top_u16`) goes to `top_hotkey` if provided (the canonical
+    "current top for emissions" from `/v1/public/top`), otherwise falls back
+    to the rank-1 finisher of the most recent completed race.
+
+    The tail is the top 50% of last-race finishers minus the top hotkey if
+    they overlap. Tail entries receive a linear taper M, M-1, ..., 1 in rank
+    order, where M is the number of tail entries. The tail's share comes
+    out of `t_burn` — the top miner's share does not move with N.
 
     Bottom 50% (and ties at the rank-K boundary, by tiebreak) get no entry.
-
-    The "top" entry receives `top_u16` (sized so the chain-normalised
-    share is exactly `t_top` regardless of N). Ranks 2..K receive a
-    linear taper `K + 1 - rank`, so rank 2 = K-1, rank 3 = K-2, ...,
-    rank K = 1. The tail's share comes out of `t_burn` — the top
-    miner's share does not move with N.
     """
     ranked = rank_finishers(qualifiers)
     n = len(ranked)
-    k = n // 2  # floor
-    if k == 0:
-        return {}
+    k = n // 2  # floor — protected-set size
 
-    tail_sum = _tail_sum_for(k)
+    if top_hotkey is None:
+        if k == 0:
+            return {}
+        effective_top = ranked[0].miner_hotkey
+    else:
+        effective_top = top_hotkey
+
+    # Tail = top-K finishers excluding the effective top hotkey. When
+    # effective_top is the rank-1 finisher this matches the historical
+    # ranks 2..K tail; when effective_top is rank j (j > 1) of the
+    # protected set, rank 1 takes the largest tail weight; when
+    # effective_top is outside the protected set entirely (or there
+    # are no finishers), the tail is the full top-K.
+    protected = ranked[:k] if k > 0 else []
+    tail_finishers = [f for f in protected if f.miner_hotkey != effective_top]
+
+    m = len(tail_finishers)
+    tail_sum = m * (m + 1) // 2  # M + (M-1) + ... + 1
+
     top_u16, _ = compute_pinned_weights(t_top, t_burn, tail_sum)
-    weights: dict[str, int] = {}
-    weights[ranked[0].miner_hotkey] = top_u16
-
-    # Ranks 2..K (1-indexed) → indices 1..K-1 in `ranked`.
-    for idx in range(1, k):
-        rank_1based = idx + 1  # 2..K
-        weights[ranked[idx].miner_hotkey] = k + 1 - rank_1based
+    weights: dict[str, int] = {effective_top: top_u16}
+    for idx, finisher in enumerate(tail_finishers):
+        weights[finisher.miner_hotkey] = m - idx
 
     return weights
 
@@ -178,12 +195,20 @@ def build_metagraph_weight_vector(
     metagraph_hotkeys: list[str],
     t_top: float,
     t_burn: float,
+    top_hotkey: str | None = None,
 ) -> tuple[list[int], list[int]]:
     """Produce `(uids, weights_u16)` aligned to the metagraph.
 
+    `top_hotkey` is the canonical "current top for emissions" (from
+    `/v1/public/top`). When set and present in the metagraph, that hotkey
+    receives the top emission slot regardless of whether they finished
+    last race. Falls back to rank-1 of last-race finishers when
+    `top_hotkey` is None or has deregistered between Backend's
+    designation and the weight set.
+
     Steps:
 
-    1. Rank qualifiers and compute hotkey → top-half u16 weights.
+    1. Rank qualifiers and compute hotkey → top-slot + tail u16 weights.
     2. Compute the burn u16 from the configured ratio.
     3. Map every hotkey-weight onto its metagraph index. A hotkey present
        in the race but absent from the metagraph (deregistered between
@@ -195,25 +220,41 @@ def build_metagraph_weight_vector(
     Returns:
         Two parallel lists of length `len(metagraph_hotkeys)`. `uids[i]`
         is `i` (the metagraph index), `weights_u16[i]` is the u16 weight
-        for that uid (0 if the hotkey is not in the top 50% and not the
-        burn uid).
+        for that uid (0 if the hotkey is not in the top slot, not in the
+        last-race tail, and not the burn uid).
     """
     n_meta = len(metagraph_hotkeys)
     if n_meta == 0:
         return [], []
 
     finishers = list(qualifiers)
-    hotkey_weights = compute_hotkey_weights(finishers, t_top, t_burn)
+    hotkey_to_idx = {hk: i for i, hk in enumerate(metagraph_hotkeys)}
+
+    # If the designated top hotkey isn't in the current metagraph (deregistered
+    # between Backend designation and weight set), fall back to rank-1 of
+    # last-race finishers. Keeps the protection mechanism alive instead of
+    # burning everything.
+    effective_top_hotkey = top_hotkey
+    if effective_top_hotkey is not None and effective_top_hotkey not in hotkey_to_idx:
+        effective_top_hotkey = None
+
+    hotkey_weights = compute_hotkey_weights(
+        finishers, t_top, t_burn, top_hotkey=effective_top_hotkey
+    )
     if not hotkey_weights:
-        # No protected entries (race too small for K >= 1) — burn everything.
+        # No top hotkey AND no finishers — burn everything.
         weights = [0] * n_meta
         weights[0] = U16_MAX
         return list(range(n_meta)), weights
 
     weights = [0] * n_meta
-    hotkey_to_idx = {hk: i for i, hk in enumerate(metagraph_hotkeys)}
-    ranked = rank_finishers(finishers)
-    top_hk = ranked[0].miner_hotkey
+    # The effective top hotkey is whoever `compute_hotkey_weights` placed in
+    # the top slot — explicit override if set + valid, else rank-1 finisher.
+    if effective_top_hotkey is not None:
+        top_hk = effective_top_hotkey
+    else:
+        ranked = rank_finishers(finishers)
+        top_hk = ranked[0].miner_hotkey
     top_idx: int | None = None
     tail_sum_actual = 0
     for hk, w in hotkey_weights.items():

--- a/subnet/validator/weight_setter.py
+++ b/subnet/validator/weight_setter.py
@@ -151,8 +151,28 @@ class WeightSetterThread:
                 return _qualifiers_to_finishers(qualifiers)
         return None
 
+    def _fetch_top_hotkey(self) -> Optional[str]:
+        """Return the canonical "current top miner" hotkey for emissions.
+
+        Reads `GET /v1/public/top` (the score-to-beat designation). Returns
+        None when there's no admin-designated top (fresh subnet) or the
+        request fails — `build_metagraph_weight_vector` falls back to rank-1
+        of last-race finishers in that case.
+        """
+        try:
+            top = self.backend_client.get_top_miner()
+        except BackendError as e:
+            logging.warning(
+                f"Top-miner fetch failed, falling back to last-race rank-1: {e}"
+            )
+            return None
+        hk = top.top_miner_hotkey
+        if hk is None or hk is UNSET:
+            return None
+        return str(hk)
+
     def _build_weights_from_race(
-        self, finishers: list[RankedFinisher]
+        self, finishers: list[RankedFinisher], top_hotkey: Optional[str]
     ) -> tuple[list[int], list[int]]:
         """Compute the full `(uids, u16 weights)` vector for the metagraph.
 
@@ -173,11 +193,17 @@ class WeightSetterThread:
                 f"(deregistered between race close and weight set), "
                 f"weight skipped: {missing[:5]}{'…' if len(missing) > 5 else ''}"
             )
+        if top_hotkey is not None and top_hotkey not in present:
+            logging.warning(
+                f"Designated top miner {top_hotkey} not in current metagraph; "
+                f"falling back to rank-1 of last-race finishers for top slot"
+            )
         return build_metagraph_weight_vector(
             finishers,
             metagraph_hotkeys=metagraph_hotkeys,
             t_top=self.t_top,
             t_burn=self.t_burn,
+            top_hotkey=top_hotkey,
         )
 
     def _submit_weights(self, uids: list[int], weights: list[int]) -> None:
@@ -212,10 +238,12 @@ class WeightSetterThread:
             )
             return
 
-        uids, weights = self._build_weights_from_race(finishers)
+        top_hotkey = self._fetch_top_hotkey()
+        uids, weights = self._build_weights_from_race(finishers, top_hotkey)
         non_zero = sum(1 for w in weights if w > 0)
         logging.info(
             f"Race-based weight vector: N={len(finishers)} finishers, "
+            f"top={top_hotkey or '(rank-1 fallback)'}, "
             f"{non_zero} non-zero metagraph slots"
         )
 


### PR DESCRIPTION
## Description

Fixes a misallocation in the validator weight setter: the 25% top emission slot was going to the rank-1 finisher of the most recent completed race, ignoring the score-to-beat mechanic that designates the canonical "current top" the moment a new agent outscores the previous one. Until the next race completed the validator kept rewarding the wrong miner.

The fix consults Backend's `GET /v1/public/top` per weight-setter tick and uses the designated `top_miner_hotkey` for the top u16 slot. Last-race deregistration protection (top-half-of-finishers tail) is preserved.

## Changes Made

- `subnet/validator/weight_distribution.py`: `compute_hotkey_weights` and `build_metagraph_weight_vector` accept an optional `top_hotkey` parameter that overrides the rank-1 finisher in the top slot. The tail derivation excludes the top hotkey if they overlap with the protected set, otherwise the full top-K finishers populate the tail.
- `subnet/validator/weight_setter.py`: new `_fetch_top_hotkey()` reads `/v1/public/top` via the existing `BackendClient.get_top_miner` wrapper. `_tick` passes the result through to `_build_weights_from_race`. Falls back to rank-1 on Backend errors or when the designated hotkey is no longer in the metagraph.
- `subnet/tests/validator/test_weight_distribution.py`: 7 new test cases covering the override paths (legacy parity, override promotes non-winner, override-not-in-finishers, override-not-in-metagraph fallback, determinism with override, top-share invariance).

## Issue Link

- Related to: N/A
- Closes: ORO-1076

## Testing

### Manual Testing
N/A — change is exercised by the validator weight-set loop on the next 5min tick after deploy. Will verify post-merge by tailing validator logs after `:stable` is repromoted.

**Test Results:**
N/A

### Automated Testing
Full validator test suite passes (170/170), including the new 7 cases for the override paths.

**Test Command(s):**
```bash
uv run --project docker/validator/ --with pytest pytest subnet/tests/validator/ -q
```


## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
Updated docstrings in `weight_distribution.py` and `weight_setter.py` describing the new `top_hotkey` parameter and the fallback semantics.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

Time-critical: needs to land before the next epoch / weight-set tick. The change is fully backwards-compatible — `top_hotkey=None` reproduces byte-identical legacy behavior, and the metagraph-fallback path also produces byte-identical legacy output. Yuma determinism is preserved.