### PR TITLE
refactor(validator): split ProgressReporter into focused components

### DIFF
--- a/subnet/tests/validator/test_progress_reporter_envelope.py
+++ b/subnet/tests/validator/test_progress_reporter_envelope.py
@@ -56,15 +56,15 @@ def reporter(tmp_path) -> ProgressReporter:
     # Disable scoring side effects — tests assert on dispatch/no-dispatch,
     # not on what scoring computes. Replace scorers with a stub that always
     # produces a clean SUCCESS so dispatched futures complete promptly.
-    rep._scorers = {}
+    rep._scoring_pool.scorers = {}
     return rep
 
 
 class TestEnvelopeParsing:
     def test_success_envelope_dispatches_to_scoring(self, reporter, tmp_path):
         _write_envelope(tmp_path / "output.jsonl", problem_id=_P1, status="SUCCESS")
-        reporter._read_and_dispatch()
-        assert _P1 in reporter._scoring_futures
+        reporter._envelope_dispatcher.read_and_dispatch()
+        assert _P1 in reporter._scoring_pool.futures
 
     def test_failure_envelope_records_without_scoring(self, reporter, tmp_path):
         _write_envelope(
@@ -74,8 +74,8 @@ class TestEnvelopeParsing:
             dialogue=None,
             error={"type": "RuntimeError", "message": "boom"},
         )
-        reporter._read_and_dispatch()
-        assert _P1 not in reporter._scoring_futures
+        reporter._envelope_dispatcher.read_and_dispatch()
+        assert _P1 not in reporter._scoring_pool.futures
         assert reporter._results[_P1].status == ProblemStatus.FAILED
 
     def test_timeout_envelope_records_without_scoring(self, reporter, tmp_path):
@@ -86,8 +86,8 @@ class TestEnvelopeParsing:
             dialogue=None,
             error={"type": "TimeoutError", "message": "..."},
         )
-        reporter._read_and_dispatch()
-        assert _P1 not in reporter._scoring_futures
+        reporter._envelope_dispatcher.read_and_dispatch()
+        assert _P1 not in reporter._scoring_pool.futures
         assert reporter._results[_P1].status == ProblemStatus.TIMED_OUT
 
     def test_inference_counts_come_from_envelope(self, reporter, tmp_path):
@@ -100,9 +100,9 @@ class TestEnvelopeParsing:
             inference_total=7,
             error={"type": "RuntimeError", "message": "x"},
         )
-        reporter._read_and_dispatch()
+        reporter._envelope_dispatcher.read_and_dispatch()
         # Inference counts captured from envelope at dispatch time.
-        meta = reporter._envelope_meta[_P1]
+        meta = reporter._envelope_dispatcher.envelope_meta[_P1]
         assert (meta.inference_failure_count, meta.inference_total) == (2, 7)
         # And materialized into the terminal result.
         assert reporter._results[_P1].inference_failures == 2
@@ -122,7 +122,7 @@ class TestEnvelopeParsing:
             error={"type": "RuntimeError", "message": "x"},
         )
         # Should not raise. If validator reads sidecar, JSONDecodeError surfaces.
-        reporter._read_and_dispatch()
+        reporter._envelope_dispatcher.read_and_dispatch()
         assert reporter._results[_P1].status == ProblemStatus.FAILED
 
     def test_validator_no_longer_has_read_inference_stats(self, reporter):
@@ -138,16 +138,21 @@ class TestEnvelopeParsing:
             execution_time=42.0,
             error={"type": "TimeoutError", "message": "..."},
         )
-        reporter._read_and_dispatch()
+        reporter._envelope_dispatcher.read_and_dispatch()
         assert reporter._results[_P1].execution_time == 42.0
 
     def test_malformed_line_skipped(self, reporter, tmp_path):
         out = tmp_path / "output.jsonl"
         with open(out, "a") as f:
             f.write("not json\n")
-        _write_envelope(out, problem_id=_P1, status="FAILED", dialogue=None,
-                        error={"type": "RuntimeError", "message": "x"})
-        reporter._read_and_dispatch()
+        _write_envelope(
+            out,
+            problem_id=_P1,
+            status="FAILED",
+            dialogue=None,
+            error={"type": "RuntimeError", "message": "x"},
+        )
+        reporter._envelope_dispatcher.read_and_dispatch()
         assert reporter._results[_P1].status == ProblemStatus.FAILED
 
 
@@ -161,13 +166,13 @@ class TestSweepNarrowing:
             dialogue=None,
             error={"type": "RuntimeError", "message": "x"},
         )
-        reporter._read_and_dispatch()
-        reporter._mark_remaining_timed_out()
+        reporter._envelope_dispatcher.read_and_dispatch()
+        reporter._envelope_dispatcher.mark_remaining_timed_out()
         assert reporter._results[_P1].status == ProblemStatus.FAILED
 
     def test_sweep_marks_only_never_seen_problems(self, reporter):
         # No envelope written. Sweep should mark all three TIMED_OUT.
-        reporter._mark_remaining_timed_out()
+        reporter._envelope_dispatcher.mark_remaining_timed_out()
         assert reporter._results[_P1].status == ProblemStatus.TIMED_OUT
         assert reporter._results[_P2].status == ProblemStatus.TIMED_OUT
         assert reporter._results[_P3].status == ProblemStatus.TIMED_OUT

