### PR TITLE
fix: isolate local problem request logs

### DIFF
--- a/src/agent/sandbox_executor.py
+++ b/src/agent/sandbox_executor.py
@@ -1,6 +1,7 @@
 """Sandbox executor for running agents against problems in parallel."""
 
 import importlib.util
+import hashlib
 import json
 import logging
 import multiprocessing
@@ -187,6 +188,17 @@ def _read_request_log(path: str) -> List[Dict]:
     return entries
 
 
+def _problem_id_for(problem: Dict) -> str:
+    """Return an explicit problem id or a stable local-suite fallback id."""
+    problem_id = problem.get("problem_id") or problem.get("id")
+    if problem_id:
+        return str(problem_id)
+
+    payload = json.dumps(problem, sort_keys=True, separators=(",", ":"), default=str)
+    digest = hashlib.sha1(payload.encode("utf-8")).hexdigest()[:16]
+    return f"local-{digest}"
+
+
 def _run_in_process(
     problem: Dict,
     agent_file: Optional[str],
@@ -234,7 +246,7 @@ def execute_single_problem(
         ExecutionResult with execution outcome.
     """
     query = problem.get("query", "")
-    problem_id = problem.get("problem_id") or problem.get("id")
+    problem_id = _problem_id_for(problem)
     start_time = time.time()
 
     # All processes append to a shared JSONL file alongside output.jsonl.
@@ -483,7 +495,7 @@ def execute_problems_parallel(
                 except FutureTimeoutError:
                     problem = future_to_problem[future]
                     query = problem.get("query", "unknown")
-                    problem_id = problem.get("problem_id") or problem.get("id")
+                    problem_id = _problem_id_for(problem)
                     logger.error(
                         f"Future for problem '{query}' timed out during result retrieval"
                     )
@@ -500,7 +512,7 @@ def execute_problems_parallel(
                 except Exception as e:
                     problem = future_to_problem[future]
                     query = problem.get("query", "unknown")
-                    problem_id = problem.get("problem_id") or problem.get("id")
+                    problem_id = _problem_id_for(problem)
                     logger.error(
                         f"Unexpected error retrieving result for '{query}': {e}"
                     )

--- a/tests/test_sandbox_envelope.py
+++ b/tests/test_sandbox_envelope.py
@@ -87,6 +87,38 @@ class TestExecuteSingleProblemStatus:
         assert result.status == SandboxProblemStatus.FAILED
         assert result.success is False
 
+    def test_missing_problem_ids_use_stable_content_fallback(
+        self, tmp_path, monkeypatch
+    ):
+        """Bundled local suites may omit problem_id/id; they still need
+        per-problem sidecar files so proxy logs do not bleed between problems."""
+        monkeypatch.setenv("SANDBOX_OUTPUT_FILE", str(tmp_path / "output.jsonl"))
+
+        mock_proc = MagicMock()
+        mock_proc.is_alive.return_value = False
+        mock_proc.pid = 3
+        mock_proc.exitcode = 1
+        with patch.object(
+            sandbox_executor.multiprocessing, "Process", return_value=mock_proc
+        ):
+            first = sandbox_executor.execute_single_problem(
+                {"query": "cream bowl", "category": "voucher"},
+                timeout=0.01,
+            )
+            same_content = sandbox_executor.execute_single_problem(
+                {"category": "voucher", "query": "cream bowl"},
+                timeout=0.01,
+            )
+            second = sandbox_executor.execute_single_problem(
+                {"query": "healthy cheese", "category": "product"},
+                timeout=0.01,
+            )
+
+        assert first.problem_id
+        assert first.problem_id.startswith("local-")
+        assert first.problem_id == same_content.problem_id
+        assert first.problem_id != second.problem_id
+
 
 def _parse(line: str) -> dict:
     obj = json.loads(line)


### PR DESCRIPTION
Fixes ORO-AI/oro#96.

## Summary
- Add a stable content-derived fallback problem id for local suite problems that omit `problem_id`/`id`.
- Reuse the fallback anywhere sandbox execution needs a result `problem_id`, including timeout and unexpected-error paths.
- Add a regression test proving local-suite problems without explicit ids get stable, distinct `local-...` ids.

## Verification
- `python -m pytest tests/test_sandbox_envelope.py -k missing_problem_ids`
- `python -m pytest tests/test_sandbox_envelope.py tests/test_proxy_client.py tests/test_output_split.py`
- `python -m py_compile src/agent/sandbox_executor.py tests/test_sandbox_envelope.py`
- `git diff --check`
