### PR TITLE
Add Qwen3.6-27B + Kimi-K2.6 cross-provider pairs

### DIFF
--- a/docker/proxy/model_pairs.json
+++ b/docker/proxy/model_pairs.json
@@ -8,10 +8,12 @@
     { "chutes": "tngtech/DeepSeek-TNG-R1T2-Chimera-TEE",    "openrouter": "tngtech/deepseek-r1t2-chimera" },
     { "chutes": "Qwen/Qwen3-32B-TEE",                        "openrouter": "qwen/qwen3-32b" },
     { "chutes": "Qwen/Qwen3.5-397B-A17B-TEE",               "openrouter": "qwen/qwen3.5-397b-a17b" },
+    { "chutes": "Qwen/Qwen3.6-27B-TEE",                      "openrouter": "qwen/qwen3.6-27b" },
     { "chutes": "google/gemma-4-31B-turbo-TEE",             "openrouter": "google/gemma-4-31b-it" },
     { "chutes": "zai-org/GLM-5-TEE",                         "openrouter": "z-ai/glm-5" },
     { "chutes": "zai-org/GLM-5.1-TEE",                       "openrouter": "z-ai/glm-5.1" },
     { "chutes": "moonshotai/Kimi-K2.5-TEE",                  "openrouter": "moonshotai/kimi-k2.5" },
+    { "chutes": "moonshotai/Kimi-K2.6-TEE",                  "openrouter": "moonshotai/kimi-k2.6" },
     { "chutes": "MiniMaxAI/MiniMax-M2.5-TEE",               "openrouter": "minimax/minimax-m2.5" },
     { "chutes": "XiaomiMiMo/MiMo-V2-Flash-TEE",             "openrouter": "xiaomi/mimo-v2-flash" }
   ]


### PR DESCRIPTION
## Summary

Adds two new model pairs to `docker/proxy/model_pairs.json` so the validator proxy can rewrite the `model` field between Chutes and OpenRouter forms for the same model intent.

- `Qwen/Qwen3.6-27B-TEE` ↔ `qwen/qwen3.6-27b`
- `moonshotai/Kimi-K2.6-TEE` ↔ `moonshotai/kimi-k2.6`

Companion PR adds both to the Backend allowlists: ORO-AI/Backend#356.

Verified each slug exists on its respective provider catalog:
- `https://llm.chutes.ai/v1/models` — both Chutes IDs returned.
- `https://openrouter.ai/api/v1/models` — both OpenRouter slugs returned.

**Draft — do not merge until after today's race.**

## Test plan

- [ ] CI passes (lint + JSON shape check).
- [ ] After merge, validator proxy image picks up the new pairs via Watchtower.
- [ ] Spot-check with a Chutes-token request sending `Qwen/Qwen3.6-27B-TEE` and an OpenRouter-token request sending the same → both succeed (proxy rewrites OpenRouter side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)