### PR TITLE
proxy: template the resolver instead of hardcoding 127.0.0.11

### DIFF
--- a/docker/proxy/Dockerfile
+++ b/docker/proxy/Dockerfile
@@ -6,4 +6,4 @@ COPY docker/proxy/nginx.conf.template /tmp/nginx.conf.template
 COPY docker/proxy/validate_model.js /etc/nginx/validate_model.js
 COPY docker/proxy/model_pairs.json /etc/nginx/model_pairs.json
 
-CMD ["/bin/sh", "-c", ": ${BACKEND_URL:=https://api.oroagents.com} && : ${BACKEND_HOST:=api.oroagents.com} && : ${OPENROUTER_HOST:=openrouter.ai} && export BACKEND_URL BACKEND_HOST OPENROUTER_HOST && envsubst '${SEARCH_SERVER_URL} ${SEARCH_SERVER_PORT} ${CHUTES_HOST} ${BACKEND_URL} ${BACKEND_HOST} ${OPENROUTER_HOST}' < /tmp/nginx.conf.template > /etc/nginx/nginx.conf && exec nginx -g 'daemon off;'"]
+CMD ["/bin/sh", "-c", ": ${BACKEND_URL:=https://api.oroagents.com} && : ${BACKEND_HOST:=api.oroagents.com} && : ${OPENROUTER_HOST:=openrouter.ai} && : ${PROXY_RESOLVER:=127.0.0.11 valid=30s} && export BACKEND_URL BACKEND_HOST OPENROUTER_HOST PROXY_RESOLVER && envsubst '${SEARCH_SERVER_URL} ${SEARCH_SERVER_PORT} ${CHUTES_HOST} ${BACKEND_URL} ${BACKEND_HOST} ${OPENROUTER_HOST} ${PROXY_RESOLVER}' < /tmp/nginx.conf.template > /etc/nginx/nginx.conf && exec nginx -g 'daemon off;'"]

