### PR TITLE
feat(validator): burn top 25% slot when no admin-designated top (ORO-1120)

### DIFF
--- a/subnet/tests/validator/test_weight_distribution.py
+++ b/subnet/tests/validator/test_weight_distribution.py
@@ -162,12 +162,14 @@ def test_compute_hotkey_weights_shape_per_spec(n, t_top, t_burn):
     """Rank 1 = top_u16 (sized for exact `t_top` share), ranks 2..K =
     K+1-rank, bottom 50% absent."""
     finishers = _make_finishers(n, seed=n)
-    weights = compute_hotkey_weights(finishers, t_top, t_burn)
+    ranked = rank_finishers(finishers)
+    weights = compute_hotkey_weights(
+        finishers, t_top, t_burn, top_hotkey=ranked[0].miner_hotkey
+    )
 
     k = n // 2
     assert len(weights) == k
 
-    ranked = rank_finishers(finishers)
     tail_sum = sum(range(1, k))  # 1 + 2 + ... + (K-1)
     expected_top, _ = compute_pinned_weights(t_top, t_burn, tail_sum=tail_sum)
 
@@ -188,9 +190,9 @@ def test_compute_hotkey_weights_shape_per_spec(n, t_top, t_burn):
 
 @pytest.mark.parametrize("n", [0, 1])
 def test_compute_hotkey_weights_empty_for_too_few_finishers(n):
-    """N=0 or N=1 → floor(N/2)=0, no rank-1 to receive the top weight.
-    The burn uid still fires unconditionally in
-    `build_metagraph_weight_vector`."""
+    """N=0 or N=1 → floor(N/2)=0, no protected tail entries. With no
+    `top_hotkey` either, the dict is empty; the burn uid still fires
+    unconditionally in `build_metagraph_weight_vector`."""
     weights = compute_hotkey_weights(_make_finishers(n), 0.25, 0.75)
     assert weights == {}
 
