### PR TITLE
feat(proxy): rewrite model names across Chutes/OpenRouter providers

### DIFF
--- a/docker/proxy/Dockerfile
+++ b/docker/proxy/Dockerfile
@@ -4,5 +4,6 @@ RUN apk add --no-cache gettext nginx-module-njs
 
 COPY docker/proxy/nginx.conf.template /tmp/nginx.conf.template
 COPY docker/proxy/validate_model.js /etc/nginx/validate_model.js
+COPY docker/proxy/model_pairs.json /etc/nginx/model_pairs.json
 
 CMD ["/bin/sh", "-c", ": ${BACKEND_URL:=https://api.oroagents.com} && : ${BACKEND_HOST:=api.oroagents.com} && : ${OPENROUTER_HOST:=openrouter.ai} && export BACKEND_URL BACKEND_HOST OPENROUTER_HOST && envsubst '${SEARCH_SERVER_URL} ${SEARCH_SERVER_PORT} ${CHUTES_HOST} ${BACKEND_URL} ${BACKEND_HOST} ${OPENROUTER_HOST}' < /tmp/nginx.conf.template > /etc/nginx/nginx.conf && exec nginx -g 'daemon off;'"]

--- a/docker/proxy/model_pairs.json
+++ b/docker/proxy/model_pairs.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Maps each model to its identifier on every supported provider. The proxy uses this to rewrite an incoming request's `model` field to the active provider's form, so agents can use a single string regardless of which provider is funding the run. Both sides must be in the matching allowlist served by Backend (`/v1/public/inference/models?provider=...`).",
+  "pairs": [
+    { "chutes": "deepseek-ai/DeepSeek-V3.2-TEE",            "openrouter": "deepseek/deepseek-v3.2" },
+    { "chutes": "deepseek-ai/DeepSeek-V3.1-TEE",            "openrouter": "deepseek/deepseek-chat-v3.1" },
+    { "chutes": "deepseek-ai/DeepSeek-V3-0324-TEE",         "openrouter": "deepseek/deepseek-chat-v3-0324" },
+    { "chutes": "deepseek-ai/DeepSeek-R1-0528-TEE",         "openrouter": "deepseek/deepseek-r1-0528" },
+    { "chutes": "tngtech/DeepSeek-TNG-R1T2-Chimera-TEE",    "openrouter": "tngtech/deepseek-r1t2-chimera" },
+    { "chutes": "Qwen/Qwen3-32B-TEE",                        "openrouter": "qwen/qwen3-32b" },
+    { "chutes": "Qwen/Qwen3.5-397B-A17B-TEE",               "openrouter": "qwen/qwen3.5-397b-a17b" },
+    { "chutes": "google/gemma-4-31B-turbo-TEE",             "openrouter": "google/gemma-4-31b-it" },
+    { "chutes": "zai-org/GLM-5-TEE",                         "openrouter": "z-ai/glm-5" },
+    { "chutes": "zai-org/GLM-5.1-TEE",                       "openrouter": "z-ai/glm-5.1" },
+    { "chutes": "moonshotai/Kimi-K2.5-TEE",                  "openrouter": "moonshotai/kimi-k2.5" },
+    { "chutes": "MiniMaxAI/MiniMax-M2.5-TEE",               "openrouter": "minimax/minimax-m2.5" },
+    { "chutes": "XiaomiMiMo/MiMo-V2-Flash-TEE",             "openrouter": "xiaomi/mimo-v2-flash" }
+  ]
+}

--- a/docker/proxy/validate_model.js
+++ b/docker/proxy/validate_model.js
@@ -19,6 +19,16 @@
 // Provider dispatch:
 //   - Bearer token starts with "sk-or-" → OpenRouter (allowlist enforced)
 //   - Any other token shape (e.g. cak_*) → Chutes (allowlist enforced)
