### PR TITLE
sandbox: add HTTP server mode wrapping execute_single_problem

### DIFF
--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -8,10 +8,10 @@ RUN apt-get update && apt-get install -y \
 # Set working directory
 WORKDIR /app
 
-# Install Python dependencies
-# The agent needs requests for HTTP calls
-# ujson is needed by ProblemScorer for per-problem scoring
-RUN pip install --no-cache-dir requests ujson
+# requests: agent HTTP calls
+# ujson: ProblemScorer per-problem scoring
+# fastapi/uvicorn/pydantic: sandbox_server.py HTTP mode
+RUN pip install --no-cache-dir requests ujson fastapi 'uvicorn[standard]' pydantic
 
 # Copy agent code and source structure
 COPY src /app/src

--- a/src/agent/sandbox_executor.py
+++ b/src/agent/sandbox_executor.py
@@ -358,10 +358,15 @@ def _classify_error_type(
 
 
 def _format_single_result(result: ExecutionResult) -> str:
-    """Format an ExecutionResult as one JSONL envelope line.
+    return json.dumps(build_result_envelope(result))
 
-    Always returns a non-empty line — failures emit with dialogue=null so the
-    validator's ProgressReporter sees every problem outcome through one channel.
+
+def build_result_envelope(result: ExecutionResult) -> Dict[str, Any]:
+    """Canonical on-the-wire shape for an ExecutionResult.
+
+    Stamps per-step extra_info, distributes proxy_calls across dialogue steps,
+    and normalizes errors to {type, message}. Used by both the JSONL writer
+    and the HTTP server so consumers see identical envelopes.
     """
     dialogue: Optional[List[Dict]] = None
     if result.success and isinstance(result.result, list):
@@ -412,7 +417,7 @@ def _format_single_result(result: ExecutionResult) -> str:
                 "message": result.error,
             }
 
-    envelope = {
+    return {
         "problem_id": result.problem_id,
         "status": result.status.value,
         "execution_time": result.execution_time,
@@ -421,7 +426,6 @@ def _format_single_result(result: ExecutionResult) -> str:
         "error": error_obj,
         "dialogue": dialogue,
     }
-    return json.dumps(envelope)
 
 
 def execute_problems_parallel(
@@ -488,8 +492,7 @@ def execute_problems_parallel(
                     )
 
                     if fout is not None:
-                        line = _format_single_result(result)
-                        fout.write(line + "\n")
+                        fout.write(json.dumps(build_result_envelope(result)) + "\n")
                         fout.flush()
 
                 except FutureTimeoutError:

--- a/src/agent/sandbox_server.py
+++ b/src/agent/sandbox_server.py
@@ -1,0 +1,78 @@
+"""HTTP wrapper around `execute_single_problem`.
+
+Exposes the sandbox executor as `POST /run` for callers that want to submit
+work over loopback instead of via the one-shot CLI. Running the agent inside
+this container preserves the same process isolation the CLI relies on.
+
+Run:
+
+    python -m src.agent.sandbox_server --host 0.0.0.0 --port 7000
+
+Endpoints:
+
+* `GET /health` — liveness probe.
+* `POST /run` — body `{problem, agent_code, timeout}`; writes `agent_code`
+  to a tempfile, runs `execute_single_problem`, returns the canonical
+  envelope (same shape as the JSONL writer).
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from src.agent.sandbox_executor import build_result_envelope, execute_single_problem
+
+app = FastAPI()
+
+_MAX_AGENT_CODE_BYTES = 2 * 1024 * 1024
+
+
+class RunRequest(BaseModel):
+    problem: dict[str, Any]
+    agent_code: str = Field(..., max_length=_MAX_AGENT_CODE_BYTES)
+    timeout: float = Field(300.0, ge=1.0, le=900.0)
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/run")
+def run(req: RunRequest) -> dict[str, Any]:
+    if not req.agent_code.strip():
+        raise HTTPException(status_code=400, detail="agent_code is empty")
+
+    with NamedTemporaryFile(mode="w", suffix=".py", delete=False, encoding="utf-8") as fh:
+        fh.write(req.agent_code)
+        agent_path = fh.name
+
+    try:
+        result = execute_single_problem(
+            problem=req.problem, timeout=req.timeout, agent_file=agent_path
+        )
+    finally:
+        Path(agent_path).unlink(missing_ok=True)
+
+    return build_result_envelope(result)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=7000)
+    args = parser.parse_args()
+
+    import uvicorn
+
+    uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_sandbox_server.py
+++ b/tests/test_sandbox_server.py
@@ -1,0 +1,57 @@
+"""Smoke tests for sandbox_server FastAPI app."""
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from src.agent.sandbox_executor import ExecutionResult
+from src.agent.sandbox_status import SandboxProblemStatus
+from src.agent.sandbox_server import app
+
+client = TestClient(app)
+
+
+def test_health() -> None:
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+
+
+def test_run_rejects_empty_agent_code() -> None:
+    r = client.post("/run", json={"problem": {"query": "x"}, "agent_code": "   "})
+    assert r.status_code == 400
+
+
+def test_run_invokes_executor_and_returns_envelope() -> None:
+    fake_result = ExecutionResult(
+        query="test",
+        success=True,
+        result=[{"action": "search", "args": {"q": "x"}}],
+        execution_time=1.5,
+        problem_id="p-1",
+        status=SandboxProblemStatus.SUCCESS,
+    )
+    with patch("src.agent.sandbox_server.execute_single_problem", return_value=fake_result) as m:
+        r = client.post(
+            "/run",
+            json={
+                "problem": {"query": "test"},
+                "agent_code": "def agent_main(*a, **k): return []\n",
+                "timeout": 30.0,
+            },
+        )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["problem_id"] == "p-1"
+    assert body["status"] == "SUCCESS"
+    assert body["dialogue"][0]["action"] == "search"
+    assert m.call_args.kwargs["timeout"] == 30.0
+
+
+def test_run_rejects_timeout_out_of_range() -> None:
+    r = client.post(
+        "/run",
+        json={"problem": {"query": "x"}, "agent_code": "x = 1\n", "timeout": 0.1},
+    )
+    assert r.status_code == 422


