### PR TITLE
fix(validator): tolerate empty SANDBOX_MAX_WORKERS / REASONING_MAX_WORKERS env vars

### DIFF
--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -101,25 +101,25 @@ class Validator:
         parser.add_argument(
             "--sandbox-timeout",
             type=int,
-            default=int(os.environ.get("SANDBOX_TIMEOUT", "1800")),
+            default=int(os.environ.get("SANDBOX_TIMEOUT") or "1800"),
             help="Timeout in seconds for the entire sandbox subprocess (env: SANDBOX_TIMEOUT, default: 1800 = 30 min).",
         )
         parser.add_argument(
             "--sandbox-max-workers",
             type=int,
-            default=int(os.environ.get("SANDBOX_MAX_WORKERS", "15")),
+            default=int(os.environ.get("SANDBOX_MAX_WORKERS") or "15"),
             help="Number of parallel problem workers in sandbox (env: SANDBOX_MAX_WORKERS).",
         )
         parser.add_argument(
             "--sandbox-problem-timeout",
             type=float,
-            default=float(os.environ.get("SANDBOX_PROBLEM_TIMEOUT", "300")),
+            default=float(os.environ.get("SANDBOX_PROBLEM_TIMEOUT") or "300"),
             help="Timeout in seconds per problem in sandbox (env: SANDBOX_PROBLEM_TIMEOUT, default: 300 = 5 min).",
         )
         parser.add_argument(
             "--reasoning-max-workers",
             type=int,
-            default=int(os.environ.get("REASONING_MAX_WORKERS", "4")),
+            default=int(os.environ.get("REASONING_MAX_WORKERS") or "4"),
             help="Number of parallel reasoning judge workers (env: REASONING_MAX_WORKERS).",
         )
         # Backend API configuration


### PR DESCRIPTION
## Description

**Hot fix.** PRs #145 and #146 introduced a crash-loop for any operator who pulled the latest validator source without setting the new env vars in their `.env`. A remote operator reported the traceback:

```
File "/app/subnet/validator/main.py", line 110, in get_config
    default=int(os.environ.get("SANDBOX_MAX_WORKERS", "15")),
ValueError: invalid literal for int() with base 10: ''
```

### Root cause

`docker-compose.yml` declares the env vars as `${SANDBOX_MAX_WORKERS:-}` and `${REASONING_MAX_WORKERS:-}`. The trailing `:-` (empty default) means: if the operator hasn't set the var in `.env`, compose still injects the var into the container — as an empty string.

Python's `os.environ.get(name, "default")` only returns the default when the key is **unset**. An empty value is returned as-is, so `int("")` raises `ValueError`.

This is a regression introduced by my own PRs (#145, #146).

## Changes Made

- **`subnet/validator/main.py`**: switch from `os.environ.get("X", "default")` to `os.environ.get("X") or "default"` so empty strings fall through to the default. This also covers operators running an older compose file (no reference to these vars) who pull the new image — the var is simply absent and the default kicks in.

Defaults are kept in one place (Python) rather than duplicated in compose.

### Backwards compatibility

`get(name) or "default"` covers all three cases:
| Scenario | `get()` returns | `or` result |
|---|---|---|
| Var unset (old compose, no env reference) | `None` | `"15"` |
| Var set to empty (new compose, operator didn't override) | `""` | `"15"` |
| Var set to a value | `"30"` | `"30"` |

Since `compose.yml` is not baked into the image, operators on the old compose are still on `${VAR}`-not-referenced; operators on the new compose are on `${VAR:-}`-empty-string. Both work after this fix.

## Issue Link

- Related to: #145, #146

## Testing

### Manual Testing

Verified locally that `int(os.environ.get("FOO") or "15")` returns `15` for both:
- unset `FOO`
- `FOO=""`

### Automated Testing

No test added — one-line behavior change in argparse defaults.

**Test Command(s):**
```bash
SANDBOX_MAX_WORKERS= python -c "import os; print(int(os.environ.get('SANDBOX_MAX_WORKERS') or '15'))"
# 15
unset SANDBOX_MAX_WORKERS && python -c "import os; print(int(os.environ.get('SANDBOX_MAX_WORKERS') or '15'))"
# 15
```

## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:** N/A — no behavioral change for operators who set the vars.

## Operator workaround (until image rebuilds)

Add to `.env`:
```
SANDBOX_MAX_WORKERS=15
REASONING_MAX_WORKERS=4
```

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

Damage radius: only operators who pulled the latest validator source after #145 merged were affected (compose isn't baked into the image, so most operators on the old compose file weren't broken). Once this PR's image is built and pushed to prod, the bug is fixed for everyone — no coordinated `.env` update needed.