### PR TITLE
fix(validator): correct stale 'rank-1 fallback' log label (ORO-1120)

### DIFF
--- a/subnet/validator/weight_setter.py
+++ b/subnet/validator/weight_setter.py
@@ -260,7 +260,7 @@ class WeightSetterThread:
         non_zero = sum(1 for w in weights if w > 0)
         logging.info(
             f"Race-based weight vector: N={len(finishers)} finishers, "
-            f"top={top_hotkey or '(rank-1 fallback)'}, "
+            f"top={top_hotkey or '(none — top share burns)'}, "
             f"{non_zero} non-zero metagraph slots"
         )
 


### PR DESCRIPTION
## Description

ORO-1120 removed the rank-1 fallback from `build_metagraph_weight_vector`, but the log line at `weight_setter.py:262` still printed `top=(rank-1 fallback)` when `top_hotkey` was `None` — implying a fallback fires that no longer exists.

Surfaced during staging verification of `v1.0.92`:

```
01:09:43  Dropping discarded agent from race finishers: hotkey=5E79cgat… (Sky / admin top)
01:09:43  Dropping discarded agent from race finishers: hotkey=5EkBKCD8… (test_pro_plan_again)
01:09:43  Race-based weight vector: N=1 finishers, top=(rank-1 fallback), 1 non-zero metagraph slots
```

The submitted vector has only **1 non-zero slot** (burn at uid 0) — that's the correct ORO-1120 behavior, not a fallback. The log message just lied about the reason. A real fallback would produce 2 non-zero slots (top + burn).

## Changes Made

- `subnet/validator/weight_setter.py`: replace `'(rank-1 fallback)'` with `'(none — top share burns)'` in the weight-vector summary log line.

## Issue Link

- Related to: ORO-1120
- Closes: N/A (follow-up to merged PR #151)

## Testing

### Manual Testing

This is a string-literal change in a logging.info call. Verified the new message is what's emitted by visual inspection. Will re-run the same ORO-1120 verification on v1.0.93 to confirm the new label appears.

**Test Results:**

Same staging behavior as v1.0.92 (1-slot full-burn vector when no admin top); only the log label changes.

### Automated Testing

No new tests — the existing weight_distribution tests still pass unchanged.

**Test Command(s):**
```bash
.venv/bin/python -m pytest subnet/tests/validator/test_weight_distribution.py subnet/tests/validator/test_weight_setter.py -q
```


## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**

N/A — operator-visible log only.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

Plan to bundle into `oro v1.0.93` along with anything else queued for the next release. Single-line cosmetic change — low risk.