### PR TITLE
validator: detect judge HTTP 402, short-circuit, lower max_tokens

### DIFF
--- a/src/agent/reasoning_scorer.py
+++ b/src/agent/reasoning_scorer.py
@@ -611,7 +611,7 @@ def score_reasoning_quality(
         Dict with 'score' (float 0-1), 'explanation' (str),
         'model' (str), 'inference_failed' (int), 'inference_total' (int).
     """
-    empty = {"score": 0.0, "explanation": "", "model": "", "inference_failed": 0, "inference_total": 0}
+    empty = {"score": 0.0, "explanation": "", "model": "", "inference_failed": 0, "inference_total": 0, "inference_402": 0}
     if not dialogue:
         return empty
 
@@ -631,6 +631,7 @@ def score_reasoning_quality(
     model_idx = 0
     inference_failed = 0
     inference_total = 0
+    inference_402 = 0
     for attempt in range(max_retries):
         if len(bad_models) >= len(models):
             logger.error(
@@ -676,6 +677,7 @@ def score_reasoning_quality(
                         "model": model,
                         "inference_failed": inference_failed,
                         "inference_total": inference_total,
+                        "inference_402": inference_402,
                     }
                 # 200 OK with empty/unparseable body — model is broken upstream
                 # (Chutes serving an unhealthy TEE instance). Blacklist it for
@@ -692,14 +694,18 @@ def score_reasoning_quality(
                 continue
 
             inference_failed += 1
+            if resp.status_code == 402:
+                inference_402 += 1
 
-            # Auth failures are terminal — token is bad, retrying won't help
-            if resp.status_code in (401, 403):
+            # Auth failures are terminal — token is bad, retrying won't help.
+            # 402 = miner out of credits; same token is used across every
+            # rotation model, so retrying any other model hits the same wall.
+            if resp.status_code in (401, 402, 403):
                 logger.error(
-                    f"Judge auth failure ({resp.status_code}) with {model}, "
-                    f"aborting (bad or expired token)"
+                    f"Judge {resp.status_code} with {model}, aborting: "
+                    f"{resp.text[:200]}"
                 )
-                return {**empty, "inference_failed": inference_failed, "inference_total": inference_total}
+                return {**empty, "inference_failed": inference_failed, "inference_total": inference_total, "inference_402": inference_402}
 
             if resp.status_code in (429, 502, 503, 504):
                 logger.warning(
@@ -724,4 +730,4 @@ def score_reasoning_quality(
             model_idx += 1
 
     logger.error(f"All {max_retries} judge retries exhausted, returning 0.0")
-    return {**empty, "inference_failed": inference_failed, "inference_total": inference_total}
+    return {**empty, "inference_failed": inference_failed, "inference_total": inference_total, "inference_402": inference_402}

--- a/src/agent/types.py
+++ b/src/agent/types.py
@@ -100,6 +100,9 @@ class JudgeResult(TypedDict):
     model: str
     inference_failed: int
     inference_total: int
+    # 402 = miner out of credits. Counted separately so the validator can
+    # label a stalled eval as a miner-funding failure rather than infra.
+    inference_402: int
 
 
 class ReasoningSummary(TypedDict):
@@ -110,6 +113,7 @@ class ReasoningSummary(TypedDict):
     reasoning_coefficient: float
     judge_inference_failed: int
     judge_inference_total: int
+    judge_inference_402: int
 
 
 class ScoreComponentsSummary(TypedDict, total=False):

--- a/subnet/tests/test_reasoning_scorer.py
+++ b/subnet/tests/test_reasoning_scorer.py
@@ -347,6 +347,24 @@ class TestScoreReasoningQuality:
     def test_judge_models_nonempty(self):
         assert len(JUDGE_MODELS) >= 1
 
+    @patch("reasoning_scorer.time.sleep")
+    @patch("reasoning_scorer.requests.post")
+    def test_short_circuits_on_402_without_retry(self, mock_post, _mock_sleep):
+        """HTTP 402 = miner out of credits. The same token is used for
+        every model in the rotation, so retrying is guaranteed to fail
+        too. The scorer must short-circuit on the first 402 and surface
+        inference_402 to the caller."""
+        mock_post.return_value = MagicMock(
+            status_code=402,
+            text='{"error":{"message":"This request requires more credits"}}',
+        )
+        result = score_reasoning_quality(REASONING_AGENT, api_key="test-key")
+        assert result["score"] == 0.0
+        assert result["inference_402"] == 1
+        assert result["inference_failed"] == 1
+        assert result["inference_total"] == 1
+        assert mock_post.call_count == 1
+
 
 class TestFetchRankedModels:
     """Tests for the Backend ranked-endpoint consumer."""

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -823,18 +823,22 @@ class Validator:
             # Step 4b: Get reasoning data (judged per-problem during scoring)
             reasoning_result = progress_reporter.get_reasoning_data()
 
-            # If most judge calls failed, treat as infrastructure failure.
+            # If most judge calls failed, treat as failure. Any 402 means
+            # the miner is out of inference credits — surface that as a
+            # miner-funding failure instead of misleading "infrastructure".
             judge_total = reasoning_result["judge_inference_total"]
             judge_failed = reasoning_result["judge_inference_failed"]
+            judge_402 = reasoning_result["judge_inference_402"]
             if judge_total >= 3 and judge_failed > judge_total / 2:
-                logging.warning(
-                    f"Reasoning judge failed on {judge_failed}/{judge_total} calls, "
-                    f"completing as FAILED so another validator can retry"
-                )
+                if judge_402 > 0:
+                    failure_reason = f"Reasoning judge insufficient miner credits ({judge_402}/{judge_total} calls returned 402)"
+                else:
+                    failure_reason = f"Reasoning judge infrastructure failure ({judge_failed}/{judge_total} calls failed)"
+                logging.warning(f"Completing as FAILED: {failure_reason}")
                 self._complete_with_failure(
                     eval_run_id,
                     TerminalStatus.FAILED,
-                    f"Reasoning judge infrastructure failure ({judge_failed}/{judge_total} calls failed)",
+                    failure_reason,
                     sandbox_metadata=sandbox_metadata,
                 )
                 return
@@ -853,6 +857,7 @@ class Validator:
             aggregate["judge_inference_total"] = reasoning_result[
                 "judge_inference_total"
             ]
+            aggregate["judge_inference_402"] = reasoning_result["judge_inference_402"]
 
             logging.info(
                 f"Score: final={score:.4f} "

--- a/subnet/validator/progress_reporter.py
+++ b/subnet/validator/progress_reporter.py
@@ -186,6 +186,7 @@ class ProgressReporter:
                 "reasoning_coefficient": reasoning_coefficient(0.0),
                 "judge_inference_failed": 0,
                 "judge_inference_total": 0,
+                "judge_inference_402": 0,
             }
 
         judged = [r for r in results if r.reasoning_score is not None]
@@ -194,6 +195,7 @@ class ProgressReporter:
         coeff = reasoning_coefficient(avg)
         total_inf_failed = sum(r.reasoning_inf_failed for r in results)
         total_inf_total = sum(r.reasoning_inf_total for r in results)
+        total_inf_402 = sum(r.reasoning_inf_402 for r in results)
 
         logging.info(
             f"Reasoning aggregate: quality={avg:.4f}, coefficient={coeff:.4f} "
@@ -205,6 +207,7 @@ class ProgressReporter:
             "reasoning_coefficient": coeff,
             "judge_inference_failed": total_inf_failed,
             "judge_inference_total": total_inf_total,
+            "judge_inference_402": total_inf_402,
         }
 
     def get_problem_status(self, problem_id: str) -> ProblemStatus:

--- a/subnet/validator/reasoning_judge.py
+++ b/subnet/validator/reasoning_judge.py
@@ -26,6 +26,7 @@ _EMPTY_RESULT: Dict[str, Any] = {
     "reasoning_model": "",
     "reasoning_inf_failed": 0,
     "reasoning_inf_total": 0,
+    "reasoning_inf_402": 0,
 }
 
 
@@ -64,8 +65,19 @@ class ReasoningJudge:
 
             inf_failed = judge_result["inference_failed"]
             inf_total = judge_result["inference_total"]
+            inf_402 = judge_result["inference_402"]
             with self._lock:
-                if inf_total > 0 and inf_failed == inf_total:
+                # Any 402 trips the breaker immediately — the miner's
+                # token can't afford a single judge call, and the same
+                # token is reused across every rotation model.
+                if inf_402 > 0:
+                    self._circuit_open = True
+                    self._consecutive_failures = CIRCUIT_BREAKER_THRESHOLD
+                    logging.error(
+                        f"Reasoning judge circuit breaker tripped on 402 "
+                        f"(miner out of credits) at problem {problem_id}"
+                    )
+                elif inf_total > 0 and inf_failed == inf_total:
                     self._consecutive_failures += 1
                     if self._consecutive_failures >= CIRCUIT_BREAKER_THRESHOLD:
                         self._circuit_open = True
@@ -87,6 +99,7 @@ class ReasoningJudge:
                 "reasoning_model": judge_result["model"],
                 "reasoning_inf_failed": inf_failed,
                 "reasoning_inf_total": inf_total,
+                "reasoning_inf_402": inf_402,
             }
         except Exception as e:
             logging.warning(f"Reasoning judge failed for {problem_id}: {e}")

--- a/subnet/validator/types.py
+++ b/subnet/validator/types.py
@@ -51,4 +51,5 @@ class ProblemResult:
     reasoning_model: str = ""
     reasoning_inf_failed: int = 0
     reasoning_inf_total: int = 0
+    reasoning_inf_402: int = 0
     execution_time: float | None = None


### PR DESCRIPTION
## Description

The reasoning judge currently uses the miner's inference token. When the miner is underfunded the provider returns HTTP 402 on every call. The validator counts those 402s as ordinary failures, exhausts the 8-retry budget per problem, and ends the eval with `Reasoning judge infrastructure failure` — wording that wrongly implies our infra is broken when the root cause is purely miner-side funding. With multiple validators evaluating the same agent this can stall a race for hours.

This PR teaches the judge to recognise 402, short-circuit immediately, and label the failure correctly.

## Changes Made

- `score_reasoning_quality` short-circuits on 402 alongside 401/403 (same token across every rotation model — retrying can't succeed) and surfaces an `inference_402` counter on the result dict.
- `ReasoningJudge` trips its circuit breaker immediately on any 402 so subsequent problems in the same eval don't burn another judge call. The existing `should_judge` gate at the top of `score()` already returns empty when the circuit is open, so total cost stays at one 402 per eval.
- `JudgeResult`, `ReasoningSummary`, and `ProblemResult` gain a parallel `inference_402` / `judge_inference_402` / `reasoning_inf_402` field. The per-problem counter rolls up through `progress_reporter` into the run-level summary.
- Validator `main.py` checks the rolled-up `judge_inference_402` and labels the failure `Reasoning judge insufficient miner credits (X/N calls returned 402)` instead of the misleading `infrastructure failure` text. True upstream-provider failures still use the original wording.

Reasoning-judge `max_tokens` is intentionally left at 3072 — the judge needs the full budget for accurate scoring on long trajectories.

## Issue Link

N/A (internal tracking).

## Testing

### Manual Testing

Unit tests cover the new branch. End-to-end staging validation will follow before flipping prod (separate ticket).

**Test Results:**

```
405 passed, 5 skipped in 13.95s
```

### Automated Testing

**Test Command(s):**
```bash
python3.11 -m pytest subnet/tests/ tests/ -q
python3.11 -m ruff check src/agent/reasoning_scorer.py src/agent/types.py \
  subnet/validator/main.py subnet/validator/reasoning_judge.py \
  subnet/validator/progress_reporter.py subnet/validator/types.py \
  subnet/tests/test_reasoning_scorer.py
```

New test:
- `TestScoreReasoningQuality::test_short_circuits_on_402_without_retry` — single 402 yields one POST + `inference_402 == 1`, no rotation, no retries.

## Documentation

- [ ] README updated
- [x] Code comments added/updated (why-comments only — 402 short-circuit rationale, miner-funding-vs-infra distinction)
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**

N/A.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

This is the validator-side half of the fix. The Backend-side companions — auto-discard parity for the new `Reasoning judge insufficient miner credits` failure class, and exposing `discard_reason` on the miner endpoint so miners can self-diagnose — will land in a follow-up PR against the Backend repo.