### PR TITLE
chore(proxy): log upstream status on /inference/* for finer-grained alerting

### DIFF
--- a/docker/proxy/nginx.conf.template
+++ b/docker/proxy/nginx.conf.template
@@ -23,6 +23,17 @@ http {
     # Rate limiting zone: 30 requests/second per client IP
     limit_req_zone $binary_remote_addr zone=agent:10m rate=30r/s;
 
+    # Combined access log + upstream metadata. `$upstream_status` is `-` when
+    # the request never reached an upstream (e.g. njs short-circuit via
+    # `r.return(503, ...)`), and the actual upstream HTTP status when a
+    # `proxy_pass` ran. CloudWatch metric filters key off `ups=` to tell apart
+    # "upstream returned 5xx the proxy correctly forwarded" from "proxy itself
+    # could not serve the request". See ORO-1159.
+    log_format inference_combined '$remote_addr - $remote_user [$time_local] '
+                                  '"$request" $status $body_bytes_sent '
+                                  '"$http_referer" "$http_user_agent" '
+                                  'ups=$upstream_status urt=$upstream_response_time';
+
     # Local-only stub_status endpoint for nginx-prometheus-exporter. On a
     # separate listener so it never conflicts with the public proxy paths
     # and can never be reached from the sandbox network.
@@ -40,6 +51,11 @@ http {
 
     server {
         listen 80;
+
+        # Emit the upstream-aware combined format so CloudWatch metric filters
+        # can split inference 503s by source (ORO-1159). /stub_status and
+        # /health below opt out via their own `access_log off`.
+        access_log /dev/stdout inference_combined;
 
         # Default deny — block any path not explicitly handled below
         location / {


### PR DESCRIPTION
## Description

Extend the inference server's nginx access log with `\$upstream_status` and `\$upstream_response_time` so log-based metrics downstream can distinguish upstream-relayed errors from proxy-internal failures.

- `ups=-` means no `proxy_pass` ran (e.g. njs short-circuit, allowlist check returned a status directly).
- `ups=5xx` means an upstream returned 5xx that the proxy correctly forwarded.

No behavior change. Log format only.

## Changes Made
- `docker/proxy/nginx.conf.template`: added `log_format inference_combined` extending the default Combined format with `ups=` and `urt=` keys, and one `access_log /dev/stdout inference_combined` directive on the listen-80 server. `/stub_status` and `/health` keep their existing `access_log off`. Other listeners untouched.

## Issue Link
- Related to: ORO-1159

## Testing

### Manual Testing
Ran `nginx -t` against the envsubst'd template (njs module load stubbed for local nginx, which lacks `ngx_http_js_module`).

**Test Results:** `configuration file ... syntax is ok` / `test is successful`.

### Automated Testing
No unit-test target for nginx config in this repo. Validation is `nginx -t` at build/start time.

## Documentation
- [ ] README updated
- [x] Code comments added/updated — inline comment in `nginx.conf.template` explains the `ups=` / `urt=` keys and why metric consumers care.
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works — config-only change, validated via `nginx -t`.
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged — companion change lives in the Infrastructure repo and consumes the new log fields; they are decoupled and either can ship first (new metric filters at 0 datapoints during the gap window are harmless).

## Additional Notes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)