### PR TITLE
feat(proxy): tag inference outcomes with $proxy_outcome for 503 metric split

### DIFF
--- a/docker/proxy/nginx.conf.template
+++ b/docker/proxy/nginx.conf.template
@@ -6,6 +6,14 @@ http {
     # Load njs validation script
     js_import validate_model from /etc/nginx/validate_model.js;
 
+    # Per-request outcome label written by validate_model.js. `js_set` makes
+    # the variable lazy: nginx calls `validate_model.outcome(r)` only when the
+    # value is needed (at access-log time), which returns whatever label the
+    # njs handler stashed on the request before `r.return(...)`. Lets metric
+    # filters tell `upstream-5xx-503` (Chutes parrot, dashboard) apart from
+    # `internal-allowlist-unavailable` (proxy broken, page). See ORO-1159.
+    js_set $proxy_outcome validate_model.outcome;
+
     # Cross-worker shared cache for the inference allowlist. njs module-level
     # vars are per-worker, so 8 workers each cold-start with an empty cache
     # and 8 simultaneous fetches storm the Backend, where some get 429 and
@@ -23,16 +31,20 @@ http {
     # Rate limiting zone: 30 requests/second per client IP
     limit_req_zone $binary_remote_addr zone=agent:10m rate=30r/s;
 
-    # Combined access log + upstream metadata. `$upstream_status` is `-` when
-    # the request never reached an upstream (e.g. njs short-circuit via
-    # `r.return(503, ...)`), and the actual upstream HTTP status when a
-    # `proxy_pass` ran. CloudWatch metric filters key off `ups=` to tell apart
-    # "upstream returned 5xx the proxy correctly forwarded" from "proxy itself
-    # could not serve the request". See ORO-1159.
+    # Combined access log + upstream metadata + per-request outcome label.
+    # `$upstream_status` propagates the upstream HTTP status when a parent
+    # location uses `proxy_pass` (e.g. /search/*) but stays `-` when the
+    # parent uses `js_content` and dispatches to upstream via an njs
+    # subrequest (e.g. /inference/). `$proxy_outcome` covers the gap for the
+    # inference path — see js_set above and validate_model.js. CloudWatch
+    # metric filters key off `outcome=upstream-5` vs `outcome=internal-` to
+    # tell upstream-relayed 5xx apart from proxy-internal failures. See
+    # ORO-1159.
     log_format inference_combined '$remote_addr - $remote_user [$time_local] '
                                   '"$request" $status $body_bytes_sent '
                                   '"$http_referer" "$http_user_agent" '
-                                  'ups=$upstream_status urt=$upstream_response_time';
+                                  'ups=$upstream_status urt=$upstream_response_time '
+                                  'outcome=$proxy_outcome';
 
     # Local-only stub_status endpoint for nginx-prometheus-exporter. On a
     # separate listener so it never conflicts with the public proxy paths

--- a/docker/proxy/validate_model.js
+++ b/docker/proxy/validate_model.js
@@ -27,8 +27,40 @@
 // allowlist validation, so the same agent code works on either provider.
 // Models with no pair entry pass through unchanged and hit the existing
 // allowlist check as before.
+//
+// Per-request outcome tagging: `$upstream_status` on the parent /inference/
+// access log line is always `-` because the location uses `js_content` rather
+// than `proxy_pass`. To let CloudWatch metric filters distinguish
+// upstream-relayed errors (Chutes/OpenRouter returned 5xx) from proxy-internal
+// failures (allowlist unavailable, model not allowed), we stash a short label
+// on the request object before every `r.return(...)` and expose it via
+// `js_set $proxy_outcome validate_model.outcome` so it lands in the access
+// log. See ORO-1159.
 
 import fs from "fs";
+
+// Tag this request with what happened so the access log can record it.
+// Called before every r.return(...) in validate(). Read back via outcome(r)
+// which is bound to $proxy_outcome by js_set in nginx.conf.template.
+function _tag(r, label) {
+  r._oroOutcome = label;
+}
+
+function outcome(r) {
+  return r._oroOutcome || "unknown";
+}
+
+// Build the upstream-* label from a subrequest reply status. Keeps the label
+// space small enough for CloudWatch term-match patterns: filters key off the
+// `upstream-2xx-` / `upstream-4xx-` / `upstream-5xx-` prefix.
+function _upstreamLabel(status) {
+  var bucket;
+  if (status >= 500 && status < 600) bucket = "5xx";
+  else if (status >= 400 && status < 500) bucket = "4xx";
+  else if (status >= 200 && status < 300) bucket = "ok";
+  else bucket = "other";
+  return "upstream-" + bucket + "-" + status;
+}
 
 function detectProvider(r) {
   var auth = r.headersIn["Authorization"] || "";
@@ -156,6 +188,7 @@ function validate(r) {
   if (r.method !== "POST") {
     var passUri = upstreamLocation + r.uri.replace(/^\/inference\//, "");
     r.subrequest(passUri, { method: r.method, args: r.variables.args || "" }, function (reply) {
+      _tag(r, _upstreamLabel(reply.status));
       for (var h in reply.headersOut) {
         r.headersOut[h] = reply.headersOut[h];
       }
@@ -167,6 +200,7 @@ function validate(r) {
   var body = r.requestText;
 
   if (!body) {
+    _tag(r, "internal-bad-request");
     r.headersOut["Content-Type"] = "application/json";
     r.return(400, JSON.stringify({ error: "Missing or unreadable request body" }));
     return;
@@ -176,18 +210,21 @@ function validate(r) {
   try {
     parsed = JSON.parse(body);
   } catch (e) {
+    _tag(r, "internal-bad-request");
     r.headersOut["Content-Type"] = "application/json";
     r.return(400, JSON.stringify({ error: "Invalid JSON in request body" }));
     return;
   }
 
   if (!parsed.model) {
+    _tag(r, "internal-bad-request");
     r.headersOut["Content-Type"] = "application/json";
     r.return(400, JSON.stringify({ error: "Missing 'model' field in request body" }));
     return;
   }
 
   if (parsed.stream === true) {
+    _tag(r, "internal-bad-request");
     r.headersOut["Content-Type"] = "application/json";
     r.return(400, JSON.stringify({ error: "Streaming is not supported through the proxy" }));
     return;
@@ -202,12 +239,14 @@ function validate(r) {
 
   getAllowlist(r, provider, function (allowed) {
     if (!allowed) {
+      _tag(r, "internal-allowlist-unavailable");
       r.headersOut["Content-Type"] = "application/json";
       r.return(503, JSON.stringify({ error: "Inference allowlist unavailable" }));
       return;
     }
 
     if (allowed.indexOf(parsed.model) === -1) {
+      _tag(r, "internal-model-not-allowed");
       r.error("Model not allowed for " + provider + ": " + parsed.model);
       r.headersOut["Content-Type"] = "application/json";
       r.return(
@@ -225,6 +264,7 @@ function validate(r) {
       uri,
       { method: "POST", body: forwardBody, args: r.variables.args || "" },
       function (reply) {
+        _tag(r, _upstreamLabel(reply.status));
         for (var h in reply.headersOut) {
           r.headersOut[h] = reply.headersOut[h];
         }
@@ -234,4 +274,4 @@ function validate(r) {
   });
 }
 
-export default { validate };
+export default { validate: validate, outcome: outcome };


### PR DESCRIPTION
## Description

The `/inference/` nginx location uses `js_content validate_model.validate` rather than `proxy_pass`. As a result, `$upstream_status` on the parent access-log line is always `-` even when the njs handler subrequested to `/_chutes_proxy/` or `/_openrouter_proxy/` and Chutes/OpenRouter returned a real status. That made the `ups=` field PR #165 added unusable for splitting "upstream-relayed 5xx the proxy correctly forwarded" from "proxy-internal failure" — which is the whole point of ORO-1159 ask #2(a) and the companion Infrastructure PR (ORO-AI/Infrastructure#95).

Confirmed empirically on staging on 2026-05-14 during burn-in of PR #165:

```
GET  /search/find_product  →  200  ups=200 urt=0.336   ← proxy_pass at parent, propagates
POST /inference/chat/...   →  200  ups=-   urt=-       ← js_content + njs subrequest, does NOT propagate
```

This PR closes that gap by having `validate_model.js` stash a short outcome label on `r` before every `r.return(...)`, exposed to the access log via `js_set $proxy_outcome validate_model.outcome`. The Infrastructure metric filters will then key off `outcome=upstream-5` vs `outcome=internal-` (one-line `filter_pattern` swap in PR #95).

## Changes Made

- `docker/proxy/validate_model.js`: add `_tag(r, label)` helper and `outcome(r)` getter; export `outcome` alongside `validate`. Tag every `r.return(...)` path with the appropriate label. Add `_upstreamLabel(status)` that builds `upstream-{ok,4xx,5xx,other}-NNN` from a subrequest reply status.
- `docker/proxy/nginx.conf.template`: declare `js_set \$proxy_outcome validate_model.outcome;` next to `js_import`; append `outcome=\$proxy_outcome` to the `inference_combined` log_format. Update inline comment to explain why the new field exists.

### Outcome label space

| Path | Label |
|---|---|
| Subrequest callback (POST + non-POST passthrough) | `upstream-ok-200` / `upstream-4xx-NNN` / `upstream-5xx-NNN` / `upstream-other-NNN` |
| Allowlist fetch failed + no stale grace → `r.return(503, ...)` | `internal-allowlist-unavailable` |
| Model not in active provider allowlist → `r.return(403, ...)` | `internal-model-not-allowed` |
| Missing body / invalid JSON / missing model / streaming → `r.return(400, ...)` | `internal-bad-request` |
| Path that never reached njs (e.g. `limit_req` 429s) | `unknown` (falls through `js_set`) |

### Expected access-log shapes after this PR

```
503 93  ... ups=- urt=- outcome=upstream-5xx-503             ← Chutes parrot — dashboard, no page
503 43  ... ups=- urt=- outcome=internal-allowlist-unavailable  ← real proxy failure — pages
403 ... ups=- urt=- outcome=internal-model-not-allowed
200 ... ups=- urt=- outcome=upstream-ok-200
429 67  ... ups=- urt=- outcome=unknown                       ← limit_req, never reached njs
```

## Issue Link

- Related to: ORO-1159 (proxy ask #2(a) — distinguish upstream vs internal 503)
- Builds on: #165 (log_format with \`ups=\` + \`urt=\`)
- Pairs with: ORO-AI/Infrastructure#95 (CloudWatch metric filter split; needs a one-line `filter_pattern` update to key off `outcome=` once this lands)
- Closes: N/A

## Testing

### Manual Testing

Built the proxy image locally from this branch and ran nginx config validation against the envsubst'd template (with stub env vars for SEARCH_SERVER_URL, CHUTES_HOST, etc.):

```bash
docker build -f docker/proxy/Dockerfile -t oro-proxy-test:oro-1159 .
docker run --rm --entrypoint sh oro-proxy-test:oro-1159 -c '
: \${BACKEND_URL:=https://api.oroagents.com}
: \${BACKEND_HOST:=api.oroagents.com}
: \${OPENROUTER_HOST:=openrouter.ai}
: \${SEARCH_SERVER_URL:=search-server}
: \${SEARCH_SERVER_PORT:=5632}
: \${CHUTES_HOST:=llm.chutes.ai}
export BACKEND_URL BACKEND_HOST OPENROUTER_HOST SEARCH_SERVER_URL SEARCH_SERVER_PORT CHUTES_HOST
envsubst "\\\${SEARCH_SERVER_URL} \\\${SEARCH_SERVER_PORT} \\\${CHUTES_HOST} \\\${BACKEND_URL} \\\${BACKEND_HOST} \\\${OPENROUTER_HOST}" < /tmp/nginx.conf.template > /etc/nginx/nginx.conf
nginx -t
'
```

**Test Results:**

```
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
```

Live access-log verification will happen on staging once this image rolls out via Watchtower — should see `outcome=upstream-ok-200` on successful inference calls, `outcome=upstream-5xx-NNN` on Chutes saturation 503s, and `outcome=internal-*` on the proxy-internal failure paths.

### Automated Testing

No JS test harness in this repo. Validation is `nginx -t` at container start. Run as part of \`docker build\` for the proxy image.

**Test Command(s):**

```bash
docker build -f docker/proxy/Dockerfile -t oro-proxy-test:oro-1159 .
# Then the envsubst + nginx -t pipeline above
```

## Documentation

- [ ] README updated
- [x] Code comments added/updated — both files have new inline comments explaining the `\$proxy_outcome` mechanism and why it's needed (js_content vs proxy_pass and the parent-vs-subrequest \$upstream_status semantics).
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify): N/A

**Documentation Changes:** Inline comments in `validate_model.js` (new \"Per-request outcome tagging\" section in the file header) and in `nginx.conf.template` (next to the new `js_set` directive and updated `log_format` block).

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works — config-only + ~30 LOC of njs; validated via `nginx -t` + planned staging burn-in
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged — PR #165 (log_format scaffolding) already merged on main; the Infrastructure metric-filter update (#95) is pending review and will follow once this lands so CW filters can key off `outcome=`.

## Additional Notes

### Sequencing

1. This PR lands first, image rebuilds, Watchtower picks up `:latest` on staging.
2. Verify access-log lines on staging show the new `outcome=` field with expected values (especially `outcome=upstream-5xx-NNN` for a Chutes 503 case, since that's the bit that didn't work via `ups=`).
3. Update Infrastructure PR #95 to swap its `FilterPattern.all_terms(..., "ups=5")` / `..., "ups=-"` for `..., "outcome=upstream-5"` / `..., "outcome=internal-"`.
4. Then promote v1.0.X+1 to prod stable.

If anyone deploys Infrastructure PR #95 in its current form before this PR rolls out, the alarm goes silent on `*-internal` and never alarms on `*-upstream`. That's why #95 should be held until this lands and is verified live.

### Why a per-request `r` property instead of an nginx `set` variable

nginx variables created via `set $X "...";` are writable from njs only when declared in the location/server scope. For something that needs to be settable from inside `r.subrequest(...)` callbacks (which run after the parent's location-scope `set` has fired), a property on `r` is the path of least resistance and stays purely in JS-land. `js_set` then exposes it as `$proxy_outcome` only when nginx actually needs the value (at access-log time).