### PR DESCRIPTION
## Description

Adds a FastAPI HTTP wrapper around `execute_single_problem` so callers can submit work over loopback instead of through the one-shot CLI. Running the agent inside this container preserves the same process isolation the CLI relies on (caller gets no IAM, env vars, or filesystem access from inside the agent's subprocess).

Also refactors the JSONL envelope build into `build_result_envelope()` so the HTTP server and the existing JSONL writer emit identical shapes.

## Changes Made

- `src/agent/sandbox_server.py` — FastAPI app with `GET /health` + `POST /run`.
- `src/agent/sandbox_executor.py` — extract `build_result_envelope()`; `_format_single_result` is now a thin `json.dumps(...)` wrapper for backward compatibility.
- `docker/sandbox/Dockerfile` — add `fastapi`, `uvicorn[standard]`, `pydantic`.
- `tests/test_sandbox_server.py` — smoke tests (health, empty-body rejection, executor invocation, timeout validation).

## Issue Link

N/A

## Testing

### Manual Testing

\`\`\`bash
python -m src.agent.sandbox_server --host 127.0.0.1 --port 7000 &
curl -s http://127.0.0.1:7000/health
# {"status":"ok"}
\`\`\`

**Test Results:**
- \`/health\` returns 200 immediately.
- \`/run\` with valid body invokes executor and returns the canonical envelope.
- \`/run\` with empty \`agent_code\` returns 400.
- \`/run\` with out-of-range timeout returns 422 (Pydantic validation).

### Automated Testing

**Test Command(s):**
\`\`\`bash
python -m pytest tests/test_sandbox_server.py tests/test_sandbox_envelope.py -q
# 17 passed
\`\`\`

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
Module docstring in \`sandbox_server.py\` documents endpoints and invocation.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

The endpoint is sync \`def\` — FastAPI runs it in its threadpool, so multiple concurrent requests can run in parallel up to the threadpool limit. Callers that need strict serialization should rate-limit themselves.