### PR TITLE
feat(proxy): add gpt-oss-120b cross-provider pair (ORO-1213)

### DIFF
--- a/docker/proxy/model_pairs.json
+++ b/docker/proxy/model_pairs.json
@@ -15,6 +15,7 @@
     { "chutes": "moonshotai/Kimi-K2.5-TEE",                  "openrouter": "moonshotai/kimi-k2.5" },
     { "chutes": "moonshotai/Kimi-K2.6-TEE",                  "openrouter": "moonshotai/kimi-k2.6" },
     { "chutes": "MiniMaxAI/MiniMax-M2.5-TEE",               "openrouter": "minimax/minimax-m2.5" },
-    { "chutes": "XiaomiMiMo/MiMo-V2-Flash-TEE",             "openrouter": "xiaomi/mimo-v2-flash" }
+    { "chutes": "XiaomiMiMo/MiMo-V2-Flash-TEE",             "openrouter": "xiaomi/mimo-v2-flash" },
+    { "chutes": "openai/gpt-oss-120b-TEE",                   "openrouter": "openai/gpt-oss-120b" }
   ]
 }


### PR DESCRIPTION
## Summary
- Add \`openai/gpt-oss-120b-TEE\` ↔ \`openai/gpt-oss-120b\` to \`docker/proxy/model_pairs.json\`
- Lets the inference proxy rewrite either form to the active provider's form, matching the convention used for every other model in the list

## Test plan
- [x] \`tests/test_model_pairs.py\` — all 6 assertions still pass (well-formedness, no dupes, -TEE suffix on Chutes side, org/model shape)

## Cross-repo dependency
This PR is paired with [Backend #367](https://github.com/ORO-AI/Backend/pull/367) (allowlist) and [Frontend #447](https://github.com/ORO-AI/Frontend/pull/447) (docs). Backend should land first so the proxy's allowlist fetch returns the new IDs by the time validators redeploy with this pair file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)