@@ -204,11 +206,15 @@ def test_top_miner_share_is_exactly_t_top_regardless_of_n(n):
     eating from both proportionally) is that the top miner's share is
     invariant under N. Verify on the integrated metagraph vector."""
     finishers = _make_finishers(n, seed=n)
+    ranked = rank_finishers(finishers)
     metagraph = ["hk_burn"] + [e.miner_hotkey for e in finishers]
     _, weights = build_metagraph_weight_vector(
-        finishers, metagraph, t_top=0.25, t_burn=0.75
+        finishers,
+        metagraph,
+        t_top=0.25,
+        t_burn=0.75,
+        top_hotkey=ranked[0].miner_hotkey,
     )
-    ranked = rank_finishers(finishers)
     rank1_idx = metagraph.index(ranked[0].miner_hotkey)
 
     total = sum(weights)
@@ -226,8 +232,10 @@ def test_top_miner_share_is_exactly_t_top_regardless_of_n(n):
 def test_compute_hotkey_weights_n30_top_share_25pct():
     """N=30, K=15, tail_sum=105. Top = round(0.25*(65535+105)/0.75) = 21880."""
     finishers = _make_finishers(30, seed=30)
-    weights = compute_hotkey_weights(finishers, 0.25, 0.75)
     ranked = rank_finishers(finishers)
+    weights = compute_hotkey_weights(
+        finishers, 0.25, 0.75, top_hotkey=ranked[0].miner_hotkey
+    )
 
     assert weights[ranked[0].miner_hotkey] == 21880
     tail_sum = sum(weights[ranked[idx].miner_hotkey] for idx in range(1, 15))
@@ -237,8 +245,10 @@ def test_compute_hotkey_weights_n30_top_share_25pct():
 def test_compute_hotkey_weights_n100_top_share_25pct():
     """N=100, K=50, tail_sum=1225. Top = round(0.25*(65535+1225)/0.75) = 22253."""
     finishers = _make_finishers(100, seed=100)
-    weights = compute_hotkey_weights(finishers, 0.25, 0.75)
     ranked = rank_finishers(finishers)
+    weights = compute_hotkey_weights(
+        finishers, 0.25, 0.75, top_hotkey=ranked[0].miner_hotkey
+    )
 
     assert weights[ranked[0].miner_hotkey] == 22253
     tail_sum = sum(weights[ranked[idx].miner_hotkey] for idx in range(1, 50))
@@ -325,16 +335,24 @@ def test_build_metagraph_vector_empty_metagraph_returns_empty():
 # --- top_hotkey override (current top via score-to-beat) ---
 
 
-def test_top_hotkey_none_matches_legacy_rank1_behavior():
-    """`top_hotkey=None` must produce byte-identical weights to passing
-    explicit rank-1 hotkey — the override is opt-in, not a behavior change."""
+def test_top_hotkey_none_burns_top_share_no_synthesis():
+    """ORO-1120: when no admin-designated top exists, do NOT synthesize
+    one from rank-1 of finishers. The dict carries the full top-K tail
+    (no top entry); the caller burns the 25% top share."""
     finishers = _make_finishers(20, seed=42)
     ranked = rank_finishers(finishers)
-    rank1 = ranked[0].miner_hotkey
+    k = len(finishers) // 2
 
-    weights_none = compute_hotkey_weights(finishers, 0.25, 0.75, top_hotkey=None)
-    weights_explicit = compute_hotkey_weights(finishers, 0.25, 0.75, top_hotkey=rank1)
-    assert weights_none == weights_explicit
+    weights = compute_hotkey_weights(finishers, 0.25, 0.75, top_hotkey=None)
+
+    # No top entry: every entry is a tail entry with a small u16 weight.
+    # In particular, rank-1 does NOT receive top_u16.
+    expected_top_u16, _ = compute_pinned_weights(0.25, 0.75, tail_sum=k * (k + 1) // 2)
+    assert weights[ranked[0].miner_hotkey] != expected_top_u16
+    # Full top-K populates the tail (M = K, weights K, K-1, ..., 1).
+    assert weights[ranked[0].miner_hotkey] == k
+    assert weights[ranked[k - 1].miner_hotkey] == 1
+    assert len(weights) == k
 
 
 def test_top_hotkey_override_promotes_non_winner_to_top_slot():
@@ -423,32 +441,82 @@ def test_build_metagraph_vector_top_hotkey_promoted_to_top_slot():
     assert weights[0] > 0  # burn slot non-zero
 
 
-def test_build_metagraph_vector_top_hotkey_not_in_metagraph_falls_back():
-    """If `top_hotkey` deregistered between Backend designation and weight
-    set, fall back to rank-1 of last-race finishers (legacy behavior)."""
+def test_build_metagraph_vector_top_hotkey_not_in_metagraph_burns_top_share():
+    """ORO-1120: when `top_hotkey` is designated by Backend but the hotkey
+    deregistered between designation and the weight set, the validator no
+    longer falls back to rank-1 of finishers. The top share burns; the
+    tail still receives its dereg-protection weights."""
     finishers = _make_finishers(20, seed=8)
     ranked = rank_finishers(finishers)
     rank1_hk = ranked[0].miner_hotkey
     metagraph_hotkeys = ["burn_uid"] + [f.miner_hotkey for f in finishers]
 
-    uids, weights_with_missing = build_metagraph_weight_vector(
+    uids, weights = build_metagraph_weight_vector(
         finishers,
         metagraph_hotkeys=metagraph_hotkeys,
         t_top=0.25,
         t_burn=0.75,
         top_hotkey="hk_deregistered",
     )
-    uids_legacy, weights_legacy = build_metagraph_weight_vector(
-        finishers, metagraph_hotkeys=metagraph_hotkeys, t_top=0.25, t_burn=0.75
+
+    # Burn uid pinned at U16_MAX (it dominates the vector). No rank-1
+    # promotion: the rank-1 finisher only receives its small tail weight.
+    assert weights[0] == U16_MAX
+    rank1_idx = metagraph_hotkeys.index(rank1_hk)
+    k = len(finishers) // 2
+    assert weights[rank1_idx] == k  # full top-K tail; rank-1 gets weight = K
+    # Burn dominates the chain-normalised vector — top share ≈ 0%.
+    total = sum(weights)
+    burn_share = weights[0] / total
+    assert burn_share > 0.99
+
+
+def test_build_metagraph_vector_no_top_hotkey_burns_top_share():
+    """ORO-1120: with `top_hotkey=None` (no admin top designated — fresh
+    subnet, suite switch, or designated top discarded), the 25% slot
+    burns. Tail finishers still receive their linear-taper dereg-protection
+    weights."""
+    finishers = _make_finishers(20, seed=42)
+    ranked = rank_finishers(finishers)
+    metagraph_hotkeys = ["burn_uid"] + [f.miner_hotkey for f in finishers]
+
+    uids, weights = build_metagraph_weight_vector(
+        finishers,
+        metagraph_hotkeys=metagraph_hotkeys,
+        t_top=0.25,
+        t_burn=0.75,
+        top_hotkey=None,
     )
 
-    # Fallback path produces byte-identical output to the legacy
-    # (no-override) call — preserves Yuma determinism across validators.
-    assert weights_with_missing == weights_legacy
-    rank1_idx = metagraph_hotkeys.index(rank1_hk)
-    # rank-1 finisher takes the top slot (highest weight among non-burn uids).
-    non_burn = [w if i != 0 else 0 for i, w in enumerate(weights_with_missing)]
-    assert weights_with_missing[rank1_idx] == max(non_burn)
+    assert weights[0] == U16_MAX  # burn pinned
+    # Rank-1 finisher does NOT receive top_u16 — they only get a tail weight.
+    rank1_idx = metagraph_hotkeys.index(ranked[0].miner_hotkey)
+    k = len(finishers) // 2
+    assert weights[rank1_idx] == k  # full top-K tail, M=K
+    # Burn dominates: top share ≈ 0%.
+    total = sum(weights)
+    assert weights[0] / total > 0.99
+    # Bottom-half finishers still get 0.
+    for idx in range(k, len(finishers)):
+        bottom_idx = metagraph_hotkeys.index(ranked[idx].miner_hotkey)
+        assert weights[bottom_idx] == 0
+
+
+def test_build_metagraph_vector_no_top_hotkey_no_finishers_burns_everything():
+    """ORO-1120: no admin top + no finishers → full burn (existing behavior
+    is preserved end-to-end)."""
+    metagraph_hotkeys = ["burn_uid", "hk_other_1", "hk_other_2"]
+    uids, weights = build_metagraph_weight_vector(
+        [],
+        metagraph_hotkeys=metagraph_hotkeys,
+        t_top=0.25,
+        t_burn=0.75,
+        top_hotkey=None,
+    )
+
+    assert weights[0] == U16_MAX
+    assert weights[1] == 0
+    assert weights[2] == 0
 
 
 def test_two_validators_with_top_override_emit_byte_identical_weights():

--- a/subnet/tests/validator/test_weight_setter.py
+++ b/subnet/tests/validator/test_weight_setter.py
@@ -174,6 +174,8 @@ class TestWeightSetterThread:
         metagraph.hotkeys = ["5BurnUid"] + [e["miner_hotkey"] for e in finishers]
         metagraph.uids = list(range(len(metagraph.hotkeys)))
 
+        # Admin-designated top is rank-1 of this race (and is in the metagraph).
+        mock_backend_client.get_top_miner.return_value.top_miner_hotkey = "5HK0"
         race_id = uuid4()
         mock_backend_client.get_race_history.return_value = _race_complete_history(race_id)
         mock_backend_client.get_race_detail.return_value = _race_detail(finishers)
@@ -217,6 +219,8 @@ class TestWeightSetterThread:
         metagraph.hotkeys = ["5BurnUid"] + [f["miner_hotkey"] for f in finishers]
         metagraph.uids = list(range(len(metagraph.hotkeys)))
 
+        # Admin-designated top is rank-1 of the completed race.
+        mock_backend_client.get_top_miner.return_value.top_miner_hotkey = "5HK0"
         in_progress_id = uuid4()
         completed_id = uuid4()
         mock_backend_client.get_race_history.return_value = _history_with_races(
@@ -263,6 +267,8 @@ class TestWeightSetterThread:
         metagraph.hotkeys = ["5BurnUid", "5HK0"]  # only burn + rank 1
         metagraph.uids = list(range(len(metagraph.hotkeys)))
 
+        # Admin-designated top is rank-1 (5HK0), which is in the metagraph.
+        mock_backend_client.get_top_miner.return_value.top_miner_hotkey = "5HK0"
         mock_backend_client.get_race_history.return_value = _race_complete_history(uuid4())
         mock_backend_client.get_race_detail.return_value = _race_detail(finishers)
 

--- a/subnet/validator/weight_distribution.py
+++ b/subnet/validator/weight_distribution.py
@@ -149,8 +149,13 @@ def compute_hotkey_weights(
     deregistration-protection tail.
 
     The top slot (`top_u16`) goes to `top_hotkey` if provided (the canonical
-    "current top for emissions" from `/v1/public/top`), otherwise falls back
-    to the rank-1 finisher of the most recent completed race.
+    "current top for emissions" from `/v1/public/top`). When `top_hotkey`
+    is None — no admin-designated top exists (fresh subnet, suite switch,
+    or the designated top was discarded) — the top share is **not**
+    assigned to anyone here; the caller (`build_metagraph_weight_vector`)
+    routes it to the burn slot. We deliberately do not synthesize a top
+    from rank-1 of finishers: the 25% slot belongs to the admin-designated
+    top only.
 
     The tail is the top 50% of last-race finishers minus the top hotkey if
     they overlap. Tail entries receive a linear taper M, M-1, ..., 1 in rank
@@ -160,30 +165,20 @@ def compute_hotkey_weights(
     Bottom 50% (and ties at the rank-K boundary, by tiebreak) get no entry.
     """
     ranked = rank_finishers(qualifiers)