+//
+// Cross-provider model-name rewriting: agents can use any model identifier
+// listed in model_pairs.json regardless of which provider funds the run. If
+// the request `model` matches the inactive provider's side of a pair we
+// rewrite the body's `model` field to the active provider's side before
+// allowlist validation, so the same agent code works on either provider.
+// Models with no pair entry pass through unchanged and hit the existing
+// allowlist check as before.
+
+import fs from "fs";
 
 function detectProvider(r) {
   var auth = r.headersIn["Authorization"] || "";
@@ -26,6 +36,39 @@ function detectProvider(r) {
     return "openrouter";
   }
   return "chutes";
+}
+
+// Lookup tables for both directions, populated once at module init. Each
+// nginx worker loads the file independently; reload (`nginx -s reload`)
+// picks up edits.
+var MODEL_PAIRS_PATH = "/etc/nginx/model_pairs.json";
+var _pairsByChutes = {};
+var _pairsByOpenrouter = {};
+try {
+  var _pairsDoc = JSON.parse(fs.readFileSync(MODEL_PAIRS_PATH, "utf8"));
+  for (var i = 0; i < _pairsDoc.pairs.length; i++) {
+    var p = _pairsDoc.pairs[i];
+    _pairsByChutes[p.chutes] = p.openrouter;
+    _pairsByOpenrouter[p.openrouter] = p.chutes;
+  }
+} catch (e) {
+  // Don't crash the worker — same-provider names still work via the
+  // existing allowlist check. Surface the error so it's noticeable.
+  ngx.log(ngx.ERR, "model_pairs load failed: " + e.message);
+}
+
+// Returns the request model rewritten for `activeProvider`, or null if no
+// rewrite is needed (already on the active side, or unknown — let allowlist
+// validation handle it).
+function rewriteModelFor(activeProvider, requested) {
+  if (activeProvider === "chutes") {
+    if (_pairsByChutes[requested] !== undefined) return null;
+    if (_pairsByOpenrouter[requested] !== undefined) return _pairsByOpenrouter[requested];
+  } else if (activeProvider === "openrouter") {
+    if (_pairsByOpenrouter[requested] !== undefined) return null;
+    if (_pairsByChutes[requested] !== undefined) return _pairsByChutes[requested];
+  }
+  return null;
 }
 
 var CACHE_TTL_MS = 15 * 60 * 1000;
@@ -150,6 +193,13 @@ function validate(r) {
     return;
   }
 