--- a/subnet/validator/envelope_dispatcher.py
+++ b/subnet/validator/envelope_dispatcher.py
@@ -1,0 +1,144 @@
+"""Sandbox envelope-stream reader.
+
+Translates raw envelope records from OutputWatcher into actions:
+
+- SUCCESS  → dispatch the dialogue to the scoring pool
+- FAILED / TIMED_OUT → write a terminal ProblemResult directly to results
+- End-of-run sweep → mark never-seen problems TIMED_OUT
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Dict, Optional
+
+from bittensor.utils.btlogging import logging
+
+from oro_sdk.models import ProblemStatus
+
+from src.agent.sandbox_status import SandboxProblemStatus
+from src.agent.types import ProblemDict
+
+from .output_watcher import ErrorInfo, OutputWatcher
+from .scoring_pool import ScoringPool
+from .types import EnvelopeMeta, ProblemResult
+
+
+class EnvelopeDispatcher:
+    """Reads sandbox envelope stream and routes each record."""
+
+    def __init__(
+        self,
+        watcher: OutputWatcher,
+        results: Dict[str, ProblemResult],
+        envelope_meta: Dict[str, EnvelopeMeta],
+        id_to_problem: Dict[str, ProblemDict],
+        lock: threading.Lock,
+        scoring_pool: ScoringPool,
+    ):
+        self._watcher = watcher
+        self._results = results
+        self.envelope_meta = envelope_meta
+        self._id_to_problem = id_to_problem
+        self._lock = lock
+        self._scoring_pool = scoring_pool
+
+    def read_and_dispatch(self, hard_deadline: Optional[float] = None) -> int:
+        """Read new records from the watcher and act on each.
+
+        SUCCESS records are dispatched to the scoring pool; FAILED and
+        TIMED_OUT records are stored directly without scoring. Returns
+        the number of newly dispatched (SUCCESS) problems. If
+        ``hard_deadline`` is set, the read loop bails when wall-clock
+        time reaches it.
+        """
+        newly_dispatched = 0
+        for record in self._watcher.read_new():
+            with self._lock:
+                if record.problem_id in self._results or self._scoring_pool.has_future(
+                    record.problem_id
+                ):
+                    continue
+                self.envelope_meta[record.problem_id] = EnvelopeMeta(
+                    inference_failure_count=record.inference_failure_count,
+                    inference_total=record.inference_total,
+                    execution_time=record.execution_time,
+                )
+
+            if record.status is SandboxProblemStatus.SUCCESS:
+                self._scoring_pool.submit(record.problem_id, record.dialogue or [])
+                newly_dispatched += 1
+            else:
+                # FAILED / TIMED_OUT — record directly, no scoring dispatch.
+                terminal = self.build_terminal_result(
+                    problem_id=record.problem_id,
+                    status=record.status,
+                    error=record.error,
+                )
+                if terminal is not None:
+                    with self._lock:
+                        self._results[record.problem_id] = terminal
+
+            if hard_deadline is not None and time.time() >= hard_deadline:
+                break
+
+        return newly_dispatched
+
+    def build_terminal_result(
+        self,
+        *,
+        problem_id: str,
+        status: SandboxProblemStatus,
+        error: Optional[ErrorInfo],
+    ) -> Optional[ProblemResult]:
+        """Build a non-success ProblemResult from envelope-only data."""
+        problem = self._id_to_problem.get(problem_id)
+        if not problem:
+            logging.warning(f"Unknown problem_id in terminal envelope: {problem_id}")
+            return None
+        category = problem.get("category", "product").lower()
+        problem_status = ProblemStatus(status.value)
+        with self._lock:
+            meta = self.envelope_meta.get(problem_id)
+        inf_fail = meta.inference_failure_count if meta else 0
+        inf_total = meta.inference_total if meta else 0
+        exec_time = meta.execution_time if meta else 0.0
+        if error and error.message:
+            logging.info(
+                f"Recording terminal {status} for {problem_id}: {error.message[:80]}"
+            )
+        return ProblemResult(
+            problem_id=problem_id,
+            category=category,
+            status=problem_status,
+            score=0.0,
+            inference_failures=inf_fail,
+            inference_total=inf_total,
+            execution_time=exec_time,
+        )
+
+    def mark_remaining_timed_out(self) -> None:
+        """Mark all unscored problems as TIMED_OUT in local results.
+
+        Only reaches problems that never produced an envelope (sandbox death
+        before write, never-started, or partial run cut off by hard deadline).
+        """
+        with self._lock:
+            scored_ids = set(self._results.keys())
+
+        unscored = set(self._id_to_problem.keys()) - scored_ids
+        if not unscored:
+            return
+
+        logging.info(f"Marking {len(unscored)} unscored problems as TIMED_OUT")
+        with self._lock:
+            for pid in unscored:
+                self._results[pid] = ProblemResult(
+                    problem_id=pid,
+                    category=self._id_to_problem[pid]
+                    .get("category", "product")
+                    .lower(),
+                    status=ProblemStatus.TIMED_OUT,
+                    score=0.0,
+                )

--- a/subnet/validator/progress_batcher.py
+++ b/subnet/validator/progress_batcher.py
@@ -1,0 +1,109 @@
+"""Batches per-problem progress updates and reports them to the backend.
+
+`maybe_report()` is the throttled entry point called every loop tick;
+`batch_report()` is the unconditional flush for end-of-run and forced
+checkpoints. Both build their payload from the shared results dict under
+ProgressReporter's lock.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Dict, Optional
+from uuid import UUID
+
+import requests
+from bittensor.utils.btlogging import logging
+
+from oro_sdk.models import ProblemProgressUpdate
+
+from src.agent.types import ScoreComponentsSummary
+
+from .backend_client import BackendClient, BackendError
+from .types import ProblemResult
+
+
+# Report to backend at most every N seconds
+REPORT_INTERVAL_SECONDS = 10.0
+
+
+class ProgressBatcher:
+    """Periodic, lock-aware batch reporter to the backend."""
+
+    def __init__(
+        self,
+        backend_client: BackendClient,
+        eval_run_id: UUID,
+        total_problems: int,
+        results: Dict[str, ProblemResult],
+        lock: threading.Lock,
+        report_interval: float = REPORT_INTERVAL_SECONDS,
+    ):
+        self._backend_client = backend_client
+        self._eval_run_id = eval_run_id
+        self._total_problems = total_problems
+        self._results = results
+        self._lock = lock
+        self._report_interval = report_interval
+        self._last_report_time = 0.0
+        self._last_reported_count = 0
+
+    def reset(self) -> None:
+        """Reset rolling state at start_monitoring()."""
+        self._last_report_time = 0.0
+        self._last_reported_count = 0
+
+    def maybe_report(self) -> None:
+        """Send a batch if at least one new result exists and the interval elapsed."""
+        with self._lock:
+            current_count = len(self._results)
+
+        if current_count == self._last_reported_count:
+            return
+
+        now = time.time()
+        if now - self._last_report_time >= self._report_interval:
+            self.batch_report()
+            self._last_report_time = now
+            self._last_reported_count = current_count
+
+    def batch_report(self) -> None:
+        """Send all accumulated results to backend in one request."""
+        with self._lock:
+            results = list(self._results.values())
+
+        if not results:
+            return
+
+        updates = []
+        for r in results:
+            # Include per-problem reasoning data if judge ran
+            scs: Optional[ScoreComponentsSummary] = None
+            if r.reasoning_score is not None:
+                scs = {
+                    "reasoning_explanation": r.reasoning_explanation,
+                    "reasoning_model": r.reasoning_model,
+                }
+
+            update = ProblemProgressUpdate(
+                problem_id=UUID(r.problem_id),
+                status=r.status,
+                score=r.score,
+                reasoning_score=r.reasoning_score,
+                score_components_summary=scs,
+                inference_failure_count=r.inference_failures
+                if r.inference_total > 0
+                else None,
+                inference_total=r.inference_total if r.inference_total > 0 else None,
+                execution_time=r.execution_time,
+            )
+            updates.append(update)
+
+        try:
+            self._backend_client.report_progress(self._eval_run_id, updates)
+            logging.info(
+                f"Batch reported {len(updates)}/{self._total_problems} problems"
+            )
+        except (BackendError, requests.RequestException) as e:
+            logging.warning(f"Batch report failed ({len(updates)} problems): {e}")