-    n = len(ranked)
-    k = n // 2  # floor — protected-set size
+    k = len(ranked) // 2  # floor — protected-set size
 
-    if top_hotkey is None:
-        if k == 0:
-            return {}
-        effective_top = ranked[0].miner_hotkey
-    else:
-        effective_top = top_hotkey
-
-    # Tail = top-K finishers excluding the effective top hotkey. When
-    # effective_top is the rank-1 finisher this matches the historical
-    # ranks 2..K tail; when effective_top is rank j (j > 1) of the
-    # protected set, rank 1 takes the largest tail weight; when
-    # effective_top is outside the protected set entirely (or there
-    # are no finishers), the tail is the full top-K.
-    protected = ranked[:k] if k > 0 else []
-    tail_finishers = [f for f in protected if f.miner_hotkey != effective_top]
-
+    # Tail = top-K finishers excluding `top_hotkey` if they overlap.
+    # When `top_hotkey` is None the filter never matches, so the tail is
+    # the full top-K. When `top_hotkey` is rank-1 of finishers, the tail
+    # is ranks 2..K (the historical shape).
+    tail_finishers = [f for f in ranked[:k] if f.miner_hotkey != top_hotkey]
     m = len(tail_finishers)
     tail_sum = m * (m + 1) // 2  # M + (M-1) + ... + 1
 
     top_u16, _ = compute_pinned_weights(t_top, t_burn, tail_sum)