+  var rewritten = rewriteModelFor(provider, parsed.model);
+  var forwardBody = body;
+  if (rewritten !== null) {
+    parsed.model = rewritten;
+    forwardBody = JSON.stringify(parsed);
+  }
+
   getAllowlist(r, provider, function (allowed) {
     if (!allowed) {
       r.headersOut["Content-Type"] = "application/json";
@@ -173,7 +223,7 @@ function validate(r) {
     var uri = upstreamLocation + r.uri.replace(/^\/inference\//, "");
     r.subrequest(
       uri,
-      { method: "POST", body: body, args: r.variables.args || "" },
+      { method: "POST", body: forwardBody, args: r.variables.args || "" },
       function (reply) {
         for (var h in reply.headersOut) {
           r.headersOut[h] = reply.headersOut[h];

--- a/tests/test_model_pairs.py
+++ b/tests/test_model_pairs.py
@@ -1,0 +1,68 @@
+"""Validates docker/proxy/model_pairs.json — the cross-provider model-name
+mapping used by the inference proxy. The proxy njs runtime isn't
+exercisable in this Python CI, so this test focuses on the data file: it's
+the most likely failure mode (typos, missing entries, drifted from the
+Backend allowlist), and well-formedness is enough for the rewrite logic in
+validate_model.js to behave correctly given the data.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+PAIRS_PATH = Path(__file__).resolve().parent.parent / "docker" / "proxy" / "model_pairs.json"
+
+
+@pytest.fixture(scope="module")
+def pairs() -> list[dict[str, str]]:
+    doc = json.loads(PAIRS_PATH.read_text())
+    return doc["pairs"]
+
+
+def test_pairs_file_parses_with_pairs_array(pairs: list[dict[str, str]]) -> None:
+    assert isinstance(pairs, list)
+    assert len(pairs) > 0
+
+
+def test_each_pair_has_both_sides_non_empty(pairs: list[dict[str, str]]) -> None:
+    for p in pairs:
+        assert set(p.keys()) == {"chutes", "openrouter"}, p
+        assert isinstance(p["chutes"], str) and p["chutes"].strip() == p["chutes"] and p["chutes"]
+        assert (
+            isinstance(p["openrouter"], str)
+            and p["openrouter"].strip() == p["openrouter"]
+            and p["openrouter"]
+        )
+
+
+def test_no_duplicate_chutes_or_openrouter_ids(pairs: list[dict[str, str]]) -> None:
+    chutes_ids = [p["chutes"] for p in pairs]
+    openrouter_ids = [p["openrouter"] for p in pairs]
+    assert len(chutes_ids) == len(set(chutes_ids))
+    assert len(openrouter_ids) == len(set(openrouter_ids))
+
+
+def test_chutes_and_openrouter_namespaces_dont_overlap(pairs: list[dict[str, str]]) -> None:
+    """If a string appeared on both columns the rewriter would loop ambiguously.
+    Chutes IDs end in `-TEE`; OpenRouter slugs are lowercase and never do."""
+    chutes_ids = {p["chutes"] for p in pairs}
+    openrouter_ids = {p["openrouter"] for p in pairs}
+    assert chutes_ids.isdisjoint(openrouter_ids)
+
+
+def test_chutes_ids_use_tee_inference_variant(pairs: list[dict[str, str]]) -> None:
+    """Backend's Chutes allowlist only includes the `-TEE` inference variants
+    today. Catches accidental copy-paste of bare HF repo names."""
+    for p in pairs:
+        assert p["chutes"].endswith("-TEE"), p
+
+
+def test_each_id_has_org_slash_model_shape(pairs: list[dict[str, str]]) -> None:
+    """Both Chutes and OpenRouter use `<org>/<model>`; an entry without a slash
+    is almost certainly a typo."""
+    for p in pairs:
+        assert "/" in p["chutes"], p
+        assert "/" in p["openrouter"], p


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does. Include the motivation and context if relevant. -->

Lets agents inside the sandbox use a single model identifier regardless of which inference provider is currently funding the run.

The Chutes ID and the OpenRouter slug for the same model diverge by naming convention — e.g. `deepseek-ai/DeepSeek-V3.1-TEE` vs `deepseek/deepseek-chat-v3.1`, `Qwen/Qwen3-32B-TEE` vs `qwen/qwen3-32b`. Without translation, the same agent code can't be portable across providers: a miner who switches their default provider would silently start hitting the upstream's 404.

The proxy already detects the active provider from the bearer-token prefix (`sk-or-` → OpenRouter, otherwise Chutes). This PR extends `validate_model.js` to also rewrite the request body's `model` field — if the agent passed the inactive provider's side of a pair, we substitute the active provider's side before allowlist validation. The pair table is a hand-maintained JSON file shipped in the proxy image.

## Changes Made

<!-- List the key changes made in this PR: -->
- New `docker/proxy/model_pairs.json` — Chutes ↔ OpenRouter identifier pairs for every model currently in both allowlists
- `docker/proxy/validate_model.js` — load the pair table at module init via `fs.readFileSync`, rewrite the request body's `model` field before allowlist validation when the requested name matches the inactive provider's side of a pair, leave the body untouched when no rewrite is needed
- `docker/proxy/Dockerfile` — copy `model_pairs.json` to `/etc/nginx/` alongside `validate_model.js`
- `tests/test_model_pairs.py` — pair-table well-formedness checks (no duplicates, both keys non-empty, namespaces disjoint, expected ID shape)

## Issue Link

<!-- Link to the related issue(s). Use "Closes #issue_number" or "Fixes #issue_number" if this PR resolves an issue: -->
- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing
<!-- Describe the manual testing steps you performed: -->

Plan to manually verify against staging once the new validator image rolls: send a chat-completions request with the Chutes-style name while OpenRouter is the active provider (and vice versa), confirm the upstream returns 200 instead of 404 and that the response model echoes the active provider's slug.

**Test Results:**

Pair-table tests pass locally; the rewrite is small enough to review by inspection.

### Automated Testing
<!-- Describe any automated tests that were run like unit tests, integration tests, scripts, etc.: -->

Six pair-table tests covering parse, both-keys-present, no duplicates, namespace disjointness, Chutes TEE-suffix sanity, and `<org>/<model>` shape. Existing proxy + validator tests run unchanged.

**Test Command(s):**
```bash
pytest tests/test_model_pairs.py -v
```


## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**

Inline comments in `validate_model.js` explain the rewrite contract and why a rewrite failure is non-fatal (same-provider names still work via the existing allowlist check).

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

The rewrite happens on the request side only — response bodies pass through unchanged, so the model field returned by the upstream still reflects the active provider's slug. If we want symmetric rewriting on the response later (so agents always see the same name they sent) it can layer on top.

A follow-up will surface the pair table to miners on the public docs page so they can see at a glance which Chutes ID corresponds to which OpenRouter slug; that's a Frontend-only change and is not blocking.