--- a/subnet/validator/progress_reporter.py
+++ b/subnet/validator/progress_reporter.py
@@ -1,58 +1,48 @@
-"""File watcher for scoring problems and reporting progress to Backend.
+"""Validator-side orchestrator for sandbox progress reporting.
 
-Architecture:
-  - Main loop reads output file and dispatches scoring to a thread pool
-  - Each worker runs the full per-problem pipeline: outcome + reasoning judge
-  - _results dict is the sole source of truth for problem state
-  - Loop exits when all problems are confirmed or hard timeout expires
-  - Aggregate score is computed on-demand from _results
+Owns the shared results dict + lock and the monitor thread; delegates
+each concern to a focused component:
+
+  EnvelopeDispatcher  — read sandbox output, dispatch to scoring
+  ScoringPool         — per-problem scoring on a thread pool
+  ReasoningJudge      — LLM reasoning-quality judge (called by the pool)
+  ProgressBatcher     — periodic backend progress reports
+
+Loop exits when all problems are confirmed or the hard timeout expires.
+Aggregate score is computed on demand from the shared results dict.
 """
 
 import time
-import traceback
 import threading
-from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict
 from uuid import UUID
 
-from oro_sdk.models import ProblemProgressUpdate, ProblemStatus
+from oro_sdk.models import ProblemStatus
 
 from bittensor.utils.btlogging import logging
 
-from src.agent.problem_scorer import ProblemScorer, clear_product_cache
-from src.agent.sandbox_status import SandboxProblemStatus
-from src.agent.scoring import is_problem_successful, compute_aggregate, reasoning_coefficient
+from src.agent.scoring import compute_aggregate, reasoning_coefficient
 from src.agent.types import (
     AggregateScore,
     ProblemDict,
     ReasoningSummary,
-    ScoreComponentsSummary,
 )
-from subnet.sandbox import attach_title_embeddings
-import requests
 
-from .backend_client import BackendClient, BackendError
-from .output_watcher import ErrorInfo, OutputWatcher
+from .backend_client import BackendClient
+from .envelope_dispatcher import EnvelopeDispatcher
+from .output_watcher import OutputWatcher
+from .progress_batcher import ProgressBatcher
+from .reasoning_judge import ReasoningJudge
+from .scoring_pool import DEFAULT_SCORING_WORKERS, ScoringPool
 from .types import EnvelopeMeta, ProblemResult
 
 
-# Default number of concurrent scoring workers
-DEFAULT_SCORING_WORKERS = 4
-
-# Report to backend at most every N seconds
-REPORT_INTERVAL_SECONDS = 10.0
-
-
 class ProgressReporter:
-    """Monitors sandbox output, scores problems, and reports to Backend.
+    """Monitors sandbox output, scores problems, and reports to Backend."""
 
