### PR TITLE
feat(proxy_client): preserve full proxy bodies in trace log (ORO-1162)

### DIFF
--- a/src/agent/proxy_client.py
+++ b/src/agent/proxy_client.py
@@ -52,26 +52,18 @@ class RequestLog:
         if params:
             entry["params"] = {k: v for k, v in params.items() if v is not None}
         if json_data:
-            if "/inference/" in path:
-                # Omit large message arrays from inference requests
-                entry["json_data"] = {k: v for k, v in json_data.items() if k != "messages"}
-            else:
-                entry["json_data"] = json_data
+            entry["json_data"] = json_data
         if response_body is not None:
-            body_str = json.dumps(response_body, default=str)
-            if len(body_str) > 2000:
-                entry["response_truncated"] = True
-                entry["response_length"] = len(body_str)
-                if "/search/find_product" in path and isinstance(response_body, list):
-                    # Preserve product IDs so the reasoning judge can verify the
-                    # agent's selections came from actual search results.
-                    entry["result_product_ids"] = [
-                        str(item["product_id"])
-                        for item in response_body
-                        if isinstance(item, dict) and "product_id" in item
-                    ]
-            else:
-                entry["response"] = response_body
+            entry["response"] = response_body
+            if "/search/find_product" in path and isinstance(response_body, list):
+                # Redundant index of product IDs so consumers that bucket only
+                # by summary fields (e.g. the reasoning judge) don't have to
+                # re-parse the full response list.
+                entry["result_product_ids"] = [
+                    str(item["product_id"])
+                    for item in response_body
+                    if isinstance(item, dict) and "product_id" in item
+                ]
         self._write(entry)
 
     def record_attempt(
@@ -259,7 +251,9 @@ class ProxyClient:
                 status_code = response.status_code
                 if response.status_code == 200:
                     self.request_log.record_attempt(
-                        method, path, i,
+                        method,
+                        path,
+                        i,
                         (time.monotonic() - attempt_t0) * 1000,
                         status_code=status_code,
                     )
@@ -282,7 +276,9 @@ class ProxyClient:
                 response = None
 
             self.request_log.record_attempt(
-                method, path, i,
+                method,
+                path,
+                i,
                 (time.monotonic() - attempt_t0) * 1000,
                 status_code=status_code,
                 error_class=error_class,
@@ -290,8 +286,10 @@ class ProxyClient:
 
             if i < self.max_retries - 1:
                 is_rate_limited = response is not None and response.status_code == 429
-                base_delay = self.rate_limit_retry_delay if is_rate_limited else self.retry_delay
-                delay = min(base_delay * (2 ** i), 10)
+                base_delay = (
+                    self.rate_limit_retry_delay if is_rate_limited else self.retry_delay
+                )
+                delay = min(base_delay * (2**i), 10)
                 time.sleep(delay)
 
         logger.error(f"Failed {operation_name} after {self.max_retries} retries")

--- a/subnet/tests/test_proxy_client.py
+++ b/subnet/tests/test_proxy_client.py
@@ -176,17 +176,18 @@ class TestRequestLog:
         finally:
             os.unlink(path)
 
-    def test_inference_body_omits_messages(self):
+    def test_inference_body_preserved(self):
         with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
             path = f.name
         try:
             log = RequestLog(log_file=path)
+            messages = [{"role": "user", "content": "very long prompt..."}]
             log.record(
                 method="POST",
                 path="/inference/chat/completions",
                 json_data={
                     "model": "gpt-4",
-                    "messages": [{"role": "user", "content": "very long prompt..."}],
+                    "messages": messages,
                     "temperature": 0.7,
                 },
                 status_code=200,
@@ -196,13 +197,13 @@ class TestRequestLog:
             with open(path) as f:
                 entry = json.loads(f.readline())
 
-            assert "messages" not in entry["json_data"]
+            assert entry["json_data"]["messages"] == messages
             assert entry["json_data"]["model"] == "gpt-4"
             assert entry["json_data"]["temperature"] == 0.7
         finally:
             os.unlink(path)
 
-    def test_large_response_truncated(self):
+    def test_large_response_preserved(self):
         with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
             path = f.name
         try:
@@ -219,13 +220,13 @@ class TestRequestLog:
             with open(path) as f:
                 entry = json.loads(f.readline())
 
-            assert entry["response_truncated"] is True
-            assert entry["response_length"] > 2000
-            assert "response" not in entry
+            assert entry["response"] == large_body
+            assert "response_truncated" not in entry
+            assert "response_length" not in entry
         finally:
             os.unlink(path)
 
-    def test_find_product_preserves_ids_when_truncated(self):
+    def test_find_product_extracts_result_ids_alongside_full_response(self):
         with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
             path = f.name
         try:
@@ -246,13 +247,13 @@ class TestRequestLog:
             with open(path) as f:
                 entry = json.loads(f.readline())
 
-            assert entry["response_truncated"] is True
+            assert entry["response"] == large_results
             assert entry["result_product_ids"] == [f"pid-{i}" for i in range(10)]
-            assert "response" not in entry
+            assert "response_truncated" not in entry
         finally:
             os.unlink(path)
 
-    def test_view_product_truncation_does_not_add_result_ids(self):
+    def test_view_product_full_response_no_result_ids(self):
         with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
             path = f.name
         try:
@@ -273,8 +274,44 @@ class TestRequestLog:
             with open(path) as f:
                 entry = json.loads(f.readline())
 
-            assert entry["response_truncated"] is True
+            assert entry["response"] == large_results
             assert "result_product_ids" not in entry
+        finally:
+            os.unlink(path)
+
+    def test_inference_response_preserves_usage_for_judge(self):
+        """Regression: judge reads response.usage.completion_tokens; truncation
+        used to strip the entire response body, breaking token tracking."""
+        with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False) as f:
+            path = f.name
+        try:
+            log = RequestLog(log_file=path)
+            full_inference_response = {
+                "choices": [
+                    {
+                        "message": {"role": "assistant", "content": "y" * 5000},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 800,
+                    "completion_tokens": 1200,
+                    "total_tokens": 2000,
+                },
+            }
+            log.record(
+                method="POST",
+                path="/inference/chat/completions",
+                status_code=200,
+                response_body=full_inference_response,
+                duration_ms=2500.0,
+            )
+
+            with open(path) as f:
+                entry = json.loads(f.readline())
+
+            assert entry["response"]["usage"]["completion_tokens"] == 1200
+            assert entry["response"]["choices"][0]["finish_reason"] == "stop"
         finally:
             os.unlink(path)
 


### PR DESCRIPTION
## Description

Drop the 2KB response-body truncation cap and the inference-request `messages` strip in `RequestLog.record()` (`src/agent/proxy_client.py`). The agent already receives the full response unchanged — these truncations only stripped data from the JSONL trace that feeds distillation / DPO training and the eval log bundles uploaded to S3.

Investigation in ORO-1161 traced the truncation to a single hardcoded 2KB cap inside the sandbox-side proxy client, predating the current reasoning judge. Removing it has zero impact on judge prompt size (the judge already only consumes summary fields, never the response body).

Closes ORO-1162.

## Changes Made

- Removed the `if len(body_str) > 2000` branch in `RequestLog.record()`. Response bodies are now always written verbatim under `entry["response"]`.
- Removed the `/inference/*` `messages` strip. Inference request bodies (model, messages, temperature, etc.) are now logged in full.
- Kept the `/search/find_product` `result_product_ids` extraction as a redundant index alongside the full response (consumers that bucket only on summary fields don't have to re-parse the list).
- Dropped the `response_truncated` and `response_length` fields entirely — no consumer reads them.
- Updated `subnet/tests/test_proxy_client.py` to assert full bodies are preserved for both `/search/*` and `/inference/*` paths.
- Added regression test (`test_inference_response_preserves_usage_for_judge`) confirming the judge can now read `usage.completion_tokens` on inference responses (latent bug — previously stripped because inference responses are almost always >2KB).

## Issue Link

- Related to: ORO-1161, ORO-957, ORO-1025
- Closes: ORO-1162

## Testing

### Manual Testing

Confirmed via code reading + grep that nothing outside the test file consumes `response_truncated` or `response_length`. The judge's `_format_proxy_call` / `_summarize_proxy_calls` in `src/agent/reasoning_scorer.py` only reads summary fields (`method`, `path`, `params`, `status_code`, `duration_ms`, `result_product_ids`, `usage.completion_tokens`), so the additional bytes in `response` are never injected into the judge prompt.

Functional impact on evaluations: zero. Truncation only ever touched the trace entry — the agent's request methods return `response.json()` directly to caller code, unchanged.

**Test Results:**

Full validator + subnet suite passes (390 passed, 1 net new test):

\`\`\`bash
.venv/bin/python -m pytest tests/ subnet/tests/ -q --no-header \\
  --ignore=subnet/tests/validator/test_weight_setter.py \\
  --ignore=tests/integration/test_sandbox_isolation.py
# 390 passed
\`\`\`

Ruff:
\`\`\`bash
ruff check src/agent/proxy_client.py tests/test_proxy_client.py subnet/tests/test_proxy_client.py   # All checks passed!
ruff format --check src/agent/proxy_client.py   # already formatted
\`\`\`

### Automated Testing

**Test Command(s):**
\`\`\`bash
.venv/bin/python -m pytest tests/ subnet/tests/ -q --no-header \\
  --ignore=subnet/tests/validator/test_weight_setter.py \\
  --ignore=tests/integration/test_sandbox_isolation.py
\`\`\`

## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**

N/A — module docstring on `RequestLog` already covers the behavior; the only semantic change is "full response always preserved" which is the obvious read of the new code.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

Storage impact: ~1000 30-problem evals/day × ~1MB gzipped/run ≈ 45GB/month net new at single-digit dollars/month on S3 Standard. Negligible compared to the Modal + Pyserini re-fetch cost that the distillation pipeline (ORO-957 / ORO-1025) currently pays to reconstruct what the agent saw.

Once this lands, the distillation pipeline can drop its Pyserini re-fetch stage entirely. Search/catalog responses are now captured exactly as the agent observed them; inference responses now retain logprobs / `finish_reason` / `usage` for DPO + process-reward training.

🤖 Generated with [Claude Code](https://claude.com/claude-code)