### PR TITLE
proxy: drop variable URL for /_backend_models subrequest

### DIFF
--- a/docker/proxy/nginx.conf.template
+++ b/docker/proxy/nginx.conf.template
@@ -116,14 +116,13 @@ http {
         location = /_backend_models {
             internal;
 
-            resolver 1.1.1.1 ipv6=off valid=300s;
-            # Forward the ?provider= arg from the njs subrequest. proxy_pass
-            # with a variable URL drops the original query string, so without
-            # this the Backend always returns the Chutes (default) allowlist
-            # and the OR cache silently stores Chutes-named models.
-            set $backend_models_url ${BACKEND_URL}/v1/public/inference/models?provider=$arg_provider;
+            # Literal URL (no nginx vars) — nginx resolves the hostname once at
+            # startup via libc, which consults /etc/hosts. Lets environments
+            # that need to pin Backend to a specific IP override DNS without
+            # forking the proxy image. Location-match URI replacement still
+            # forwards `?provider=…` from the subrequest automatically.
             proxy_method GET;
-            proxy_pass $backend_models_url;
+            proxy_pass ${BACKEND_URL}/v1/public/inference/models;
             proxy_ssl_server_name on;
             proxy_http_version 1.1;
             # Strip parent-request headers + body and overwrite the framing


### PR DESCRIPTION
## Description

The allowlist subrequest used `set $backend_models_url ${BACKEND_URL}/...?provider=$arg_provider;` followed by `proxy_pass $backend_models_url;`. With variable URLs nginx requires the `resolver` directive and bypasses `/etc/hosts` entirely — breaking environments that pin Backend to a specific IP via `/etc/hosts` rather than DNS.

Switch to a literal URL: `proxy_pass ${BACKEND_URL}/v1/public/inference/models;`. envsubst renders the URL at template time so nginx sees a fixed upstream and resolves the hostname once at startup via libc, which DOES consult `/etc/hosts`.

The location-match URI replacement still forwards `?provider=…` from the subrequest's query string automatically — no behavior change for existing deployments, just an extra mode that works now.

## Changes Made

- `docker/proxy/nginx.conf.template` — `/_backend_models` location:
  - Remove `resolver 1.1.1.1 ipv6=off valid=300s;`
  - Remove `set $backend_models_url …` + comment
  - Replace `proxy_pass $backend_models_url;` with `proxy_pass ${BACKEND_URL}/v1/public/inference/models;`

## Issue Link

N/A

## Testing

### Manual Testing

- `docker build` succeeds
- `nginx -t` passes with both default (`BACKEND_URL=https://api.oroagents.com`) and HTTP override
- Container reaches "ready" cleanly under both

### Automated Testing

```bash
docker build -t oro-proxy-test -f docker/proxy/Dockerfile .
# nginx -t inside the rendered container for both URL variants
```

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

One-line architectural shift: literal `proxy_pass` URL → startup-time DNS resolution via libc (honors `/etc/hosts`) → no resolver directive needed for this location. The other three `resolver 127.0.0.11` blocks in the template are untouched — they proxy to dynamic upstreams (search-server, Chutes, OpenRouter) where the docker-compose DNS server is the right primitive.