### PR TITLE
ci: fix Integration Tests workflow after build_index.sh removal (ORO-1126)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,104 +3,41 @@ name: Integration Tests
 on:
   push:
     branches: [ main ]
+  pull_request:
+    paths:
+      - 'docker/search-server/**'
+      - 'docker/proxy/**'
+      - 'docker/sandbox/**'
+      - 'src/search_engine/**'
+      - 'src/sandbox/**'
+      - 'tests/integration/**'
+      - 'docker-compose.yml'
+      - '.github/workflows/integration-tests.yml'
 
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          lfs: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
-      - name: Check if indexes exist locally
-        id: check-indexes
-        run: |
-          if [ -d "indexes" ] && [ -n "$(ls -A indexes 2>/dev/null)" ]; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Local indexes directory found"
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-            echo "No local indexes found, will try cache or build"
-          fi
-      
-      - name: Get documents.jsonl hash for cache key
-        if: steps.check-indexes.outputs.exists != 'true'
-        id: cache-key
-        run: |
-          if [ -f "resources/documents.jsonl.gz" ]; then
-            HASH=$(sha256sum resources/documents.jsonl.gz | cut -d' ' -f1)
-            echo "hash=$HASH" >> $GITHUB_OUTPUT
-          else
-            echo "hash=no-documents" >> $GITHUB_OUTPUT
-          fi
-      
-      - name: Restore indexes from cache
-        if: steps.check-indexes.outputs.exists != 'true'
-        id: cache-indexes
-        uses: actions/cache@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          path: indexes
-          key: search-indexes-${{ steps.cache-key.outputs.hash }}
-          restore-keys: |
-            search-indexes-
-      
-      - name: Check if build is needed
-        id: need-build
-        run: |
-          if [ "${{ steps.check-indexes.outputs.exists }}" = "true" ]; then
-            echo "needed=false" >> $GITHUB_OUTPUT
-          elif [ "${{ steps.cache-indexes.outputs.cache-hit }}" = "true" ]; then
-            echo "needed=false" >> $GITHUB_OUTPUT
-          else
-            echo "needed=true" >> $GITHUB_OUTPUT
-          fi
-      
-      - name: Install and configure Java 21
-        if: steps.need-build.outputs.needed == 'true'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends openjdk-21-jdk-headless
-          sudo update-alternatives --set java /usr/lib/jvm/java-21-openjdk-amd64/bin/java
-          echo "JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64" >> $GITHUB_ENV
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
-        if: steps.need-build.outputs.needed == 'true'
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-      
-      - name: Build search indexes
-        if: steps.need-build.outputs.needed == 'true'
-        run: |
-          pip install -r requirements.txt
-          ./build_index.sh
-      
-      - name: Save indexes to cache
-        if: steps.need-build.outputs.needed == 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: indexes
-          key: search-indexes-${{ steps.cache-key.outputs.hash }}
-
-      - name: Verify indexes exist
-        run: |
-          if [ ! -d "indexes" ] || [ -z "$(ls -A indexes)" ]; then
-            echo "Error: Indexes directory is empty or does not exist!"
-            exit 1
-          fi
-          echo "Indexes verified"
-      
-      - name: Set up Python (for tests)
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
-      - name: Build all services
+      - name: Build services
         run: |
           docker compose build search-server proxy sandbox
 
@@ -108,30 +45,30 @@ jobs:
         run: |
           docker compose up -d search-server
           timeout 120 bash -c 'until docker compose ps search-server | grep -q "healthy"; do sleep 2; done' || true
-      
+
       - name: Start proxy
         run: |
           docker compose up -d proxy
           timeout 60 bash -c 'until docker compose ps proxy | grep -q "healthy"; do sleep 2; done' || true
-      
+
       - name: Start sandbox
         run: |
           docker compose up -d sandbox
-      
+
       - name: Install test dependencies
         run: |
-          pip install requests
-      
+          pip install requests pytest
+
       - name: Run sandbox isolation tests
         run: |
           pytest tests/integration/test_sandbox_isolation.py -v --tb=short
-      
+
       - name: Show service logs on failure
         if: failure()
         run: |
           docker compose logs --tail 50 search-server
           docker compose logs --tail 50 proxy
-      
+
       - name: Cleanup
         if: always()
         run: |


### PR DESCRIPTION
## Description

\`Integration Tests\` has been red on every push to \`main\` since 2026-03-25 (commit \`553d29ec\`, which removed \`build_index.sh\` from the public repo without updating the CI that depended on it). 6 weeks of false-red signal — everyone learned to ignore it, which means real integration regressions also fly under the radar.

Switching to option (B) from the ticket: drop the in-CI index-build path, rely on the pre-built \`ghcr.io/oro-ai/oro/search-server-base:latest\` image (already \`FROM\`'d by \`docker/search-server/Dockerfile\`) which ships indexes baked in.

## Changes Made

- Drop the local index-build path:
  - \`Check if indexes exist locally\` / cache-key hash / cache restore-save
  - \`Install and configure Java 21\` (was only needed for pyserini index build)
  - \`Build search indexes\` (\`./build_index.sh\` — the broken step)
  - \`Verify indexes exist\`
- Add \`Log in to GHCR\` step so \`docker compose build search-server\` can pull the base layer.
- Add \`pull_request\` trigger with a path filter scoped to:
  \`docker/search-server/**\`, \`docker/proxy/**\`, \`docker/sandbox/**\`, \`src/search_engine/**\`, \`src/sandbox/**\`, \`tests/integration/**\`, \`docker-compose.yml\`, and the workflow itself — so PRs touching those areas surface the gate while unrelated PRs aren't paying integration-test time.

## Issue Link

- Closes: ORO-1126

## Testing

### Manual Testing

Verified the YAML parses and the workflow's logical flow is sound:

\`\`\`bash
python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/integration-tests.yml'))\"
\`\`\`

**Test Results:** YAML OK.

True end-to-end validation can only happen by running the workflow itself — which is what this PR will do (the workflow includes itself in the path filter). Watching CI on this PR is the real test.

### Automated Testing

N/A — pure CI workflow change.

**Test Command(s):**
\`\`\`bash
# In CI, this PR triggers Integration Tests via the new path filter
\`\`\`

## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated

**Documentation Changes:** N/A. The third AC item (\"Re-enable / configure required-checks if appropriate so a real failure here blocks merges\") is branch-protection config, not in-repo — flagged as a follow-up.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

Branch-protection follow-up: once this PR runs green and we trust the path filter, the \`Integration Tests\` check can be added to required status checks on \`main\`. Doing that in this PR would risk wedging the merge if something unexpected fails on first run.