--- a/docker/proxy/nginx.conf.template
+++ b/docker/proxy/nginx.conf.template
@@ -145,13 +145,12 @@ http {
         location /_chutes_proxy/ {
             internal;
 
-            # DNS resolution for external hostname (use Docker internal DNS)
-            resolver 127.0.0.11 valid=30s;
-            set $chutes_upstream https://${CHUTES_HOST};
-
-            # Strip /_chutes_proxy prefix and map to Chutes /v1/* API
+            # Literal URL — nginx resolves the hostname once at startup via
+            # libc, so the host's /etc/resolv.conf wins. No resolver directive
+            # needed; works under both docker-compose (Docker DNS) and ECS
+            # Fargate (VPC DNS) without per-environment config.
             rewrite ^/_chutes_proxy/(.*) /v1/$1 break;
-            proxy_pass $chutes_upstream;
+            proxy_pass https://${CHUTES_HOST};
             proxy_ssl_server_name on;
 
             # Forward miner's auth token (set by ProxyClient from CHUTES_ACCESS_TOKEN)
@@ -173,15 +172,10 @@ http {
         location /_openrouter_proxy/ {
             internal;
 
-            # ipv6=off: openrouter.ai resolves to Cloudflare AAAA records the
-            # Docker bridge can't reach; without this nginx tries IPv6 first
-            # and every request fails with "Network unreachable".
-            resolver 127.0.0.11 ipv6=off valid=30s;
-            set $openrouter_upstream https://${OPENROUTER_HOST};
-
-            # Strip /_openrouter_proxy prefix and map to OpenRouter /api/v1/* API
+            # Literal URL — nginx resolves once at startup via libc (uses
+            # /etc/resolv.conf), bypassing the resolver directive.
             rewrite ^/_openrouter_proxy/(.*) /api/v1/$1 break;
-            proxy_pass $openrouter_upstream;
+            proxy_pass https://${OPENROUTER_HOST};
             proxy_ssl_server_name on;
 
             # Forward miner's auth token (set by ProxyClient from CHUTES_ACCESS_TOKEN /

--- a/docker/proxy/nginx.conf.template
+++ b/docker/proxy/nginx.conf.template
@@ -145,12 +145,17 @@ http {
         location /_chutes_proxy/ {
             internal;
 
-            # Literal URL — nginx resolves the hostname once at startup via
-            # libc, so the host's /etc/resolv.conf wins. No resolver directive
-            # needed; works under both docker-compose (Docker DNS) and ECS
-            # Fargate (VPC DNS) without per-environment config.
+            # Per-request DNS via a configurable resolver. Default points at
+            # the Docker-compose embedded resolver; environments without it
+            # (e.g. ECS Fargate) override via PROXY_RESOLVER to their own
+            # DNS (VPC resolver, public DNS, etc.). Keeps the variable
+            # proxy_pass so re-resolution happens on TTL expiry.
+            resolver ${PROXY_RESOLVER};
+            set $chutes_upstream https://${CHUTES_HOST};
+
+            # Strip /_chutes_proxy prefix and map to Chutes /v1/* API
             rewrite ^/_chutes_proxy/(.*) /v1/$1 break;
-            proxy_pass https://${CHUTES_HOST};
+            proxy_pass $chutes_upstream;
             proxy_ssl_server_name on;
 
             # Forward miner's auth token (set by ProxyClient from CHUTES_ACCESS_TOKEN)
@@ -172,10 +177,17 @@ http {
         location /_openrouter_proxy/ {
             internal;
 
-            # Literal URL — nginx resolves once at startup via libc (uses
-            # /etc/resolv.conf), bypassing the resolver directive.
+            # Per-request DNS via the configurable resolver (see /_chutes_proxy/
+            # for the rationale). `ipv6=off` is required for openrouter.ai: it
+            # resolves to Cloudflare AAAA records that the Docker bridge can't
+            # reach, and without it every request fails with "Network
+            # unreachable".
+            resolver ${PROXY_RESOLVER} ipv6=off;
+            set $openrouter_upstream https://${OPENROUTER_HOST};
+
+            # Strip /_openrouter_proxy prefix and map to OpenRouter /api/v1/* API
             rewrite ^/_openrouter_proxy/(.*) /api/v1/$1 break;
-            proxy_pass https://${OPENROUTER_HOST};
+            proxy_pass $openrouter_upstream;
             proxy_ssl_server_name on;
 
             # Forward miner's auth token (set by ProxyClient from CHUTES_ACCESS_TOKEN /


### PR DESCRIPTION
## Description

v2 of this PR — addresses review feedback on the original literal-URL approach.

The previous attempt removed the resolver entirely and used \`proxy_pass https://\${HOST};\`. That reintroduced three problems on the validator side:

1. **IPv6 regression on openrouter.** \`ipv6=off\` only affects the resolver path; with a static upstream nginx round-robins all returned addresses, including the Cloudflare AAAA records the Docker bridge can't reach.
2. **Hard startup dependency on DNS.** Literal upstreams resolve at config-load. Transient failure → entire proxy aborts.
3. **Loss of TTL-based re-resolution.** Literal upstreams cache one IP per worker forever; no recovery from CDN IP rotation.

This v2 keeps the variable \`proxy_pass\` + \`resolver\` pattern, but makes the resolver **address** env-driven via the new \`PROXY_RESOLVER\`. Default \`127.0.0.11 valid=30s\` matches prior docker-compose behavior so validators see zero change. Environments without the Docker embedded DNS (e.g. ECS Fargate) override to a working DNS (VPC resolver, public DNS, etc.).

openrouter keeps \`ipv6=off\` appended after the templated resolver address, preserving the documented Cloudflare-AAAA guard.

\`/_backend_models\` stays on the literal URL approach from #177 — it specifically needs /etc/hosts pin support, which the resolver bypasses.

## Changes Made

- \`docker/proxy/nginx.conf.template\`:
  - \`/_chutes_proxy/\`: \`resolver \${PROXY_RESOLVER};\` (was \`resolver 127.0.0.11 valid=30s;\`)
  - \`/_openrouter_proxy/\`: \`resolver \${PROXY_RESOLVER} ipv6=off;\` (was \`resolver 127.0.0.11 ipv6=off valid=30s;\`)
- \`docker/proxy/Dockerfile\`: default \`PROXY_RESOLVER=127.0.0.11 valid=30s\` + envsubst the variable

## Issue Link

N/A

## Testing

- \`docker build\` succeeds
- \`nginx -t\` passes under default (no env override) — matches prior docker-compose behavior
- \`nginx -t\` passes under \`PROXY_RESOLVER="169.254.169.253 valid=30s"\` (Fargate override)

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

Default behavior is preserved end-to-end (same address, same TTL, same \`ipv6=off\` on openrouter). Validators on EC2 are unaffected.