### PR TITLE
feat(validator): drop discarded agents from race-finisher set (ORO-1111)

### DIFF
--- a/docker/validator/pyproject.toml
+++ b/docker/validator/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "async-substrate-interface==1.6.4",
     "bittensor==10.1.0",
     "bittensor-wallet==4.0.1",
-    "oro-sdk==1.0.64",
+    "oro-sdk==1.0.73",
     "prometheus-client>=0.20.0",
     "psutil>=5.9.0",
     "requests==2.32.5",

--- a/docker/validator/uv.lock
+++ b/docker/validator/uv.lock
@@ -1362,7 +1362,7 @@ wheels = [
 
 [[package]]
 name = "oro-sdk"
-version = "1.0.64"
+version = "1.0.73"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -1370,9 +1370,9 @@ dependencies = [
     { name = "httpx" },
     { name = "python-dateutil" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/7a/8ed149a5104a0649763cf841db2aac4a4b90b76faf1c64f1bc435c132dc2/oro_sdk-1.0.64.tar.gz", hash = "sha256:de6600c413361fd64192a7df5696dd2776e42c3f7db7a7c494226e7ebf101fd5", size = 125306, upload-time = "2026-05-06T21:24:35.061Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/87/e2dbe9e18ea1d619201859058565353a17dbc2cbdaedcfb45e90d643ed43/oro_sdk-1.0.73.tar.gz", hash = "sha256:6e83be34a5010974d8a16eb61a0529082739a87c00497a7802ceb50035cacc1a", size = 131684, upload-time = "2026-05-11T21:36:34.598Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/b6/7ed053448a0144e3c27ea6f7492a3387a9211a4e17dea8f0ed8c90f547a1/oro_sdk-1.0.64-py3-none-any.whl", hash = "sha256:6beb60630d081de576a5944e9c40b75b94e2f7be7a2f573969057fba8a6dc79f", size = 317367, upload-time = "2026-05-06T21:24:33.786Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/4e/12e8ca1ab0ea07a71eaa8d6e45e80f8967169619e43919b8ad650666104c/oro_sdk-1.0.73-py3-none-any.whl", hash = "sha256:79c35b7e583d08facad27c427e6953c9904d3fc18cae035aad869307f757158a", size = 325477, upload-time = "2026-05-11T21:36:32.943Z" },
 ]
 
 [[package]]
@@ -1398,7 +1398,7 @@ requires-dist = [
     { name = "async-substrate-interface", specifier = "==1.6.4" },
     { name = "bittensor", specifier = "==10.1.0" },
     { name = "bittensor-wallet", specifier = "==4.0.1" },
-    { name = "oro-sdk", specifier = "==1.0.64" },
+    { name = "oro-sdk", specifier = "==1.0.73" },
     { name = "prometheus-client", specifier = ">=0.20.0" },
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "requests", specifier = "==2.32.5" },

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ duckduckgo_search==8.1.1
 colorama==0.4.6
 googlesearch-python==1.3.0
 bittensor==10.1.0
-oro-sdk==1.0.64
+oro-sdk==1.0.73
 prometheus-client>=0.20.0
 psutil>=5.9.0

--- a/subnet/tests/validator/test_weight_setter.py
+++ b/subnet/tests/validator/test_weight_setter.py
@@ -1,11 +1,13 @@
 import time
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
 import pytest
+from oro_sdk.types import UNSET
 
 from validator.weight_distribution import compute_pinned_weights
-from validator.weight_setter import WeightSetterThread
+from validator.weight_setter import WeightSetterThread, _qualifiers_to_finishers
 
 
 def _empty_history():
@@ -39,7 +41,9 @@ def _history_with_races(races: list):
 def _race_detail(qualifiers: list[dict]):
     """Build a mock RaceDetailResponse with the supplied qualifier dicts.
 
-    Each dict needs `miner_hotkey`, `agent_version_id`, `race_score`.
+    Each dict needs `miner_hotkey`, `agent_version_id`, `race_score` and may
+    optionally provide `is_discarded` (defaults to False — set True to
+    exercise the ORO-1111 filter path).
     """
     detail = MagicMock()
     detail.qualifiers = []
@@ -48,6 +52,7 @@ def _race_detail(qualifiers: list[dict]):
         m.miner_hotkey = q["miner_hotkey"]
         m.agent_version_id = q["agent_version_id"]
         m.race_score = q["race_score"]
+        m.is_discarded = q.get("is_discarded", False)
         detail.qualifiers.append(m)
     return detail
 
@@ -282,3 +287,39 @@ class TestWeightSetterThread:
         total = sum(weights)
         top_share = weights[1] / total
         assert abs(top_share - 0.25) < 1e-3
+
+
+class TestQualifiersToFinishersIsDiscarded:
+    """ORO-1111: drop is_discarded=True qualifiers from the finisher set."""
+
+    @staticmethod
+    def _q(hotkey: str, score: float, *, is_discarded=False, with_field: bool = True):
+        attrs = {
+            "miner_hotkey": hotkey,
+            "agent_version_id": uuid4(),
+            "race_score": score,
+        }
+        if with_field:
+            attrs["is_discarded"] = is_discarded
+        return SimpleNamespace(**attrs)
+
+    def test_drops_discarded_keeps_non_discarded(self):
+        qualifiers = [
+            self._q("5HKkept", 0.9, is_discarded=False),
+            self._q("5HKdiscarded", 0.85, is_discarded=True),
+            self._q("5HKalsoKept", 0.8, is_discarded=False),
+        ]
+        finishers = _qualifiers_to_finishers(qualifiers)
+        hotkeys = {f.miner_hotkey for f in finishers}
+        assert hotkeys == {"5HKkept", "5HKalsoKept"}
+
+    def test_missing_is_discarded_field_defaults_to_false(self):
+        """Forward-compat with pre-ORO-1111 SDK builds: missing field = keep."""
+        qualifiers = [self._q("5HKlegacy", 0.7, with_field=False)]
+        finishers = _qualifiers_to_finishers(qualifiers)
+        assert [f.miner_hotkey for f in finishers] == ["5HKlegacy"]
+
+    def test_unset_is_discarded_treated_as_false(self):
+        qualifiers = [self._q("5HKunset", 0.6, is_discarded=UNSET)]
+        finishers = _qualifiers_to_finishers(qualifiers)
+        assert [f.miner_hotkey for f in finishers] == ["5HKunset"]

--- a/subnet/validator/weight_setter.py
+++ b/subnet/validator/weight_setter.py
@@ -39,6 +39,12 @@ def _qualifiers_to_finishers(qualifiers) -> list[RankedFinisher]:
 
     Also drops entries without a `miner_hotkey` defensively so a
     partial-data Backend response can't poison the ranking.
+
+    Discarded agents (admin- or auto-discarded, surfaced via
+    `is_discarded` on the SDK record) are dropped so they stop earning
+    emissions via the rank-1 fallback or the protected tail set.
+    Missing or `UNSET` `is_discarded` defaults to False for forward
+    compatibility with older Backend builds that pre-date the field.
     """
     finishers: list[RankedFinisher] = []
     for q in qualifiers:
@@ -47,6 +53,15 @@ def _qualifiers_to_finishers(qualifiers) -> list[RankedFinisher]:
             continue
         hotkey = q.miner_hotkey
         if not hotkey or hotkey is UNSET:
+            continue
+        is_discarded = getattr(q, "is_discarded", False)
+        if is_discarded is UNSET:
+            is_discarded = False
+        if is_discarded:
+            logging.info(
+                "Dropping discarded agent from race finishers: "
+                f"hotkey={hotkey} agent_version_id={q.agent_version_id}"
+            )
             continue
         finishers.append(
             RankedFinisher(


### PR DESCRIPTION
## Description

`_qualifiers_to_finishers` now skips qualifiers with `is_discarded=True` (sourced from `RaceQualifierPublic.is_discarded`, added in Backend [#337](https://github.com/ORO-AI/Backend/pull/337)), alongside the existing null-score / missing-hotkey filters.

Without this, admin- or auto-discarded agents can keep earning emissions via the rank-1 fallback (when `/v1/public/top` returns null post-ORO-1097) and protected-tail paths for up to ~24h after discard, until the next race completes.

Forward-compat: `getattr(q, "is_discarded", False)` plus an `UNSET` guard keeps the validator safe when paired with a pre-ORO-1111 SDK build or a Backend that hasn't deployed yet — qualifiers fall back to the prior keep-everything behavior.

## Changes Made

- `subnet/validator/weight_setter.py::_qualifiers_to_finishers`: skip qualifiers with `is_discarded=True`. Log at INFO so operators can see when this kicks in.
- `subnet/tests/validator/test_weight_setter.py`: add `TestQualifiersToFinishersIsDiscarded` (3 cases: discarded dropped, non-discarded retained, missing field defaulted to False).
- `_race_detail` test helper now defaults `is_discarded=False` on mocked qualifiers so the pre-existing race-path tests keep working.

## Issue Link

- Related to: ORO-1111
- Closes: ORO-1111 (paired with Backend PR #337)
- Depends on: Backend PR #337 + the auto-published SDK release that exposes the field

## Testing

### Manual Testing

Ran `pytest subnet/tests/validator/test_weight_setter.py` locally — 11/11 pass.

**Test Results:**

```
subnet/tests/validator/test_weight_setter.py::TestQualifiersToFinishersIsDiscarded::test_drops_discarded_keeps_non_discarded PASSED
subnet/tests/validator/test_weight_setter.py::TestQualifiersToFinishersIsDiscarded::test_missing_is_discarded_field_defaults_to_false PASSED
subnet/tests/validator/test_weight_setter.py::TestQualifiersToFinishersIsDiscarded::test_unset_is_discarded_treated_as_false PASSED
... (8 pre-existing race-path tests also pass)
```

### Automated Testing

**Test Command(s):**
```bash
.venv/bin/python -m pytest subnet/tests/validator/test_weight_setter.py -v
```


## Documentation

- [ ] README updated
- [x] Code comments added/updated (docstring on `_qualifiers_to_finishers` updated)
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**

Docstring on `_qualifiers_to_finishers` now explains the discard-filter behavior and forward-compat semantics.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

**Deploy order:** Backend #337 must merge + deploy + the auto-published `oro-sdk` release must land before this PR moves the needle in production. Merging this PR early is safe (forward-compat path = no-op). After Backend deploys, bump `oro-sdk` to the version that exposes `is_discarded` in a follow-up commit on this branch or a separate PR so the validator can actually see the field.

**Tag + roll-out:** Per the ticket, tag a new validator version (oro v1.0.x) once everything lands and promote to staging + the ORO official validator before broader roll-out.