-    Architecture:
-    - Main loop tails output file and dispatches lines to a thread pool
-    - Each worker scores one problem end-to-end (outcome + reasoning judge)
-    - Batch reports consolidated every REPORT_INTERVAL_SECONDS
-    - Exit when confirmed == total_problems or timeout expires
-    """
+    # How long to wait with no new output before giving up (seconds)
+    IDLE_TIMEOUT = 120.0
 
     def __init__(
         self,
@@ -74,37 +64,15 @@ class ProgressReporter:
         self.workspace_dir = workspace_dir
         self.poll_interval = poll_interval
         self.scoring_timeout = scoring_timeout
-        self._chutes_access_token = chutes_access_token
-        self._inference_provider = inference_provider or "chutes"
 
         self._stop_event = threading.Event()
         self._hard_deadline: Optional[float] = None
         self._thread: Optional[threading.Thread] = None
-        self._watcher = OutputWatcher(output_file)
         self._lock = threading.Lock()
 
         # Single source of truth for all problem results
         self._results: Dict[str, ProblemResult] = {}
         self._total_problems = len(problems)
-        self._scorers: Dict[str, Any] = {}
-
-        self._envelope_meta: Dict[str, EnvelopeMeta] = {}
-
-        # Circuit breaker for reasoning judge — stop after N consecutive
-        # total failures to avoid retry storms on bad tokens/infra issues.
-        self._consecutive_judge_failures = 0
-        self._judge_circuit_open = False
-
-        # Batch reporting state
-        self._last_report_time = 0.0
-        self._last_reported_count = 0
-
-        # Thread pool for concurrent scoring
-        self._scoring_executor = ThreadPoolExecutor(
-            max_workers=max_scoring_workers,
-            thread_name_prefix="scorer",
-        )
-        self._scoring_futures: Dict[str, Future] = {}
 
         # Build problem_id -> problem lookup
         self._id_to_problem: Dict[str, ProblemDict] = {}
@@ -113,59 +81,49 @@ class ProgressReporter:
             if problem_id:
                 self._id_to_problem[problem_id] = problem
 
-        self._initialize_scorers()
+        # Shared between dispatcher (writer) and scoring pool (reader); the
+        # reporter itself never reads it after wire-up.
+        envelope_meta: Dict[str, EnvelopeMeta] = {}
 
-    def _initialize_scorers(self) -> None:
-        """Initialize per-category ProblemScorers from problem metadata."""
-        try:
-            clear_product_cache()
-
-            category_rewards: Dict[str, Dict] = {}
-            category_vouchers: Dict[str, Dict] = {}
-
-            for problem in self.problems:
-                query = problem.get("query")
-                reward = problem.get("reward")
-                category = problem.get("category", "product").lower()
-
-                if category not in ("product", "shop", "voucher"):
-                    category = "product"
-
-                if query and reward:
-                    attach_title_embeddings(reward, problem.get("reward_title_embeddings"))
-                    category_rewards.setdefault(category, {})[query] = reward
-
-                if category == "voucher":
-                    voucher = problem.get("voucher")
-                    if query and voucher:
-                        category_vouchers.setdefault(category, {})[query] = voucher
-
-            for category, rewards in category_rewards.items():
-                vouchers = category_vouchers.get(category, {})
-                self._scorers[category] = ProblemScorer(
-                    task=category, rewards=rewards, vouchers=vouchers
-                )
-                logging.info(
-                    f"Created ProblemScorer for '{category}' with {len(rewards)} problems"
-                )
-
-            logging.info(
-                f"Initialized {len(self._scorers)} scorers: {list(self._scorers.keys())}"
-            )
-
-        except (ImportError, OSError, ValueError, TypeError, KeyError) as e:
-            logging.error(f"Failed to initialize ProblemScorers: {e}")
-            self._scorers = {}
+        self._watcher = OutputWatcher(output_file)
+        self._reasoning_judge = ReasoningJudge(
+            chutes_access_token=chutes_access_token,
+            inference_provider=inference_provider or "chutes",
+            backend_base_url=backend_client.base_url,
+        )
+        self._scoring_pool = ScoringPool(
+            problems=problems,
+            results=self._results,
+            envelope_meta=envelope_meta,
+            id_to_problem=self._id_to_problem,
+            lock=self._lock,
+            reasoning_judge=self._reasoning_judge,
+            max_workers=max_scoring_workers,
+        )
+        self._envelope_dispatcher = EnvelopeDispatcher(
+            watcher=self._watcher,
+            results=self._results,
+            envelope_meta=envelope_meta,
+            id_to_problem=self._id_to_problem,
+            lock=self._lock,
+            scoring_pool=self._scoring_pool,
+        )
+        self._batcher = ProgressBatcher(
+            backend_client=backend_client,
+            eval_run_id=eval_run_id,
+            total_problems=self._total_problems,
+            results=self._results,
+            lock=self._lock,
+        )
 
     def start_monitoring(self) -> None:
         """Start the background monitoring loop."""
         self._stop_event.clear()
         self._hard_deadline = None
         self._watcher.reset()
-        self._results = {}
-        self._last_reported_count = 0
-        self._last_report_time = 0.0
-        self._scoring_futures = {}
+        self._results.clear()
+        self._batcher.reset()
+        self._scoring_pool.futures.clear()
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
 
@@ -186,7 +144,7 @@ class ProgressReporter:
                 logging.warning(
                     f"Monitoring thread did not finish within {join_timeout}s"
                 )
-        self._scoring_executor.shutdown(wait=False)
+        self._scoring_pool.shutdown()
 
     def get_aggregate_score(self) -> Optional[AggregateScore]:
         """Compute aggregate score on demand from _results."""
@@ -257,9 +215,6 @@ class ProgressReporter:
             return result.status
         return ProblemStatus.FAILED
 
-    # How long to wait with no new output before giving up (seconds)
-    IDLE_TIMEOUT = 120.0
-
     def _run(self) -> None:
         """Main monitoring loop.
 
@@ -273,23 +228,21 @@ class ProgressReporter:
         last_activity_at: Optional[float] = None
 
         while True:
-            # Read new lines and dispatch to thread pool
-            newly_dispatched = self._read_and_dispatch()
-
-            # Collect completed futures
-            self._collect_completed_futures()
+            newly_dispatched = self._envelope_dispatcher.read_and_dispatch(
+                hard_deadline=self._hard_deadline
+            )
+            self._scoring_pool.collect_completed()
 
             if newly_dispatched > 0:
                 last_activity_at = time.time()
 
-            # Periodic batch report
-            self._maybe_report()
+            self._batcher.maybe_report()
 
             # Check exit: all problems have results
             with self._lock:
                 result_count = len(self._results)
             if result_count >= self._total_problems:
-                self._batch_report()
+                self._batcher.batch_report()
                 logging.info(f"All {self._total_problems} problems completed")
                 break
 
@@ -303,7 +256,7 @@ class ProgressReporter:
                 )
 
             # Check idle timeout: no new output and no in-flight scoring
-            pending_futures = sum(1 for f in self._scoring_futures.values() if not f.done())
+            pending_futures = self._scoring_pool.pending_count()
             if (
                 self._hard_deadline is not None
                 and last_activity_at is not None
@@ -312,8 +265,8 @@ class ProgressReporter:
             ):
                 idle_secs = int(time.time() - last_activity_at)
                 unscored = self._total_problems - result_count
