### PR TITLE
ci(integration): persistent sandbox container for isolation tests (ORO-1139)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,6 +12,7 @@ on:
       - 'src/sandbox/**'
       - 'tests/integration/**'
       - 'docker-compose.yml'
+      - 'docker-compose.test.yml'
       - '.github/workflows/integration-tests.yml'
 
 jobs:
@@ -51,9 +52,10 @@ jobs:
           docker compose up -d proxy
           timeout 60 bash -c 'until docker compose ps proxy | grep -q "healthy"; do sleep 2; done' || true
 
-      - name: Start sandbox
+      - name: Start sandbox (persistent, test-mode)
         run: |
-          docker compose up -d sandbox
+          docker compose -f docker-compose.yml -f docker-compose.test.yml up -d sandbox
+          docker ps --filter name=shoppingbench-sandbox --format '{{.Names}} {{.Status}}'
 
       - name: Install test dependencies
         run: |

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,12 @@
+# Compose override applied only by the Integration Tests CI workflow.
+#
+# Turns the one-shot sandbox into a persistent container that the
+# sandbox-isolation tests can `docker exec` into. The real sandbox use
+# case (`docker compose --profile tools up`) is unchanged — this file
+# is only loaded when explicitly passed via `-f`.
+services:
+  sandbox:
+    container_name: shoppingbench-sandbox
+    profiles: []
+    command: ["sleep", "infinity"]
+    restart: "no"


### PR DESCRIPTION
## Description

5 of 7 sandbox-isolation tests have been silently skipping in CI because the \`sandbox_container\` fixture (\`tests/integration/conftest.py:136\`) checks for a running container named \`shoppingbench-sandbox\`, which has never existed in any CI or local-test flow. Surfaced by the first green run of the workflow fixed in ORO-1126 / PR #156.

The sandbox service in \`docker-compose.yml\` is:
1. One-shot — \`CMD\` runs a benchmark problem and exits
2. Profile-gated (\`profiles: [tools]\`) — \`docker compose up -d sandbox\` no-ops without \`--profile tools\`
3. Has no \`container_name\` — auto-named \`<project>-sandbox-1\` even if it did start

Three independent reasons the tests' assumed container was never present. The suite was advertising "sandbox isolation coverage" while actually only running 2 pre-flight checks on search-server/proxy.

## Changes Made

- New \`docker-compose.test.yml\` (CI-only override):
  - \`container_name: shoppingbench-sandbox\`
  - \`profiles: []\` — un-gates from \`tools\`
  - \`command: ["sleep", "infinity"]\` — overrides the one-shot \`CMD\`
  - \`restart: "no"\`
- \`integration-tests.yml\` "Start sandbox" step now passes both compose files via \`-f\` so the override applies, plus a \`docker ps\` confirmation line.
- Added \`docker-compose.test.yml\` to the workflow's path filter so future edits to the override trigger CI.

\`curl\` is already in the sandbox image (\`docker/sandbox/Dockerfile:4\`) — no Dockerfile change required.

Local \`docker compose --profile tools up\` flow stays untouched — the override is opt-in (only loaded when \`-f docker-compose.test.yml\` is explicitly passed).

## Issue Link

- Closes: ORO-1139

## Testing

### Manual Testing

YAML parse + compose-merge validation:

\`\`\`bash
python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/integration-tests.yml')); yaml.safe_load(open('docker-compose.yml')); yaml.safe_load(open('docker-compose.test.yml'))\"
docker compose -f docker-compose.yml -f docker-compose.test.yml config sandbox  # confirms merge
\`\`\`

**Test Results:** YAML parses; compose merge produces the expected sandbox service with the override fields.

End-to-end test = the CI run on this PR. Expected: \`7 passed, 0 skipped\` (vs. previous \`2 passed, 5 skipped\`). If any of the 5 newly-running tests fail, those are real surfaces in proxy / sandbox-network behavior that have been silently unverified for 6+ weeks.

### Automated Testing

N/A — CI workflow + compose-override change.

**Test Command(s):**
\`\`\`bash
# In CI:
docker compose -f docker-compose.yml -f docker-compose.test.yml up -d sandbox
pytest tests/integration/test_sandbox_isolation.py -v
\`\`\`

## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [x] Other documentation updated: header comment in \`docker-compose.test.yml\` explains the file's CI-only role.

**Documentation Changes:** Inline comment in \`docker-compose.test.yml\` states it's CI-only and the local-dev flow is unaffected.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

Watch the first run carefully — if the 5 newly-running assertions fail, options are:
1. Fix the underlying proxy / sandbox-network behavior (real bugs)
2. Update the test assertions (if assumptions were wrong about routes / port numbers)
3. Mark specific failing tests as \`xfail\` with a tracking ticket if the surface is brittle

ORO-1126 (PR #156) just merged; this builds on top.