-    weights: dict[str, int] = {effective_top: top_u16}
+    weights: dict[str, int] = {}
+    if top_hotkey is not None:
+        weights[top_hotkey] = top_u16
     for idx, finisher in enumerate(tail_finishers):
         weights[finisher.miner_hotkey] = m - idx
 
@@ -201,10 +196,12 @@ def build_metagraph_weight_vector(
 
     `top_hotkey` is the canonical "current top for emissions" (from
     `/v1/public/top`). When set and present in the metagraph, that hotkey
-    receives the top emission slot regardless of whether they finished
-    last race. Falls back to rank-1 of last-race finishers when
-    `top_hotkey` is None or has deregistered between Backend's
-    designation and the weight set.
+    receives the top emission slot. When `top_hotkey` is None — no admin-
+    designated top (fresh subnet, suite switch, or the designated top was
+    discarded) — OR the designated top has deregistered between Backend
+    designation and the weight set, the top share rolls into the burn
+    slot. We do not synthesize a top from rank-1 of finishers: the 25%
+    slot belongs to the admin-designated top only.
 
     Steps:
 
@@ -213,9 +210,9 @@ def build_metagraph_weight_vector(
     3. Map every hotkey-weight onto its metagraph index. A hotkey present
        in the race but absent from the metagraph (deregistered between
        race close and weight set) is silently dropped — its weight does
-       not redistribute, so the burn share grows slightly. This matches
-       the existing "top miner missing → burn everything" fallback.
-    4. Add `burn_u16` at uid 0 (the literal burn slot).
+       not redistribute, so the burn share grows slightly.
+    4. Add `burn_u16` at uid 0; if there is no eligible top, also fold
+       `top_u16` into uid 0 so the burn slot absorbs the full 25%.
 
     Returns:
         Two parallel lists of length `len(metagraph_hotkeys)`. `uids[i]`
@@ -227,61 +224,40 @@ def build_metagraph_weight_vector(
     if n_meta == 0:
         return [], []
 
-    finishers = list(qualifiers)
     hotkey_to_idx = {hk: i for i, hk in enumerate(metagraph_hotkeys)}
 
-    # If the designated top hotkey isn't in the current metagraph (deregistered
-    # between Backend designation and weight set), fall back to rank-1 of
-    # last-race finishers. Keeps the protection mechanism alive instead of
-    # burning everything.
-    effective_top_hotkey = top_hotkey
-    if effective_top_hotkey is not None and effective_top_hotkey not in hotkey_to_idx:
-        effective_top_hotkey = None
+    # The 25% top slot is allocated to the admin-designated top — and
+    # *only* if that hotkey is in the current metagraph. Otherwise (no
+    # admin designation, or designated top deregistered after Backend
+    # picked them) the slot burns: `weights[0]` gets only `burn_u16`,
+    # and the unallocated top share normalises into burn on-chain.
+    has_eligible_top = top_hotkey is not None and top_hotkey in hotkey_to_idx
+    effective_top = top_hotkey if has_eligible_top else None
 
     hotkey_weights = compute_hotkey_weights(
-        finishers, t_top, t_burn, top_hotkey=effective_top_hotkey
+        list(qualifiers), t_top, t_burn, top_hotkey=effective_top
     )
-    if not hotkey_weights:
-        # No top hotkey AND no finishers — burn everything.
-        weights = [0] * n_meta
-        weights[0] = U16_MAX
-        return list(range(n_meta)), weights
 
+    # Place the tail. The top entry (if any) is pinned below from the
+    # recomputed `top_u16`; here we only iterate the dereg-protection
+    # tail and track the actual tail sum after any dereg drops.
     weights = [0] * n_meta
-    # The effective top hotkey is whoever `compute_hotkey_weights` placed in
-    # the top slot — explicit override if set + valid, else rank-1 finisher.
-    if effective_top_hotkey is not None:
-        top_hk = effective_top_hotkey
-    else:
-        ranked = rank_finishers(finishers)
-        top_hk = ranked[0].miner_hotkey
-    top_idx: int | None = None
     tail_sum_actual = 0
     for hk, w in hotkey_weights.items():
+        if hk == effective_top:
+            continue
         idx = hotkey_to_idx.get(hk)
         if idx is None:
-            continue
-        if hk == top_hk:
-            top_idx = idx
-        else:
-            weights[idx] = w
-            tail_sum_actual += w
+            continue  # finisher deregistered; share folds into burn on-chain
+        weights[idx] = w
+        tail_sum_actual += w
 
-    # Recompute pinned weights from the *actual* tail sum (after dropping
-    # deregistered finishers) so the top miner lands at exactly t_top of
-    # the submitted vector. Without this, missing tail u16 entries inflate
-    # both top and burn shares proportionally.
+    # Pin top + burn from the *actual* tail sum so the top miner lands at
+    # exactly `t_top` of the submitted vector. Additive assignment handles
+    # the rare testnet case where uid 0 is itself the top hotkey.
     top_u16, burn_u16 = compute_pinned_weights(t_top, t_burn, tail_sum_actual)
-    if top_idx is not None:
-        # Burn uid 0 may collide with the rank-1 hotkey on very small
-        # testnet metagraphs; weights are additive on uid 0.
-        if top_idx == 0:
-            weights[0] = top_u16 + burn_u16
-        else:
-            weights[top_idx] = top_u16
-            weights[0] = burn_u16
-    else:
-        # Top miner deregistered — pin burn slot only.
-        weights[0] = burn_u16
+    weights[0] += burn_u16
+    if has_eligible_top:
+        weights[hotkey_to_idx[top_hotkey]] += top_u16
 
     return list(range(n_meta)), weights

--- a/subnet/validator/weight_setter.py
+++ b/subnet/validator/weight_setter.py
@@ -170,9 +170,11 @@ class WeightSetterThread:
         """Return the canonical "current top miner" hotkey for emissions.
 
         Reads `GET /v1/public/top` (the score-to-beat designation). Returns
-        None when there's no admin-designated top (fresh subnet) or the
-        request fails — `build_metagraph_weight_vector` falls back to rank-1
-        of last-race finishers in that case.
+        None when there's no admin-designated top (fresh subnet, suite
+        switch, or designated top was discarded) or the request fails. In
+        all such cases `build_metagraph_weight_vector` burns the 25% top
+        share rather than synthesizing a top from rank-1 of finishers —
+        the top slot belongs to the admin-designated top only.
         """
         try:
             top = self.backend_client.get_top_miner()


### PR DESCRIPTION
## Description

The 25% top emission slot belongs to the admin-designated top hotkey (`/v1/public/top`) **only**. Previously, when no admin top existed — fresh subnet, suite switch, or designated top discarded (post-ORO-1097) — OR when the designated top deregistered between Backend designation and the validator weight set, the code synthesized rank-1 of last-race finishers as a stand-in and gave them the 25%.

That fallback bypassed the admin promotion gate and quietly handed top-slot emissions to whichever agent happened to score highest in the last race. Post-ORO-1111 it would even reroute around discarded agents to the *next-best* finisher — still not what the protocol intends.

After this change, the four "no eligible top" scenarios collapse to one rule: **no admin top in the metagraph → top share burns**. The tail (top-50% finishers, dereg-protection u16s) is unchanged.

## Behavior matrix

| `top_hotkey` | In metagraph? | Finishers | Result |
|---|---|---|---|
| set | yes | any | top hotkey gets 25%, burn 75% (unchanged) |
| `None` (no admin) | n/a | any | **top share burns** (was: rank-1 synthesized as top) |
| `None` (discarded, post-ORO-1097) | n/a | any | **top share burns** (was: rank-1 synthesized as top) |
| set | **no** (dereg'd post-designation) | any | **top share burns** (was: rank-1 synthesized as top) |
| set | yes | empty | top gets 25%, no tail (unchanged) |
| `None` | n/a | empty | full burn (unchanged) |

Burn pinned at `U16_MAX`; tail u16s stay at their linear-taper values; the unallocated 25% slot normalises into the burn share on-chain (≈99.98%+ burn / ≈0.02% tail / 0% top in the no-top cases).

## Changes Made

- `subnet/validator/weight_distribution.py`:
  - `compute_hotkey_weights`: drops the `top_hotkey is None → effective_top = ranked[0]` synthesis. When `top_hotkey` is None, no top entry is added to the dict; the tail is the full top-K.
  - `build_metagraph_weight_vector`: refactored placement. Single `has_eligible_top` predicate upfront, additive assignment of burn + top u16s, no in-loop `top_idx` tracking. Net −16 lines in the function body.
  - Updated docstrings reflecting the new rule.
- `subnet/validator/weight_setter.py`: docstring on `_fetch_top_hotkey` no longer hints at a downstream rank-1 fallback.
- Tests:
  - 4 new ORO-1120 scenarios in `test_weight_distribution.py` covering the four AC quadrants.
  - Three pre-existing tests in `test_weight_setter.py` were inadvertently exercising the dropped fallback (their mock returned `5GrwvaEF...` as top but their test-local metagraphs didn't include it). They now set the mock's top to match rank-1 of the test's finishers, exercising the real happy path.
  - Several `compute_hotkey_weights` / `build_metagraph_weight_vector` tests that called without `top_hotkey` and asserted on rank-1 = top_u16 now pass `top_hotkey=ranked[0].miner_hotkey` explicitly.

## Issue Link

- Related to: ORO-1097, ORO-1111
- Closes: ORO-1120

## Testing

### Manual Testing

Walked through the behavior matrix end-to-end via the unit + integration tests. Full validator test suite green locally.

**Test Results:**

```
subnet/tests/validator/test_weight_distribution.py ........................................ 45 passed
subnet/tests/validator/test_weight_setter.py ............ 11 passed
============================== 56 passed in 0.91s ==============================
```

### Automated Testing

**Test Command(s):**
```bash
.venv/bin/python -m pytest subnet/tests/validator/test_weight_distribution.py subnet/tests/validator/test_weight_setter.py -v
```


## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**

Docstrings on `compute_hotkey_weights`, `build_metagraph_weight_vector`, and `_fetch_top_hotkey` now state the rule explicitly: top share belongs to the admin-designated top; absent that, it burns.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged (ORO-1097 + ORO-1111 are both merged)

## Additional Notes

**Tag plan**: once this and ORO-1111's validator change are both merged, tag a single new validator version (oro v1.0.92) that bundles both changes. Roll to staging + ORO official validator for the manual verification step on each AC (discard-then-tick for ORO-1111; burn-on-no-top for this one).