-                self._mark_remaining_timed_out()
-                self._batch_report()
+                self._envelope_dispatcher.mark_remaining_timed_out()
+                self._batcher.batch_report()
                 logging.warning(
                     f"No new output for {idle_secs}s, marked "
                     f"{unscored} remaining as TIMED_OUT "
@@ -323,8 +276,8 @@ class ProgressReporter:
 
             # Check hard timeout
             if self._hard_deadline is not None and time.time() >= self._hard_deadline:
-                self._mark_remaining_timed_out()
-                self._batch_report()
+                self._envelope_dispatcher.mark_remaining_timed_out()
+                self._batcher.batch_report()
                 with self._lock:
                     result_count = len(self._results)
                 logging.warning(
@@ -339,14 +292,16 @@ class ProgressReporter:
                 and result_count == 0
                 and not self.output_file.exists()
             ):
-                self._mark_remaining_timed_out()
-                self._batch_report()
+                self._envelope_dispatcher.mark_remaining_timed_out()
+                self._batcher.batch_report()
                 logging.warning("No output file found after sandbox exit")
                 break
 
             # Log progress periodically after sandbox exits
             if self._hard_deadline is not None and newly_dispatched == 0:
-                elapsed = int(time.time() - (self._hard_deadline - self.scoring_timeout))
+                elapsed = int(
+                    time.time() - (self._hard_deadline - self.scoring_timeout)
+                )
                 logging.info(
                     f"Scored {result_count}/{self._total_problems} problems "
                     f"({pending_futures} in-flight), "
@@ -354,299 +309,3 @@ class ProgressReporter:
                 )
 
             time.sleep(self.poll_interval)
-
-    def _read_and_dispatch(self) -> int:
-        """Read new records from the OutputWatcher and act on each.
-
-        SUCCESS records are dispatched to the scoring pool; FAILED and
-        TIMED_OUT records are stored directly without scoring.
-
-        Returns the number of newly dispatched (SUCCESS) problems.
-        """
-        newly_dispatched = 0
-        for record in self._watcher.read_new():
-            with self._lock:
-                if (
-                    record.problem_id in self._results
-                    or record.problem_id in self._scoring_futures
-                ):
-                    continue
-                self._envelope_meta[record.problem_id] = EnvelopeMeta(
-                    inference_failure_count=record.inference_failure_count,
-                    inference_total=record.inference_total,
-                    execution_time=record.execution_time,
-                )
-
-            if record.status is SandboxProblemStatus.SUCCESS:
-                future = self._scoring_executor.submit(
-                    self._score_problem,
-                    record.dialogue or [],
-                    record.problem_id,
-                )
-                self._scoring_futures[record.problem_id] = future
-                newly_dispatched += 1
-            else:
-                # FAILED / TIMED_OUT — record directly, no scoring dispatch.
-                terminal = self._build_terminal_result(
-                    problem_id=record.problem_id,
-                    status=record.status,
-                    error=record.error,
-                )
-                if terminal is not None:
-                    with self._lock:
-                        self._results[record.problem_id] = terminal
-
-            if self._hard_deadline is not None and time.time() >= self._hard_deadline:
-                break
-
-        return newly_dispatched
-
-    def _build_terminal_result(
-        self,
-        *,
-        problem_id: str,
-        status: SandboxProblemStatus,
-        error: Optional[ErrorInfo],
-    ) -> Optional["ProblemResult"]:
-        """Build a non-success ProblemResult from envelope-only data."""
-        problem = self._id_to_problem.get(problem_id)
-        if not problem:
-            logging.warning(f"Unknown problem_id in terminal envelope: {problem_id}")
-            return None
-        category = problem.get("category", "product").lower()
-        problem_status = ProblemStatus(status.value)
-        with self._lock:
-            meta = self._envelope_meta.get(problem_id)
-        inf_fail = meta.inference_failure_count if meta else 0
-        inf_total = meta.inference_total if meta else 0
-        exec_time = meta.execution_time if meta else 0.0
-        if error and error.message:
-            logging.info(
-                f"Recording terminal {status} for {problem_id}: {error.message[:80]}"
-            )
-        return ProblemResult(
-            problem_id=problem_id,
-            category=category,
-            status=problem_status,
-            score=0.0,
-            inference_failures=inf_fail,
-            inference_total=inf_total,
-            execution_time=exec_time,
-        )
-
-    def _collect_completed_futures(self) -> None:
-        """Check for completed scoring futures and update last_activity_at."""
-        completed = [pid for pid, f in self._scoring_futures.items() if f.done()]
-        for pid in completed:
-            future = self._scoring_futures.pop(pid)
-            exc = future.exception()
-            if exc:
-                logging.error(f"Scoring worker failed for {pid}: {exc}")
-
-    def _score_problem(self, dialogue: list, problem_id: str) -> None:
-        """Score a single problem end-to-end. Runs in a worker thread."""
-        if not self._scorers:
-            return
-
-        if not isinstance(dialogue, list) or not dialogue:
-            return
-
-        try:
-            problem = self._id_to_problem.get(str(problem_id))
-            if not problem:
-                logging.warning(f"Unknown problem_id: {problem_id}")
-                return
-
-            extra_info = (dialogue[0].get("extra_info") or {}) if dialogue else {}
-            with self._lock:
-                meta = self._envelope_meta.get(str(problem_id))
-            execution_time = (
-                meta.execution_time if meta is not None else extra_info.get("execution_time")
-            )
-            query = problem.get("query") or extra_info.get("query")
-            category = problem.get("category", "product").lower()
-
-            scorer = self._scorers.get(category)
-            if not scorer:
-                logging.warning(f"No scorer for category '{category}'")
-                return
-
-            with self._lock:
-                scored_count = len(self._results) + 1
-            logging.info(
-                f"Scoring problem {scored_count}/{self._total_problems}: "
-                f"{query[:50]}..."
-            )
-
-            score_dict = scorer.score_problem(query=query, output=dialogue)
-            is_successful = is_problem_successful(score_dict, category)
-            score = 1.0 if is_successful else 0.0
-            status = ProblemStatus.SUCCESS if is_successful else ProblemStatus.FAILED
-            inf_failures = meta.inference_failure_count if meta else 0
-            inf_total = meta.inference_total if meta else 0
-
-            reasoning = self._run_reasoning_judge(dialogue, problem_id)
-
-            result = ProblemResult(
-                problem_id=str(problem_id),
-                category=category,
-                status=status,
-                score=score,
-                score_dict=score_dict if isinstance(score_dict, dict) else {},
-                inference_failures=inf_failures,
-                inference_total=inf_total,
-                execution_time=execution_time,
-                **reasoning,
-            )
-            with self._lock:
-                self._results[str(problem_id)] = result
-                completed = len(self._results)
-
-            logging.info(
-                f"Problem {completed}/{self._total_problems} scored: "
-                f"{score:.4f} (query: {query[:50]}...)"
-            )
-
-        except Exception as e:
-            logging.error(f"Error scoring problem {problem_id}: {e}")
-            traceback.print_exc()
-
-    def _run_reasoning_judge(self, dialogue: list, problem_id: str) -> dict:
-        """Run the LLM reasoning judge with circuit breaker protection.
-
-        Returns a dict of reasoning fields to unpack into ProblemResult.
-        """
-        empty = {
-            "reasoning_score": None,
-            "reasoning_explanation": "",
-            "reasoning_model": "",
-            "reasoning_inf_failed": 0,
-            "reasoning_inf_total": 0,
-        }
-
-        with self._lock:
-            should_judge = bool(self._chutes_access_token and not self._judge_circuit_open)
-
-        if not should_judge:
-            return empty
-
-        try:
-            from src.agent.reasoning_scorer import score_reasoning_quality
-
-            judge_result = score_reasoning_quality(
-                dialogue,
-                api_key=self._chutes_access_token,
-                provider=self._inference_provider,
-                backend_url=self.backend_client.base_url,
-            )
-
-            with self._lock:
-                if judge_result["inference_total"] > 0 and judge_result["inference_failed"] == judge_result["inference_total"]:
-                    self._consecutive_judge_failures += 1
-                    if self._consecutive_judge_failures >= 3:
-                        self._judge_circuit_open = True
-                        logging.error(
-                            "Reasoning judge circuit breaker tripped: "
-                            "3 consecutive problems with 100% judge failure."
-                        )
-                else:
-                    self._consecutive_judge_failures = 0
-
-            logging.info(
-                f"Reasoning score: {judge_result['score']:.2f} "
-                f"(problem={problem_id}, model={judge_result['model']})"
-            )
-
-            return {
-                "reasoning_score": judge_result["score"],
-                "reasoning_explanation": judge_result["explanation"],
-                "reasoning_model": judge_result["model"],
-                "reasoning_inf_failed": judge_result["inference_failed"],
-                "reasoning_inf_total": judge_result["inference_total"],
-            }
-
-        except Exception as e:
-            logging.warning(f"Reasoning judge failed for {problem_id}: {e}")
-            with self._lock:
-                self._consecutive_judge_failures += 1
-                if self._consecutive_judge_failures >= 3:
-                    self._judge_circuit_open = True
-                    logging.error(
-                        "Reasoning judge circuit breaker tripped after exceptions."
-                    )
-            return empty
-
-    def _maybe_report(self) -> None:
-        """Report to backend if enough time has passed or new results are available."""
-        with self._lock:
-            current_count = len(self._results)
-
-        if current_count == self._last_reported_count:
-            return
-
-        now = time.time()
-        if now - self._last_report_time >= REPORT_INTERVAL_SECONDS:
-            self._batch_report()
-            self._last_report_time = now
-            self._last_reported_count = current_count
-
-    def _batch_report(self) -> None:
-        """Send all accumulated results to backend in one request."""
-        with self._lock:
-            results = list(self._results.values())
-
-        if not results:
-            return
-
-        updates = []
-        for r in results:
-            # Include per-problem reasoning data if judge ran
-            scs: Optional[ScoreComponentsSummary] = None
-            if r.reasoning_score is not None:
-                scs = {
-                    "reasoning_explanation": r.reasoning_explanation,
-                    "reasoning_model": r.reasoning_model,
-                }
-
-            update = ProblemProgressUpdate(
-                problem_id=UUID(r.problem_id),
-                status=r.status,
-                score=r.score,
-                reasoning_score=r.reasoning_score,
-                score_components_summary=scs,
-                inference_failure_count=r.inference_failures if r.inference_total > 0 else None,
-                inference_total=r.inference_total if r.inference_total > 0 else None,
-                execution_time=r.execution_time,
-            )
-            updates.append(update)
-
-        try:
-            self.backend_client.report_progress(self.eval_run_id, updates)
-            logging.info(
-                f"Batch reported {len(updates)}/{self._total_problems} problems"
-            )
-        except (BackendError, requests.RequestException) as e:
-            logging.warning(f"Batch report failed ({len(updates)} problems): {e}")
-
-    def _mark_remaining_timed_out(self) -> None:
-        """Mark all unscored problems as TIMED_OUT in local results.
-
-        Only reaches problems that never produced an envelope (sandbox death
-        before write, never-started, or partial run cut off by hard deadline).
-        """
-        with self._lock:
-            scored_ids = set(self._results.keys())
-
-        unscored = set(self._id_to_problem.keys()) - scored_ids
-        if not unscored:
-            return
-
-        logging.info(f"Marking {len(unscored)} unscored problems as TIMED_OUT")
-        with self._lock:
-            for pid in unscored:
-                self._results[pid] = ProblemResult(
-                    problem_id=pid,
-                    category=self._id_to_problem[pid].get("category", "product").lower(),
-                    status=ProblemStatus.TIMED_OUT,
-                    score=0.0,
-                )

--- a/subnet/validator/reasoning_judge.py
+++ b/subnet/validator/reasoning_judge.py
@@ -1,0 +1,100 @@
+"""LLM reasoning-quality judge with circuit-breaker protection.
+
+Scores one dialogue per call from a scoring worker thread. A bad token or a
+flapping inference provider can otherwise turn into a per-problem retry
+storm, so consecutive total-failure outcomes (or exceptions) trip a circuit
+breaker that suppresses further calls for the rest of the run.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Dict, Optional
+
+from bittensor.utils.btlogging import logging
+
+
+# Trip after this many consecutive total-failure / exception outcomes.
+# Low by design — a bad token usually fails on the first call.
+CIRCUIT_BREAKER_THRESHOLD = 3
+
+# Returned when the judge is disabled, tripped, or errored. Keys are the
+# reasoning_* fields ProblemResult accepts as **kwargs.
+_EMPTY_RESULT: Dict[str, Any] = {
+    "reasoning_score": None,
+    "reasoning_explanation": "",
+    "reasoning_model": "",
+    "reasoning_inf_failed": 0,
+    "reasoning_inf_total": 0,
+}
+
+
+class ReasoningJudge:
+    """Score reasoning quality for a single problem."""
+
+    def __init__(
+        self,
+        chutes_access_token: Optional[str],
+        inference_provider: str,
+        backend_base_url: str,
+    ):
+        self._token = chutes_access_token
+        self._provider = inference_provider
+        self._backend_base_url = backend_base_url
+        self._lock = threading.Lock()
+        self._consecutive_failures = 0
+        self._circuit_open = False
+
+    def score(self, dialogue: list, problem_id: str) -> Dict[str, Any]:
+        """Return reasoning-fields dict to unpack into ProblemResult."""
+        with self._lock:
+            should_judge = bool(self._token and not self._circuit_open)
+        if not should_judge:
+            return dict(_EMPTY_RESULT)
+
+        try:
+            from src.agent.reasoning_scorer import score_reasoning_quality
+
+            judge_result = score_reasoning_quality(
+                dialogue,
+                api_key=self._token,
+                provider=self._provider,
+                backend_url=self._backend_base_url,
+            )
+
+            inf_failed = judge_result["inference_failed"]
+            inf_total = judge_result["inference_total"]
+            with self._lock:
+                if inf_total > 0 and inf_failed == inf_total:
+                    self._consecutive_failures += 1
+                    if self._consecutive_failures >= CIRCUIT_BREAKER_THRESHOLD:
+                        self._circuit_open = True
+                        logging.error(
+                            "Reasoning judge circuit breaker tripped: "
+                            f"{CIRCUIT_BREAKER_THRESHOLD} consecutive problems "
+                            "with 100% judge failure."
+                        )
+                else:
+                    self._consecutive_failures = 0
+
+            logging.info(
+                f"Reasoning score: {judge_result['score']:.2f} "
+                f"(problem={problem_id}, model={judge_result['model']})"
+            )
+            return {
+                "reasoning_score": judge_result["score"],
+                "reasoning_explanation": judge_result["explanation"],
+                "reasoning_model": judge_result["model"],
+                "reasoning_inf_failed": inf_failed,
+                "reasoning_inf_total": inf_total,
+            }
+        except Exception as e:
+            logging.warning(f"Reasoning judge failed for {problem_id}: {e}")
+            with self._lock:
+                self._consecutive_failures += 1
+                if self._consecutive_failures >= CIRCUIT_BREAKER_THRESHOLD:
+                    self._circuit_open = True
+                    logging.error(
+                        "Reasoning judge circuit breaker tripped after exceptions."
+                    )
+            return dict(_EMPTY_RESULT)

--- a/subnet/validator/scoring_pool.py
+++ b/subnet/validator/scoring_pool.py
@@ -1,0 +1,182 @@
+"""Thread-pool-backed per-problem scoring.
+
+Owns the executor, the per-category ProblemScorers, and the in-flight
+futures table. Workers read from the shared envelope-meta and
+id-to-problem maps, then publish ProblemResults back into the shared
+results dict — all under a single lock owned by ProgressReporter.
+"""
+
+from __future__ import annotations
+
+import threading
+import traceback
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Any, Dict, List
+
+from bittensor.utils.btlogging import logging
+
+from oro_sdk.models import ProblemStatus
+
+from src.agent.problem_scorer import ProblemScorer, clear_product_cache
+from src.agent.scoring import is_problem_successful
+from src.agent.types import ProblemDict
+from subnet.sandbox import attach_title_embeddings
+
+from .reasoning_judge import ReasoningJudge
+from .types import EnvelopeMeta, ProblemResult
+
+
+DEFAULT_SCORING_WORKERS = 4
+
+
+class ScoringPool:
+    """Owns the scoring thread pool and the per-category scorers."""
+
+    def __init__(
+        self,
+        problems: List[ProblemDict],
+        results: Dict[str, ProblemResult],
+        envelope_meta: Dict[str, EnvelopeMeta],
+        id_to_problem: Dict[str, ProblemDict],
+        lock: threading.Lock,
+        reasoning_judge: ReasoningJudge,
+        max_workers: int = DEFAULT_SCORING_WORKERS,
+    ):
+        self._results = results
+        self._envelope_meta = envelope_meta
+        self._id_to_problem = id_to_problem
+        self._lock = lock
+        self._total_problems = len(problems)
+        self._reasoning_judge = reasoning_judge
+        self._executor = ThreadPoolExecutor(
+            max_workers=max_workers, thread_name_prefix="scorer"
+        )
+        self.futures: Dict[str, Future] = {}
+        self.scorers: Dict[str, Any] = {}
+        self._initialize_scorers(problems)
+
+    def has_future(self, problem_id: str) -> bool:
+        return problem_id in self.futures
+
+    def pending_count(self) -> int:
+        return sum(1 for f in self.futures.values() if not f.done())
+
+    def submit(self, problem_id: str, dialogue: list) -> None:
+        future = self._executor.submit(self._score_problem, dialogue, problem_id)
+        self.futures[problem_id] = future
+
+    def collect_completed(self) -> None:
+        """Reap completed futures and log any worker exceptions."""
+        completed = [pid for pid, f in self.futures.items() if f.done()]
+        for pid in completed:
+            future = self.futures.pop(pid)
+            exc = future.exception()
+            if exc:
+                logging.error(f"Scoring worker failed for {pid}: {exc}")
+
+    def shutdown(self) -> None:
+        self._executor.shutdown(wait=False)
+
+    def _initialize_scorers(self, problems: List[ProblemDict]) -> None:
+        """Build per-category ProblemScorers from problem metadata."""
+        try:
+            clear_product_cache()
+            category_rewards: Dict[str, Dict] = {}
+            category_vouchers: Dict[str, Dict] = {}
+            for problem in problems:
+                query = problem.get("query")
+                reward = problem.get("reward")
+                category = problem.get("category", "product").lower()
+                if category not in ("product", "shop", "voucher"):
+                    category = "product"
+                if query and reward:
+                    attach_title_embeddings(
+                        reward, problem.get("reward_title_embeddings")
+                    )
+                    category_rewards.setdefault(category, {})[query] = reward
+                if category == "voucher":
+                    voucher = problem.get("voucher")
+                    if query and voucher:
+                        category_vouchers.setdefault(category, {})[query] = voucher
+            for category, rewards in category_rewards.items():
+                vouchers = category_vouchers.get(category, {})
+                self.scorers[category] = ProblemScorer(
+                    task=category, rewards=rewards, vouchers=vouchers
+                )
+                logging.info(
+                    f"Created ProblemScorer for '{category}' with {len(rewards)} problems"
+                )
+            logging.info(
+                f"Initialized {len(self.scorers)} scorers: {list(self.scorers.keys())}"
+            )
+        except (ImportError, OSError, ValueError, TypeError, KeyError) as e:
+            logging.error(f"Failed to initialize ProblemScorers: {e}")
+            self.scorers = {}
+
+    def _score_problem(self, dialogue: list, problem_id: str) -> None:
+        """Score a single problem end-to-end. Runs in a worker thread."""
+        if not self.scorers:
+            return
+        if not isinstance(dialogue, list) or not dialogue:
+            return
+
+        try:
+            problem = self._id_to_problem.get(str(problem_id))
+            if not problem:
+                logging.warning(f"Unknown problem_id: {problem_id}")
+                return
+
+            extra_info = (dialogue[0].get("extra_info") or {}) if dialogue else {}
+            with self._lock:
+                meta = self._envelope_meta.get(str(problem_id))
+            execution_time = (
+                meta.execution_time
+                if meta is not None
+                else extra_info.get("execution_time")
+            )
+            query = problem.get("query") or extra_info.get("query")
+            category = problem.get("category", "product").lower()
+
+            scorer = self.scorers.get(category)
+            if not scorer:
+                logging.warning(f"No scorer for category '{category}'")
+                return
+
+            with self._lock:
+                scored_count = len(self._results) + 1
+            logging.info(
+                f"Scoring problem {scored_count}/{self._total_problems}: "
+                f"{query[:50]}..."
+            )
+
+            score_dict = scorer.score_problem(query=query, output=dialogue)
+            is_successful = is_problem_successful(score_dict, category)
+            score = 1.0 if is_successful else 0.0
+            status = ProblemStatus.SUCCESS if is_successful else ProblemStatus.FAILED
+            inf_failures = meta.inference_failure_count if meta else 0
+            inf_total = meta.inference_total if meta else 0
+
+            reasoning = self._reasoning_judge.score(dialogue, problem_id)
+
+            result = ProblemResult(
+                problem_id=str(problem_id),
+                category=category,
+                status=status,
+                score=score,
+                score_dict=score_dict if isinstance(score_dict, dict) else {},
+                inference_failures=inf_failures,
+                inference_total=inf_total,
+                execution_time=execution_time,
+                **reasoning,
+            )
+            with self._lock:
+                self._results[str(problem_id)] = result
+                completed = len(self._results)
+
+            logging.info(
+                f"Problem {completed}/{self._total_problems} scored: "
+                f"{score:.4f} (query: {query[:50]}...)"
+            )
+        except Exception as e:
+            logging.error(f"Error scoring problem {problem_id}: {e}")
+            traceback.print_exc()


### PR DESCRIPTION
## Description

`subnet/validator/progress_reporter.py` was a ~650-line class owning four distinct responsibilities (envelope parsing, scoring orchestration, the LLM reasoning judge, and backend progress batching). This PR splits each concern into its own module so they can evolve independently and be tested in isolation.

**Components introduced:**

- **`scoring_pool.py`** (`ScoringPool`) — thread pool, per-category `ProblemScorer`s, futures table, per-problem scoring worker.
- **`reasoning_judge.py`** (`ReasoningJudge`) — LLM judge token, inference provider, circuit-breaker state.
- **`envelope_dispatcher.py`** (`EnvelopeDispatcher`) — `OutputWatcher` ownership and the three methods that translate raw sandbox envelopes into actions: `read_and_dispatch` (success → scoring pool, failed/timed-out → terminal write), `build_terminal_result`, and the end-of-run `mark_remaining_timed_out` sweep.
- **`progress_batcher.py`** (`ProgressBatcher`) — report-cadence state and `ProblemProgressUpdate` payload assembly.

After the split, `ProgressReporter` shrinks from ~650 lines to ~265 lines of pure wiring: it constructs the four components in `__init__`, holds the shared `_results` dict + lock, and `_run` reads as plain orchestration.

## Changes Made

- New `subnet/validator/scoring_pool.py` — `ScoringPool` class
- New `subnet/validator/reasoning_judge.py` — `ReasoningJudge` class with circuit-breaker
- New `subnet/validator/envelope_dispatcher.py` — `EnvelopeDispatcher` class
- New `subnet/validator/progress_batcher.py` — `ProgressBatcher` class
- `subnet/validator/progress_reporter.py` — orchestrator only; ~390 lines removed, ~50 added (net ~-340)
- `subnet/tests/validator/test_progress_reporter_envelope.py` — switched to calling component methods directly (`reporter._envelope_dispatcher.read_and_dispatch()` etc.) since the corresponding wrappers are no longer on the reporter

## Issue Link

- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing

Pure mechanical refactor — no behavioral change. Verified by running the validator test suite locally; all envelope-parsing and integration tests pass unchanged.

**Test Results:**

```
subnet/tests/validator/test_progress_reporter_envelope.py — 10 passed
subnet/tests/validator/test_validator_integration.py     —  8 passed
tests/ + subnet/tests/ (minus pre-existing failures)     — 349 passed
```

One unrelated pre-existing failure in `test_backend_client.py::test_claim_work_with_resource_metrics` (SDK signature mismatch on `cpu_pct`) reproduces on `origin/main` — unchanged by this PR.

### Automated Testing

**Test Command(s):**
```bash
.venv/bin/pytest tests/ subnet/tests/ -q \
  --ignore=subnet/tests/validator/test_auto_update.py \
  --ignore=subnet/tests/validator/test_weight_setter.py \
  --ignore=tests/integration/test_sandbox_isolation.py
```

`ruff check` and `ruff format --check` both clean on all five touched/new validator modules.

## Documentation

- [ ] README updated — N/A
- [x] Code comments added/updated — each new module carries a module-level docstring describing its role and threading model; `progress_reporter.py`'s top docstring enumerates the four components
- [ ] API documentation updated — N/A
- [ ] Configuration documentation updated — N/A
- [ ] Other documentation updated — N/A

**Documentation Changes:** Module docstrings on the four new files describe each component's responsibility. `progress_reporter.py` top docstring rewritten to reflect the orchestrator role.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works — N/A; refactor preserves existing test coverage (one test updated to reach through the dispatcher)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

This PR replaces the earlier stacked pair (#153 + #154), which were collapsed into a single change after the split made the back-compat shims used in PR 1 unnecessary. Net diff is the same; review surface is one PR instead of two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)