### PR TITLE
feat(validator): drain-mode sentinel-file hook (ORO-1150)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,11 +102,7 @@ services:
       - ${HOME}/.bittensor/wallets:/root/.bittensor/wallets:ro
       - ./logs:/app/logs
       - validator-data:/root/.validator
-      # ORO-1150: drain-mode sentinel. The host orchestrator (e.g. AWS
-      # ASG drain script, k8s preStop hook, systemd timer, manual `touch`)
-      # writes to /var/run/oro-validator/drain on the host; the validator
-      # polls the same path inside the container and stops claiming new
-      # work when the file is present. See subnet/validator/drain.py.
+      # Drain-mode sentinel — host writes /drain, validator polls (ORO-1150).
       - /var/run/oro-validator:/var/run/oro-validator
     environment:
       - DOCKER_CONTEXT=default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,12 @@ services:
       - ${HOME}/.bittensor/wallets:/root/.bittensor/wallets:ro
       - ./logs:/app/logs
       - validator-data:/root/.validator
+      # ORO-1150: drain-mode sentinel. The host orchestrator (e.g. AWS
+      # ASG drain script, k8s preStop hook, systemd timer, manual `touch`)
+      # writes to /var/run/oro-validator/drain on the host; the validator
+      # polls the same path inside the container and stops claiming new
+      # work when the file is present. See subnet/validator/drain.py.
+      - /var/run/oro-validator:/var/run/oro-validator
     environment:
       - DOCKER_CONTEXT=default
       - HOST_PROJECT_DIR=${PWD}

--- a/subnet/tests/validator/test_drain_mode.py
+++ b/subnet/tests/validator/test_drain_mode.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -57,3 +58,47 @@ def test_drain_cache_ttl(
         Path(drain_file).unlink()
     now = 1000.0 + DRAIN_CACHE_TTL_SECONDS * wait_factor
     assert drain_mode_active(cache, now=now, drain_file=drain_file) is expected
+
+
+def test_main_loop_skips_claim_and_flushes_retry_queue_under_drain(
+    drain_file: str,
+) -> None:
+    """The main loop's drain branch (ORO-1150) must:
+      1. Skip backend_client.claim_work (no new work)
+      2. Skip _check_for_updates (Watchtower can't restart mid-drain)
+      3. Drive retry_queue.process_pending so completion/score reports
+         leave the node before it terminates
+      4. Bump CLAIM_WORK_TOTAL{result="draining"}
+
+    This locks the wiring: a future refactor that drops the `continue`
+    or moves the auto-update gate above the drain check will fail here.
+    """
+    Path(drain_file).touch()
+
+    backend = MagicMock()
+    retry_queue = MagicMock()
+    retry_queue.get_pending_count.return_value = 3
+    counter_inc = MagicMock()
+
+    with patch("subnet.validator.drain.DRAIN_FILE", drain_file):
+        # Re-import bound name inside the test's scope to pick up the patch.
+        from subnet.validator.drain import drain_mode_active as gate
+
+        cache: dict = {}
+
+        # Simulate ONE iteration of the loop body, with the drain check at
+        # the top and the auto-update + claim_work below.
+        if gate(cache, drain_file=drain_file):
+            counter_inc(label="draining")
+            if retry_queue.get_pending_count() > 0:
+                retry_queue.process_pending()
+        else:
+            backend.check_for_updates()
+            backend.claim_work()
+
+    # Drain branch fired:
+    counter_inc.assert_called_once_with(label="draining")
+    retry_queue.process_pending.assert_called_once()
+    # ...and the new-work / auto-update branches did NOT:
+    backend.claim_work.assert_not_called()
+    backend.check_for_updates.assert_not_called()

--- a/subnet/tests/validator/test_drain_mode.py
+++ b/subnet/tests/validator/test_drain_mode.py
@@ -1,9 +1,4 @@
-"""Tests for the validator drain-mode sentinel-file hook (ORO-1150).
-
-The hook lets any orchestrator (AWS ASG drain script, k8s preStop hook,
-systemd timer, a manual `touch`) tell the validator main loop to stop
-claiming new work while letting in-flight evals finish cleanly.
-"""
+"""Tests for the validator drain-mode sentinel-file hook (ORO-1150)."""
 
 from __future__ import annotations
 
@@ -13,7 +8,6 @@ import pytest
 
 from subnet.validator.drain import (
     DRAIN_CACHE_TTL_SECONDS,
-    DRAIN_FILE,
     drain_mode_active,
 )
 
@@ -23,66 +17,43 @@ def drain_file(tmp_path: Path) -> str:
     return str(tmp_path / "drain")
 
 
-def test_default_drain_file_constant_is_namespaced() -> None:
-    """Default sentinel path lives under a validator-owned directory so
-    operators don't accidentally collide with another process's flag."""
-    assert DRAIN_FILE.startswith("/var/run/oro-validator/")
+@pytest.mark.parametrize("present,expected", [(False, False), (True, True)])
+def test_drain_mode_reads_sentinel(drain_file: str, present: bool, expected: bool) -> None:
+    if present:
+        Path(drain_file).touch()
+    assert drain_mode_active({}, drain_file=drain_file) is expected
 
 
-def test_no_drain_file_returns_false(drain_file: str) -> None:
-    cache: dict[str, float] = {}
-    assert drain_mode_active(cache, drain_file=drain_file) is False
-
-
-def test_present_drain_file_returns_true(drain_file: str) -> None:
-    Path(drain_file).touch()
-    cache: dict[str, float] = {}
-    assert drain_mode_active(cache, drain_file=drain_file) is True
-
-
-def test_cache_skips_filesystem_check_within_ttl(drain_file: str) -> None:
-    """Within the TTL the helper must return the cached value even if the
-    file state changes — that's the entire point of the cache (keep the
-    main-loop hot path from stat()ing on every poll)."""
-    cache: dict[str, float] = {}
-    # First call: file absent, populates cache as False.
-    assert drain_mode_active(cache, now=1000.0, drain_file=drain_file) is False
-    # File appears AFTER the cache was populated.
-    Path(drain_file).touch()
-    # Within TTL: still returns cached False.
-    assert (
-        drain_mode_active(
-            cache, now=1000.0 + DRAIN_CACHE_TTL_SECONDS - 1, drain_file=drain_file
-        )
-        is False
-    )
-    # Past TTL: re-stats and picks up the new state.
-    assert (
-        drain_mode_active(
-            cache, now=1000.0 + DRAIN_CACHE_TTL_SECONDS + 1, drain_file=drain_file
-        )
-        is True
-    )
-
-
-def test_cache_picks_up_drain_clear_after_ttl(drain_file: str) -> None:
-    """The reverse — once the orchestrator removes the file, the validator
-    must come back out of drain mode on the next post-TTL check."""
-    Path(drain_file).touch()
-    cache: dict[str, float] = {}
-    assert drain_mode_active(cache, now=2000.0, drain_file=drain_file) is True
-    Path(drain_file).unlink()
-    # Still cached as True within TTL.
-    assert (
-        drain_mode_active(
-            cache, now=2000.0 + DRAIN_CACHE_TTL_SECONDS - 1, drain_file=drain_file
-        )
-        is True
-    )
-    # After TTL: returns False.
-    assert (
-        drain_mode_active(
-            cache, now=2000.0 + DRAIN_CACHE_TTL_SECONDS + 1, drain_file=drain_file
-        )
-        is False
-    )
+@pytest.mark.parametrize(
+    "starts_present,flips_to_present,wait_factor,expected",
+    [
+        # File flips on AFTER cache populated False; within TTL we still see False.
+        (False, True, 0.5, False),
+        # Same flip-on, but past TTL: re-stat picks up True.
+        (False, True, 1.5, True),
+        # File flips off AFTER cache populated True; within TTL still True.
+        (True, False, 0.5, True),
+        # Same flip-off, past TTL: re-stat picks up False.
+        (True, False, 1.5, False),
+    ],
+)
+def test_drain_cache_ttl(
+    drain_file: str,
+    starts_present: bool,
+    flips_to_present: bool,
+    wait_factor: float,
+    expected: bool,
+) -> None:
+    """Cache must keep stat() off the hot path within the TTL and pick up
+    state changes past it. Covers both flip-on (orchestrator starts drain)
+    and flip-off (orchestrator clears drain) directions."""
+    if starts_present:
+        Path(drain_file).touch()
+    cache: dict = {}
+    drain_mode_active(cache, now=1000.0, drain_file=drain_file)  # populate
+    if flips_to_present and not starts_present:
+        Path(drain_file).touch()
+    elif starts_present and not flips_to_present:
+        Path(drain_file).unlink()
+    now = 1000.0 + DRAIN_CACHE_TTL_SECONDS * wait_factor
+    assert drain_mode_active(cache, now=now, drain_file=drain_file) is expected

--- a/subnet/tests/validator/test_drain_mode.py
+++ b/subnet/tests/validator/test_drain_mode.py
@@ -7,11 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from subnet.validator.drain import (
-    DRAIN_CACHE_TTL_SECONDS,
-    drain_mode_active,
-    handle_drain_tick,
-)
+from subnet.validator.drain import drain_mode_active, handle_drain_tick
 
 
 @pytest.fixture
@@ -23,29 +19,7 @@ def drain_file(tmp_path: Path) -> str:
 def test_drain_mode_reads_sentinel(drain_file, present, expected):
     if present:
         Path(drain_file).touch()
-    assert drain_mode_active({}, drain_file=drain_file) is expected
-
-
-@pytest.mark.parametrize(
-    "starts,flips_to,wait_factor,expected",
-    [
-        (False, True, 0.5, False),  # flip-on within TTL: stale False
-        (False, True, 1.5, True),   # flip-on past TTL: re-stat picks up True
-        (True, False, 0.5, True),   # flip-off within TTL: stale True
-        (True, False, 1.5, False),  # flip-off past TTL: re-stat picks up False
-    ],
-)
-def test_drain_cache_ttl(drain_file, starts, flips_to, wait_factor, expected):
-    if starts:
-        Path(drain_file).touch()
-    cache: dict = {}
-    drain_mode_active(cache, now=1000.0, drain_file=drain_file)
-    if flips_to and not starts:
-        Path(drain_file).touch()
-    elif starts and not flips_to:
-        Path(drain_file).unlink()
-    now = 1000.0 + DRAIN_CACHE_TTL_SECONDS * wait_factor
-    assert drain_mode_active(cache, now=now, drain_file=drain_file) is expected
+    assert drain_mode_active(drain_file=drain_file) is expected
 
 
 def test_drain_mode_fails_closed_on_oserror(tmp_path):
@@ -53,7 +27,7 @@ def test_drain_mode_fails_closed_on_oserror(tmp_path):
     parent = tmp_path / "nope"
     parent.write_text("not a directory")  # NotADirectoryError on stat()
     with patch("subnet.validator.drain.logging") as log:
-        assert drain_mode_active({}, drain_file=str(parent / "drain")) is True
+        assert drain_mode_active(drain_file=str(parent / "drain")) is True
         assert any("fail-CLOSED" in str(c) for c in log.warning.call_args_list)
 
 

--- a/subnet/tests/validator/test_drain_mode.py
+++ b/subnet/tests/validator/test_drain_mode.py
@@ -10,6 +10,7 @@ import pytest
 from subnet.validator.drain import (
     DRAIN_CACHE_TTL_SECONDS,
     drain_mode_active,
+    handle_drain_tick,
 )
 
 
@@ -60,45 +61,112 @@ def test_drain_cache_ttl(
     assert drain_mode_active(cache, now=now, drain_file=drain_file) is expected
 
 
-def test_main_loop_skips_claim_and_flushes_retry_queue_under_drain(
-    drain_file: str,
+@pytest.fixture
+def fake_retry_queue():
+    rq = MagicMock()
+    rq.get_pending_count.return_value = 3
+    return rq
+
+
+def test_handle_drain_tick_returns_true_and_flushes_no_burn(
+    drain_file: str, fake_retry_queue
 ) -> None:
-    """The main loop's drain branch (ORO-1150) must:
-      1. Skip backend_client.claim_work (no new work)
-      2. Skip _check_for_updates (Watchtower can't restart mid-drain)
-      3. Drive retry_queue.process_pending so completion/score reports
-         leave the node before it terminates
-      4. Bump CLAIM_WORK_TOTAL{result="draining"}
-
-    This locks the wiring: a future refactor that drops the `continue`
-    or moves the auto-update gate above the drain check will fail here.
-    """
+    """Sentinel present → return True (caller short-circuits), flush
+    retry_queue with count_attempts=False so a multi-minute drain +
+    transient outage doesn't drop reports, increment metric, log-once
+    on entry. Second tick under same drain must NOT log again."""
     Path(drain_file).touch()
+    metric = MagicMock()
+    sleeps: list[float] = []
+    state: dict = {}
 
-    backend = MagicMock()
-    retry_queue = MagicMock()
-    retry_queue.get_pending_count.return_value = 3
-    counter_inc = MagicMock()
+    with patch("subnet.validator.drain.logging") as log:
+        assert (
+            handle_drain_tick(
+                state,
+                fake_retry_queue,
+                poll_interval=0.0,
+                metric_counter=metric,
+                sleep_fn=sleeps.append,
+                drain_file=drain_file,
+            )
+            is True
+        )
+        assert state["logged"] is True
+        metric.inc.assert_called_once()
+        fake_retry_queue.process_pending.assert_called_once_with(count_attempts=False)
+        assert sleeps == [0.0]
+        entry_logs = [c for c in log.info.call_args_list if "present" in str(c)]
+        assert len(entry_logs) == 1
 
-    with patch("subnet.validator.drain.DRAIN_FILE", drain_file):
-        # Re-import bound name inside the test's scope to pick up the patch.
-        from subnet.validator.drain import drain_mode_active as gate
+        # Second tick, same drain → still True, no second entry log.
+        assert (
+            handle_drain_tick(
+                state,
+                fake_retry_queue,
+                poll_interval=0.0,
+                metric_counter=metric,
+                sleep_fn=sleeps.append,
+                # Bypass TTL by advancing now past cache window.
+                now=10_000.0,
+                drain_file=drain_file,
+            )
+            is True
+        )
+        entry_logs = [c for c in log.info.call_args_list if "present" in str(c)]
+        assert len(entry_logs) == 1
 
-        cache: dict = {}
 
-        # Simulate ONE iteration of the loop body, with the drain check at
-        # the top and the auto-update + claim_work below.
-        if gate(cache, drain_file=drain_file):
-            counter_inc(label="draining")
-            if retry_queue.get_pending_count() > 0:
-                retry_queue.process_pending()
-        else:
-            backend.check_for_updates()
-            backend.claim_work()
+def test_handle_drain_tick_returns_false_when_sentinel_absent(
+    drain_file: str, fake_retry_queue
+) -> None:
+    """No sentinel → return False so the caller proceeds to claim_work.
+    No retry flush, no metric tick, no sleep."""
+    metric = MagicMock()
+    sleeps: list[float] = []
+    assert (
+        handle_drain_tick(
+            {},
+            fake_retry_queue,
+            poll_interval=0.0,
+            metric_counter=metric,
+            sleep_fn=sleeps.append,
+            drain_file=drain_file,
+        )
+        is False
+    )
+    metric.inc.assert_not_called()
+    fake_retry_queue.process_pending.assert_not_called()
+    assert sleeps == []
 
-    # Drain branch fired:
-    counter_inc.assert_called_once_with(label="draining")
-    retry_queue.process_pending.assert_called_once()
-    # ...and the new-work / auto-update branches did NOT:
-    backend.claim_work.assert_not_called()
-    backend.check_for_updates.assert_not_called()
+
+def test_handle_drain_tick_logs_resume_on_clear(drain_file: str, fake_retry_queue) -> None:
+    """Sentinel was present (logged=True) → cleared between ticks →
+    resume-log fires once and logged flips back to False."""
+    state: dict = {"logged": True}
+    with patch("subnet.validator.drain.logging") as log:
+        assert (
+            handle_drain_tick(
+                state,
+                fake_retry_queue,
+                poll_interval=0.0,
+                metric_counter=MagicMock(),
+                sleep_fn=lambda _: None,
+                drain_file=drain_file,
+            )
+            is False
+        )
+        assert state["logged"] is False
+        cleared = [c for c in log.info.call_args_list if "cleared" in str(c)]
+        assert len(cleared) == 1
+
+
+def test_drain_mode_active_fails_closed_on_eacces(tmp_path: Path) -> None:
+    """Mount-misconfig (OSError on stat) → fail-CLOSED (return True) +
+    surface a WARNING. Prevents the silent-keep-claiming failure mode."""
+    parent = tmp_path / "nope"
+    parent.write_text("not a directory")  # NotADirectoryError on stat()
+    bad_path = str(parent / "drain")
+    with patch("subnet.validator.drain.logging") as log:
+        assert drain_mode_active({}, drain_file=bad_path) is True
+        assert any("fail-CLOSED" in str(c) for c in log.warning.call_args_list)

--- a/subnet/tests/validator/test_drain_mode.py
+++ b/subnet/tests/validator/test_drain_mode.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from subnet.validator.drain import drain_mode_active, handle_drain_tick
+from validator.drain import drain_mode_active, handle_drain_tick
 
 
 @pytest.fixture
@@ -26,7 +26,7 @@ def test_drain_mode_fails_closed_on_oserror(tmp_path):
     """Mount-misconfig → fail-CLOSED + WARNING (prevents silent-claim)."""
     parent = tmp_path / "nope"
     parent.write_text("not a directory")  # NotADirectoryError on stat()
-    with patch("subnet.validator.drain.logging") as log:
+    with patch("validator.drain.logging") as log:
         assert drain_mode_active(drain_file=str(parent / "drain")) is True
         assert any("fail-CLOSED" in str(c) for c in log.warning.call_args_list)
 
@@ -37,8 +37,8 @@ def test_handle_drain_tick_draining_flushes_no_burn(drain_file):
     rq = MagicMock()
     rq.get_pending_count.return_value = 3
     state: dict = {}
-    with patch("subnet.validator.metrics.DRAIN_TICKS_TOTAL") as metric, patch(
-        "subnet.validator.drain.logging"
+    with patch("validator.metrics.DRAIN_TICKS_TOTAL") as metric, patch(
+        "validator.drain.logging"
     ) as log:
         for _ in range(2):
             assert handle_drain_tick(state, rq, 0.0, drain_file=drain_file) is True
@@ -51,7 +51,7 @@ def test_handle_drain_tick_draining_flushes_no_burn(drain_file):
 
 def test_handle_drain_tick_absent_passes_through(drain_file):
     rq = MagicMock()
-    with patch("subnet.validator.metrics.DRAIN_TICKS_TOTAL") as metric:
+    with patch("validator.metrics.DRAIN_TICKS_TOTAL") as metric:
         assert handle_drain_tick({}, rq, 0.0, drain_file=drain_file) is False
         metric.inc.assert_not_called()
         rq.process_pending.assert_not_called()
@@ -59,7 +59,7 @@ def test_handle_drain_tick_absent_passes_through(drain_file):
 
 def test_handle_drain_tick_logs_resume_on_clear(drain_file):
     state = {"logged": True}
-    with patch("subnet.validator.drain.logging") as log:
+    with patch("validator.drain.logging") as log:
         assert handle_drain_tick(state, MagicMock(), 0.0, drain_file=drain_file) is False
         assert state["logged"] is False
         assert any("cleared" in str(c) for c in log.info.call_args_list)

--- a/subnet/tests/validator/test_drain_mode.py
+++ b/subnet/tests/validator/test_drain_mode.py
@@ -37,7 +37,7 @@ def test_handle_drain_tick_draining_flushes_no_burn(drain_file):
     rq = MagicMock()
     rq.get_pending_count.return_value = 3
     state: dict = {}
-    with patch("subnet.validator.drain.DRAIN_TICKS_TOTAL") as metric, patch(
+    with patch("subnet.validator.metrics.DRAIN_TICKS_TOTAL") as metric, patch(
         "subnet.validator.drain.logging"
     ) as log:
         for _ in range(2):
@@ -51,7 +51,7 @@ def test_handle_drain_tick_draining_flushes_no_burn(drain_file):
 
 def test_handle_drain_tick_absent_passes_through(drain_file):
     rq = MagicMock()
-    with patch("subnet.validator.drain.DRAIN_TICKS_TOTAL") as metric:
+    with patch("subnet.validator.metrics.DRAIN_TICKS_TOTAL") as metric:
         assert handle_drain_tick({}, rq, 0.0, drain_file=drain_file) is False
         metric.inc.assert_not_called()
         rq.process_pending.assert_not_called()

--- a/subnet/tests/validator/test_drain_mode.py
+++ b/subnet/tests/validator/test_drain_mode.py
@@ -1,4 +1,4 @@
-"""Tests for the validator drain-mode sentinel-file hook (ORO-1150)."""
+"""Tests for the validator drain-mode hook (ORO-1150)."""
 
 from __future__ import annotations
 
@@ -20,153 +20,72 @@ def drain_file(tmp_path: Path) -> str:
 
 
 @pytest.mark.parametrize("present,expected", [(False, False), (True, True)])
-def test_drain_mode_reads_sentinel(drain_file: str, present: bool, expected: bool) -> None:
+def test_drain_mode_reads_sentinel(drain_file, present, expected):
     if present:
         Path(drain_file).touch()
     assert drain_mode_active({}, drain_file=drain_file) is expected
 
 
 @pytest.mark.parametrize(
-    "starts_present,flips_to_present,wait_factor,expected",
+    "starts,flips_to,wait_factor,expected",
     [
-        # File flips on AFTER cache populated False; within TTL we still see False.
-        (False, True, 0.5, False),
-        # Same flip-on, but past TTL: re-stat picks up True.
-        (False, True, 1.5, True),
-        # File flips off AFTER cache populated True; within TTL still True.
-        (True, False, 0.5, True),
-        # Same flip-off, past TTL: re-stat picks up False.
-        (True, False, 1.5, False),
+        (False, True, 0.5, False),  # flip-on within TTL: stale False
+        (False, True, 1.5, True),   # flip-on past TTL: re-stat picks up True
+        (True, False, 0.5, True),   # flip-off within TTL: stale True
+        (True, False, 1.5, False),  # flip-off past TTL: re-stat picks up False
     ],
 )
-def test_drain_cache_ttl(
-    drain_file: str,
-    starts_present: bool,
-    flips_to_present: bool,
-    wait_factor: float,
-    expected: bool,
-) -> None:
-    """Cache must keep stat() off the hot path within the TTL and pick up
-    state changes past it. Covers both flip-on (orchestrator starts drain)
-    and flip-off (orchestrator clears drain) directions."""
-    if starts_present:
+def test_drain_cache_ttl(drain_file, starts, flips_to, wait_factor, expected):
+    if starts:
         Path(drain_file).touch()
     cache: dict = {}
-    drain_mode_active(cache, now=1000.0, drain_file=drain_file)  # populate
-    if flips_to_present and not starts_present:
+    drain_mode_active(cache, now=1000.0, drain_file=drain_file)
+    if flips_to and not starts:
         Path(drain_file).touch()
-    elif starts_present and not flips_to_present:
+    elif starts and not flips_to:
         Path(drain_file).unlink()
     now = 1000.0 + DRAIN_CACHE_TTL_SECONDS * wait_factor
     assert drain_mode_active(cache, now=now, drain_file=drain_file) is expected
 
 
-@pytest.fixture
-def fake_retry_queue():
-    rq = MagicMock()
-    rq.get_pending_count.return_value = 3
-    return rq
-
-
-def test_handle_drain_tick_returns_true_and_flushes_no_burn(
-    drain_file: str, fake_retry_queue
-) -> None:
-    """Sentinel present → return True (caller short-circuits), flush
-    retry_queue with count_attempts=False so a multi-minute drain +
-    transient outage doesn't drop reports, increment metric, log-once
-    on entry. Second tick under same drain must NOT log again."""
-    Path(drain_file).touch()
-    metric = MagicMock()
-    sleeps: list[float] = []
-    state: dict = {}
-
-    with patch("subnet.validator.drain.logging") as log:
-        assert (
-            handle_drain_tick(
-                state,
-                fake_retry_queue,
-                poll_interval=0.0,
-                metric_counter=metric,
-                sleep_fn=sleeps.append,
-                drain_file=drain_file,
-            )
-            is True
-        )
-        assert state["logged"] is True
-        metric.inc.assert_called_once()
-        fake_retry_queue.process_pending.assert_called_once_with(count_attempts=False)
-        assert sleeps == [0.0]
-        entry_logs = [c for c in log.info.call_args_list if "present" in str(c)]
-        assert len(entry_logs) == 1
-
-        # Second tick, same drain → still True, no second entry log.
-        assert (
-            handle_drain_tick(
-                state,
-                fake_retry_queue,
-                poll_interval=0.0,
-                metric_counter=metric,
-                sleep_fn=sleeps.append,
-                # Bypass TTL by advancing now past cache window.
-                now=10_000.0,
-                drain_file=drain_file,
-            )
-            is True
-        )
-        entry_logs = [c for c in log.info.call_args_list if "present" in str(c)]
-        assert len(entry_logs) == 1
-
-
-def test_handle_drain_tick_returns_false_when_sentinel_absent(
-    drain_file: str, fake_retry_queue
-) -> None:
-    """No sentinel → return False so the caller proceeds to claim_work.
-    No retry flush, no metric tick, no sleep."""
-    metric = MagicMock()
-    sleeps: list[float] = []
-    assert (
-        handle_drain_tick(
-            {},
-            fake_retry_queue,
-            poll_interval=0.0,
-            metric_counter=metric,
-            sleep_fn=sleeps.append,
-            drain_file=drain_file,
-        )
-        is False
-    )
-    metric.inc.assert_not_called()
-    fake_retry_queue.process_pending.assert_not_called()
-    assert sleeps == []
-
-
-def test_handle_drain_tick_logs_resume_on_clear(drain_file: str, fake_retry_queue) -> None:
-    """Sentinel was present (logged=True) → cleared between ticks →
-    resume-log fires once and logged flips back to False."""
-    state: dict = {"logged": True}
-    with patch("subnet.validator.drain.logging") as log:
-        assert (
-            handle_drain_tick(
-                state,
-                fake_retry_queue,
-                poll_interval=0.0,
-                metric_counter=MagicMock(),
-                sleep_fn=lambda _: None,
-                drain_file=drain_file,
-            )
-            is False
-        )
-        assert state["logged"] is False
-        cleared = [c for c in log.info.call_args_list if "cleared" in str(c)]
-        assert len(cleared) == 1
-
-
-def test_drain_mode_active_fails_closed_on_eacces(tmp_path: Path) -> None:
-    """Mount-misconfig (OSError on stat) → fail-CLOSED (return True) +
-    surface a WARNING. Prevents the silent-keep-claiming failure mode."""
+def test_drain_mode_fails_closed_on_oserror(tmp_path):
+    """Mount-misconfig → fail-CLOSED + WARNING (prevents silent-claim)."""
     parent = tmp_path / "nope"
     parent.write_text("not a directory")  # NotADirectoryError on stat()
-    bad_path = str(parent / "drain")
     with patch("subnet.validator.drain.logging") as log:
-        assert drain_mode_active({}, drain_file=bad_path) is True
+        assert drain_mode_active({}, drain_file=str(parent / "drain")) is True
         assert any("fail-CLOSED" in str(c) for c in log.warning.call_args_list)
+
+
+def test_handle_drain_tick_draining_flushes_no_burn(drain_file):
+    """Sentinel present → True, no-burn flush, metric tick, log-once."""
+    Path(drain_file).touch()
+    rq = MagicMock()
+    rq.get_pending_count.return_value = 3
+    state: dict = {}
+    with patch("subnet.validator.drain.DRAIN_TICKS_TOTAL") as metric, patch(
+        "subnet.validator.drain.logging"
+    ) as log:
+        for _ in range(2):
+            assert handle_drain_tick(state, rq, 0.0, drain_file=drain_file) is True
+        assert metric.inc.call_count == 2
+        assert rq.process_pending.call_count == 2
+        rq.process_pending.assert_called_with(count_attempts=False)
+        entry = [c for c in log.info.call_args_list if "present" in str(c)]
+        assert len(entry) == 1
+
+
+def test_handle_drain_tick_absent_passes_through(drain_file):
+    rq = MagicMock()
+    with patch("subnet.validator.drain.DRAIN_TICKS_TOTAL") as metric:
+        assert handle_drain_tick({}, rq, 0.0, drain_file=drain_file) is False
+        metric.inc.assert_not_called()
+        rq.process_pending.assert_not_called()
+
+
+def test_handle_drain_tick_logs_resume_on_clear(drain_file):
+    state = {"logged": True}
+    with patch("subnet.validator.drain.logging") as log:
+        assert handle_drain_tick(state, MagicMock(), 0.0, drain_file=drain_file) is False
+        assert state["logged"] is False
+        assert any("cleared" in str(c) for c in log.info.call_args_list)

--- a/subnet/tests/validator/test_drain_mode.py
+++ b/subnet/tests/validator/test_drain_mode.py
@@ -1,0 +1,88 @@
+"""Tests for the validator drain-mode sentinel-file hook (ORO-1150).
+
+The hook lets any orchestrator (AWS ASG drain script, k8s preStop hook,
+systemd timer, a manual `touch`) tell the validator main loop to stop
+claiming new work while letting in-flight evals finish cleanly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from subnet.validator.drain import (
+    DRAIN_CACHE_TTL_SECONDS,
+    DRAIN_FILE,
+    drain_mode_active,
+)
+
+
+@pytest.fixture
+def drain_file(tmp_path: Path) -> str:
+    return str(tmp_path / "drain")
+
+
+def test_default_drain_file_constant_is_namespaced() -> None:
+    """Default sentinel path lives under a validator-owned directory so
+    operators don't accidentally collide with another process's flag."""
+    assert DRAIN_FILE.startswith("/var/run/oro-validator/")
+
+
+def test_no_drain_file_returns_false(drain_file: str) -> None:
+    cache: dict[str, float] = {}
+    assert drain_mode_active(cache, drain_file=drain_file) is False
+
+
+def test_present_drain_file_returns_true(drain_file: str) -> None:
+    Path(drain_file).touch()
+    cache: dict[str, float] = {}
+    assert drain_mode_active(cache, drain_file=drain_file) is True
+
+
+def test_cache_skips_filesystem_check_within_ttl(drain_file: str) -> None:
+    """Within the TTL the helper must return the cached value even if the
+    file state changes — that's the entire point of the cache (keep the
+    main-loop hot path from stat()ing on every poll)."""
+    cache: dict[str, float] = {}
+    # First call: file absent, populates cache as False.
+    assert drain_mode_active(cache, now=1000.0, drain_file=drain_file) is False
+    # File appears AFTER the cache was populated.
+    Path(drain_file).touch()
+    # Within TTL: still returns cached False.
+    assert (
+        drain_mode_active(
+            cache, now=1000.0 + DRAIN_CACHE_TTL_SECONDS - 1, drain_file=drain_file
+        )
+        is False
+    )
+    # Past TTL: re-stats and picks up the new state.
+    assert (
+        drain_mode_active(
+            cache, now=1000.0 + DRAIN_CACHE_TTL_SECONDS + 1, drain_file=drain_file
+        )
+        is True
+    )
+
+
+def test_cache_picks_up_drain_clear_after_ttl(drain_file: str) -> None:
+    """The reverse — once the orchestrator removes the file, the validator
+    must come back out of drain mode on the next post-TTL check."""
+    Path(drain_file).touch()
+    cache: dict[str, float] = {}
+    assert drain_mode_active(cache, now=2000.0, drain_file=drain_file) is True
+    Path(drain_file).unlink()
+    # Still cached as True within TTL.
+    assert (
+        drain_mode_active(
+            cache, now=2000.0 + DRAIN_CACHE_TTL_SECONDS - 1, drain_file=drain_file
+        )
+        is True
+    )
+    # After TTL: returns False.
+    assert (
+        drain_mode_active(
+            cache, now=2000.0 + DRAIN_CACHE_TTL_SECONDS + 1, drain_file=drain_file
+        )
+        is False
+    )

--- a/subnet/validator/drain.py
+++ b/subnet/validator/drain.py
@@ -1,49 +1,30 @@
 """Drain-mode sentinel-file hook for the validator main loop (ORO-1150).
 
-When the operator wants this validator to stop claiming NEW work but finish
-any in-flight evals (e.g. before stopping the container, before an
-autoscaling group terminates the host, before a planned maintenance window),
-they create the sentinel file. The main loop checks for it once per claim
-attempt and, when present, skips the claim and sleeps instead.
-
-The mechanism is intentionally generic — any orchestrator (systemd timer,
-k8s preStop hook, AWS ASG lifecycle drain script, manual `touch`) can flip
-it. The orchestrator clears the file (or removes it / lets the container
-restart) to take the validator back out of drain mode.
-
-Path is overridable via ``ORO_DRAIN_FILE`` env var for non-default container
-layouts.
+Touch ``DRAIN_FILE`` to make the validator stop claiming new work but keep
+finishing in-flight evals. Remove it to resume. Path is overridable via
+``ORO_DRAIN_FILE``. The orchestrator (AWS ASG drain script, k8s preStop
+hook, manual touch) writes the file; the validator polls it.
 """
 
 from __future__ import annotations
 
 import os
 import time
-from typing import Optional
 
 DRAIN_FILE = os.environ.get("ORO_DRAIN_FILE", "/var/run/oro-validator/drain")
-# Cache drain-file existence check briefly so the main loop doesn't stat() on
-# every iteration when poll_interval is short.
 DRAIN_CACHE_TTL_SECONDS = 10
 
 
 def drain_mode_active(
-    cache: dict[str, float],
-    *,
-    now: Optional[float] = None,
-    drain_file: str = DRAIN_FILE,
+    cache: dict, *, now: float | None = None, drain_file: str = DRAIN_FILE
 ) -> bool:
-    """Return True iff the validator should stop claiming new work.
-
-    ``cache`` is a single-entry dict the caller persists across calls — keeps
-    ``os.path.exists`` cost off the hot path. Mutated in place.
-
-    ``now`` and ``drain_file`` are injectable for tests.
+    """True iff ``drain_file`` exists. ``cache`` is a dict the caller persists
+    across calls; ``os.path.exists`` runs at most once per
+    ``DRAIN_CACHE_TTL_SECONDS``. ``now`` is injectable for tests.
     """
     t = time.time() if now is None else now
     if t - cache.get("checked_at", 0.0) < DRAIN_CACHE_TTL_SECONDS:
         return bool(cache.get("active", False))
-    active = os.path.exists(drain_file)
     cache["checked_at"] = t
-    cache["active"] = active
+    cache["active"] = active = os.path.exists(drain_file)
     return active

--- a/subnet/validator/drain.py
+++ b/subnet/validator/drain.py
@@ -10,8 +10,6 @@ import logging
 import os
 import time
 
-from .metrics import DRAIN_TICKS_TOTAL
-
 DRAIN_FILE = os.environ.get("ORO_DRAIN_FILE", "/var/run/oro-validator/drain")
 
 
@@ -46,6 +44,11 @@ def handle_drain_tick(
         if not state.get("logged"):
             logging.info("Drain sentinel present — pausing claim_work")
             state["logged"] = True
+        # Lazy import: module-level import triggers dual-registration when
+        # test_auto_update imports via `validator.metrics` while this file
+        # imports via `subnet.validator.metrics`.
+        from .metrics import DRAIN_TICKS_TOTAL
+
         DRAIN_TICKS_TOTAL.inc()
         if retry_queue.get_pending_count() > 0:
             retry_queue.process_pending(count_attempts=False)

--- a/subnet/validator/drain.py
+++ b/subnet/validator/drain.py
@@ -13,8 +13,10 @@ detection isn't a goal — race-scale-down drain tolerates ~10-15s.
 
 from __future__ import annotations
 
+import logging
 import os
 import time
+from typing import Callable, Protocol
 
 DRAIN_FILE = os.environ.get("ORO_DRAIN_FILE", "/var/run/oro-validator/drain")
 DRAIN_CACHE_TTL_SECONDS = 10
@@ -23,13 +25,89 @@ DRAIN_CACHE_TTL_SECONDS = 10
 def drain_mode_active(
     cache: dict, *, now: float | None = None, drain_file: str = DRAIN_FILE
 ) -> bool:
-    """True iff ``drain_file`` exists. ``cache`` is a dict the caller persists
-    across calls; ``os.path.exists`` runs at most once per
-    ``DRAIN_CACHE_TTL_SECONDS``. ``now`` is injectable for tests.
+    """True iff ``drain_file`` exists, OR the path is unreadable.
+
+    Fail-CLOSED on EACCES / ENOTDIR / missing-mount because the alternative
+    — silently keep claiming work while the orchestrator thinks we're
+    draining — is the worse failure mode (the exact ABANDON scenario this
+    feature exists to prevent). Operators see a WARNING in container logs
+    on the first unreadable check, so a misconfigured control path is
+    observable rather than silent.
+
+    ``cache`` is a dict the caller persists across calls; ``os.stat`` runs
+    at most once per ``DRAIN_CACHE_TTL_SECONDS``. ``now`` is injectable
+    for tests.
     """
     t = time.time() if now is None else now
     if t - cache.get("checked_at", 0.0) < DRAIN_CACHE_TTL_SECONDS:
         return bool(cache.get("active", False))
     cache["checked_at"] = t
-    cache["active"] = active = os.path.exists(drain_file)
+    try:
+        os.stat(drain_file)
+        active = True
+    except FileNotFoundError:
+        active = False
+    except OSError as e:
+        # Wrong ownership/mode on the bind-mount dir, mount missing,
+        # parent path replaced by a file, etc. Treat as draining and
+        # surface the misconfiguration.
+        logging.warning(
+            f"Drain sentinel path unreadable ({type(e).__name__}: {e}) — "
+            "fail-CLOSED, treating as draining. Check the host bind mount "
+            "and ownership on the parent directory."
+        )
+        active = True
+    cache["active"] = active
     return active
+
+
+class _RetryQueue(Protocol):
+    def get_pending_count(self) -> int: ...
+    def process_pending(self, *, count_attempts: bool = ...) -> None: ...
+
+
+def handle_drain_tick(
+    state: dict,
+    retry_queue: _RetryQueue,
+    poll_interval: float,
+    *,
+    metric_counter=None,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    now: float | None = None,
+    drain_file: str = DRAIN_FILE,
+) -> bool:
+    """Inspect the drain sentinel and decide whether the main-loop tick
+    should short-circuit (ORO-1150).
+
+    Returns True iff drain mode is active — caller should `continue`,
+    skipping claim_work, auto-update, and in-flight bookkeeping. False
+    lets the rest of the loop body run normally.
+
+    ``state`` is a dict the caller persists across calls — holds both the
+    ``drain_mode_active`` cache and the ``logged`` flag for log-once
+    transitions. ``metric_counter`` is the dedicated drain-tick counter
+    (kept separate from CLAIM_WORK_TOTAL so claim-success dashboards
+    aren't skewed by drain windows). ``sleep_fn`` and ``now`` are
+    injectable for tests.
+
+    Retry-queue flush uses ``count_attempts=False`` so a multi-minute
+    drain plus a coincident backend transient can't permanently drop
+    pending completion/score reports before instance termination.
+    """
+    if drain_mode_active(state, now=now, drain_file=drain_file):
+        if not state.get("logged"):
+            logging.info(
+                "Drain sentinel present — skipping new claim_work; "
+                "in-flight evals finish normally, auto-update suppressed"
+            )
+            state["logged"] = True
+        if metric_counter is not None:
+            metric_counter.inc()
+        if retry_queue.get_pending_count() > 0:
+            retry_queue.process_pending(count_attempts=False)
+        sleep_fn(poll_interval)
+        return True
+    if state.get("logged"):
+        logging.info("Drain sentinel cleared — resuming claim_work")
+        state["logged"] = False
+    return False

--- a/subnet/validator/drain.py
+++ b/subnet/validator/drain.py
@@ -13,32 +13,24 @@ import time
 from .metrics import DRAIN_TICKS_TOTAL
 
 DRAIN_FILE = os.environ.get("ORO_DRAIN_FILE", "/var/run/oro-validator/drain")
-DRAIN_CACHE_TTL_SECONDS = 10
 
 
-def drain_mode_active(
-    cache: dict, *, now: float | None = None, drain_file: str = DRAIN_FILE
-) -> bool:
+def drain_mode_active(*, drain_file: str = DRAIN_FILE) -> bool:
     """True iff drain_file exists. Fail-CLOSED on unreadable path
     (EACCES / ENOTDIR / missing mount) — silently claiming work while
     the orchestrator thinks we're draining is the worse failure mode.
     """
-    t = time.time() if now is None else now
-    if t - cache.get("checked_at", 0.0) < DRAIN_CACHE_TTL_SECONDS:
-        return bool(cache.get("active", False))
-    cache["checked_at"] = t
     try:
         os.stat(drain_file)
-        cache["active"] = True
+        return True
     except FileNotFoundError:
-        cache["active"] = False
+        return False
     except OSError as e:
         logging.warning(
             f"Drain sentinel path unreadable ({type(e).__name__}: {e}) — "
             "fail-CLOSED. Check the host bind mount."
         )
-        cache["active"] = True
-    return cache["active"]
+        return True
 
 
 def handle_drain_tick(
@@ -50,7 +42,7 @@ def handle_drain_tick(
     coincident backend transient can't burn retry budget on reports we
     haven't actually given up on.
     """
-    if drain_mode_active(state, drain_file=drain_file):
+    if drain_mode_active(drain_file=drain_file):
         if not state.get("logged"):
             logging.info("Drain sentinel present — pausing claim_work")
             state["logged"] = True

--- a/subnet/validator/drain.py
+++ b/subnet/validator/drain.py
@@ -4,6 +4,11 @@ Touch ``DRAIN_FILE`` to make the validator stop claiming new work but keep
 finishing in-flight evals. Remove it to resume. Path is overridable via
 ``ORO_DRAIN_FILE``. The orchestrator (AWS ASG drain script, k8s preStop
 hook, manual touch) writes the file; the validator polls it.
+
+Detection latency upper bound: ``DRAIN_CACHE_TTL_SECONDS`` (cache age) +
+the main loop's ``poll_interval`` (next claim opportunity). In the worst
+case a long claim_work response can extend this further. Sub-second
+detection isn't a goal — race-scale-down drain tolerates ~10-15s.
 """
 
 from __future__ import annotations

--- a/subnet/validator/drain.py
+++ b/subnet/validator/drain.py
@@ -1,0 +1,49 @@
+"""Drain-mode sentinel-file hook for the validator main loop (ORO-1150).
+
+When the operator wants this validator to stop claiming NEW work but finish
+any in-flight evals (e.g. before stopping the container, before an
+autoscaling group terminates the host, before a planned maintenance window),
+they create the sentinel file. The main loop checks for it once per claim
+attempt and, when present, skips the claim and sleeps instead.
+
+The mechanism is intentionally generic — any orchestrator (systemd timer,
+k8s preStop hook, AWS ASG lifecycle drain script, manual `touch`) can flip
+it. The orchestrator clears the file (or removes it / lets the container
+restart) to take the validator back out of drain mode.
+
+Path is overridable via ``ORO_DRAIN_FILE`` env var for non-default container
+layouts.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Optional
+
+DRAIN_FILE = os.environ.get("ORO_DRAIN_FILE", "/var/run/oro-validator/drain")
+# Cache drain-file existence check briefly so the main loop doesn't stat() on
+# every iteration when poll_interval is short.
+DRAIN_CACHE_TTL_SECONDS = 10
+
+
+def drain_mode_active(
+    cache: dict[str, float],
+    *,
+    now: Optional[float] = None,
+    drain_file: str = DRAIN_FILE,
+) -> bool:
+    """Return True iff the validator should stop claiming new work.
+
+    ``cache`` is a single-entry dict the caller persists across calls — keeps
+    ``os.path.exists`` cost off the hot path. Mutated in place.
+
+    ``now`` and ``drain_file`` are injectable for tests.
+    """
+    t = time.time() if now is None else now
+    if t - cache.get("checked_at", 0.0) < DRAIN_CACHE_TTL_SECONDS:
+        return bool(cache.get("active", False))
+    active = os.path.exists(drain_file)
+    cache["checked_at"] = t
+    cache["active"] = active
+    return active

--- a/subnet/validator/drain.py
+++ b/subnet/validator/drain.py
@@ -1,14 +1,7 @@
-"""Drain-mode sentinel-file hook for the validator main loop (ORO-1150).
+"""Drain-mode sentinel-file hook (ORO-1150).
 
-Touch ``DRAIN_FILE`` to make the validator stop claiming new work but keep
-finishing in-flight evals. Remove it to resume. Path is overridable via
-``ORO_DRAIN_FILE``. The orchestrator (AWS ASG drain script, k8s preStop
-hook, manual touch) writes the file; the validator polls it.
-
-Detection latency upper bound: ``DRAIN_CACHE_TTL_SECONDS`` (cache age) +
-the main loop's ``poll_interval`` (next claim opportunity). In the worst
-case a long claim_work response can extend this further. Sub-second
-detection isn't a goal — race-scale-down drain tolerates ~10-15s.
+Touch DRAIN_FILE to stop new claim_work while in-flight evals finish.
+Remove to resume. Path override: ORO_DRAIN_FILE.
 """
 
 from __future__ import annotations
@@ -16,7 +9,8 @@ from __future__ import annotations
 import logging
 import os
 import time
-from typing import Callable, Protocol
+
+from .metrics import DRAIN_TICKS_TOTAL
 
 DRAIN_FILE = os.environ.get("ORO_DRAIN_FILE", "/var/run/oro-validator/drain")
 DRAIN_CACHE_TTL_SECONDS = 10
@@ -25,18 +19,9 @@ DRAIN_CACHE_TTL_SECONDS = 10
 def drain_mode_active(
     cache: dict, *, now: float | None = None, drain_file: str = DRAIN_FILE
 ) -> bool:
-    """True iff ``drain_file`` exists, OR the path is unreadable.
-
-    Fail-CLOSED on EACCES / ENOTDIR / missing-mount because the alternative
-    — silently keep claiming work while the orchestrator thinks we're
-    draining — is the worse failure mode (the exact ABANDON scenario this
-    feature exists to prevent). Operators see a WARNING in container logs
-    on the first unreadable check, so a misconfigured control path is
-    observable rather than silent.
-
-    ``cache`` is a dict the caller persists across calls; ``os.stat`` runs
-    at most once per ``DRAIN_CACHE_TTL_SECONDS``. ``now`` is injectable
-    for tests.
+    """True iff drain_file exists. Fail-CLOSED on unreadable path
+    (EACCES / ENOTDIR / missing mount) — silently claiming work while
+    the orchestrator thinks we're draining is the worse failure mode.
     """
     t = time.time() if now is None else now
     if t - cache.get("checked_at", 0.0) < DRAIN_CACHE_TTL_SECONDS:
@@ -44,68 +29,35 @@ def drain_mode_active(
     cache["checked_at"] = t
     try:
         os.stat(drain_file)
-        active = True
+        cache["active"] = True
     except FileNotFoundError:
-        active = False
+        cache["active"] = False
     except OSError as e:
-        # Wrong ownership/mode on the bind-mount dir, mount missing,
-        # parent path replaced by a file, etc. Treat as draining and
-        # surface the misconfiguration.
         logging.warning(
             f"Drain sentinel path unreadable ({type(e).__name__}: {e}) — "
-            "fail-CLOSED, treating as draining. Check the host bind mount "
-            "and ownership on the parent directory."
+            "fail-CLOSED. Check the host bind mount."
         )
-        active = True
-    cache["active"] = active
-    return active
-
-
-class _RetryQueue(Protocol):
-    def get_pending_count(self) -> int: ...
-    def process_pending(self, *, count_attempts: bool = ...) -> None: ...
+        cache["active"] = True
+    return cache["active"]
 
 
 def handle_drain_tick(
-    state: dict,
-    retry_queue: _RetryQueue,
-    poll_interval: float,
-    *,
-    metric_counter=None,
-    sleep_fn: Callable[[float], None] = time.sleep,
-    now: float | None = None,
-    drain_file: str = DRAIN_FILE,
+    state: dict, retry_queue, poll_interval: float, *, drain_file: str = DRAIN_FILE
 ) -> bool:
-    """Inspect the drain sentinel and decide whether the main-loop tick
-    should short-circuit (ORO-1150).
+    """Return True iff caller should ``continue`` the main-loop tick.
 
-    Returns True iff drain mode is active — caller should `continue`,
-    skipping claim_work, auto-update, and in-flight bookkeeping. False
-    lets the rest of the loop body run normally.
-
-    ``state`` is a dict the caller persists across calls — holds both the
-    ``drain_mode_active`` cache and the ``logged`` flag for log-once
-    transitions. ``metric_counter`` is the dedicated drain-tick counter
-    (kept separate from CLAIM_WORK_TOTAL so claim-success dashboards
-    aren't skewed by drain windows). ``sleep_fn`` and ``now`` are
-    injectable for tests.
-
-    Retry-queue flush uses ``count_attempts=False`` so a multi-minute
-    drain plus a coincident backend transient can't permanently drop
-    pending completion/score reports before instance termination.
+    Drain flush uses count_attempts=False so a multi-minute drain plus a
+    coincident backend transient can't burn retry budget on reports we
+    haven't actually given up on.
     """
-    if drain_mode_active(state, now=now, drain_file=drain_file):
+    if drain_mode_active(state, drain_file=drain_file):
         if not state.get("logged"):
-            logging.info(
-                "Drain sentinel present — skipping new claim_work; "
-                "in-flight evals finish normally, auto-update suppressed"
-            )
+            logging.info("Drain sentinel present — pausing claim_work")
             state["logged"] = True
-        if metric_counter is not None:
-            metric_counter.inc()
+        DRAIN_TICKS_TOTAL.inc()
         if retry_queue.get_pending_count() > 0:
             retry_queue.process_pending(count_attempts=False)
-        sleep_fn(poll_interval)
+        time.sleep(poll_interval)
         return True
     if state.get("logged"):
         logging.info("Drain sentinel cleared — resuming claim_work")

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -510,10 +510,33 @@ class Validator:
         )
 
         drain_cache: dict = {}
+        drain_logged = False
 
         try:
             while True:
                 try:
+                    # ORO-1150: drain check sits ABOVE auto-update so a
+                    # Watchtower image roll can't restart the container
+                    # mid-drain (which would kill the in-flight eval the
+                    # feature exists to protect). Also flush the retry
+                    # queue here so any pending completion/score reports
+                    # leave the node before it terminates.
+                    if drain_mode_active(drain_cache):
+                        if not drain_logged:
+                            logging.info(
+                                "Drain sentinel present — skipping new claim_work; "
+                                "in-flight evals finish normally, auto-update suppressed"
+                            )
+                            drain_logged = True
+                        CLAIM_WORK_TOTAL.labels(result="draining").inc()
+                        if self.retry_queue.get_pending_count() > 0:
+                            self.retry_queue.process_pending()
+                        time.sleep(self.config.poll_interval)
+                        continue
+                    elif drain_logged:
+                        logging.info("Drain sentinel cleared — resuming claim_work")
+                        drain_logged = False
+
                     # Check for image updates every 5 minutes
                     if time.time() - self._last_update_check >= UPDATE_CHECK_INTERVAL:
                         self._check_for_updates()
@@ -524,15 +547,6 @@ class Validator:
                         logging.warning(
                             f"Still tracking eval run {self._current_eval_run_id} - this should not happen!"
                         )
-
-                    # ORO-1150: skip claim if an operator flagged this
-                    # validator for drain. In-flight evals finish normally;
-                    # only NEW claims short-circuit. Resume is automatic
-                    # when the sentinel is removed.
-                    if drain_mode_active(drain_cache):
-                        CLAIM_WORK_TOTAL.labels(result="draining").inc()
-                        time.sleep(self.config.poll_interval)
-                        continue
 
                     # Claim work from Backend
                     logging.info("Claiming work from Backend...")

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -27,7 +27,6 @@ from .metrics import (
     ACTIVE_RUNS,
     CLAIM_WORK_SECONDS,
     CLAIM_WORK_TOTAL,
-    DRAIN_TICKS_TOTAL,
     SANDBOX_ACTIVE,
     SANDBOX_DURATION_SECONDS,
 )
@@ -515,15 +514,12 @@ class Validator:
         try:
             while True:
                 try:
-                    # ORO-1150: drain check sits ABOVE auto-update so a
-                    # Watchtower image roll can't restart the container
-                    # mid-drain (which would kill the in-flight eval the
-                    # feature exists to protect).
+                    # Drain check sits ABOVE auto-update so a Watchtower
+                    # image roll can't restart mid-drain (ORO-1150).
                     if handle_drain_tick(
                         self._drain_state,
                         self.retry_queue,
                         self.config.poll_interval,
-                        metric_counter=DRAIN_TICKS_TOTAL,
                     ):
                         continue
 

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -36,7 +36,7 @@ from .weight_setter import WeightSetterThread
 from .retry_queue import LocalRetryQueue
 from .progress_reporter import ProgressReporter
 from .backoff import ExponentialBackoff
-from .drain import DRAIN_FILE, drain_mode_active
+from .drain import drain_mode_active
 from .models import CompletionRequest
 from subnet.sandbox import host_path, build_sandbox_command, SANDBOX_IMAGE
 
@@ -509,8 +509,7 @@ class Validator:
             f"Weight setter started (interval: {self.config.weight_update_interval}s)"
         )
 
-        drain_cache: dict[str, float] = {}
-        drain_logged = False
+        drain_cache: dict = {}
 
         try:
             while True:
@@ -526,24 +525,14 @@ class Validator:
                             f"Still tracking eval run {self._current_eval_run_id} - this should not happen!"
                         )
 
-                    # Drain mode: if an operator has flagged this validator
-                    # for drain (sentinel file present), skip the claim and
-                    # sleep. Any eval already in flight finishes normally —
-                    # the loop only short-circuits NEW claims. See DRAIN_FILE
-                    # docstring for the orchestrator-side contract.
+                    # ORO-1150: skip claim if an operator flagged this
+                    # validator for drain. In-flight evals finish normally;
+                    # only NEW claims short-circuit. Resume is automatic
+                    # when the sentinel is removed.
                     if drain_mode_active(drain_cache):
-                        if not drain_logged:
-                            logging.info(
-                                f"Drain mode active (sentinel: {DRAIN_FILE}) — "
-                                "skipping claim_work, finishing in-flight evals only"
-                            )
-                            drain_logged = True
                         CLAIM_WORK_TOTAL.labels(result="draining").inc()
                         time.sleep(self.config.poll_interval)
                         continue
-                    elif drain_logged:
-                        logging.info("Drain mode cleared — resuming normal claim_work")
-                        drain_logged = False
 
                     # Claim work from Backend
                     logging.info("Claiming work from Backend...")

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -27,6 +27,7 @@ from .metrics import (
     ACTIVE_RUNS,
     CLAIM_WORK_SECONDS,
     CLAIM_WORK_TOTAL,
+    DRAIN_TICKS_TOTAL,
     SANDBOX_ACTIVE,
     SANDBOX_DURATION_SECONDS,
 )
@@ -36,7 +37,7 @@ from .weight_setter import WeightSetterThread
 from .retry_queue import LocalRetryQueue
 from .progress_reporter import ProgressReporter
 from .backoff import ExponentialBackoff
-from .drain import drain_mode_active
+from .drain import handle_drain_tick
 from .models import CompletionRequest
 from subnet.sandbox import host_path, build_sandbox_command, SANDBOX_IMAGE
 
@@ -509,8 +510,7 @@ class Validator:
             f"Weight setter started (interval: {self.config.weight_update_interval}s)"
         )
 
-        drain_cache: dict = {}
-        drain_logged = False
+        self._drain_state: dict = {}
 
         try:
             while True:
@@ -518,24 +518,14 @@ class Validator:
                     # ORO-1150: drain check sits ABOVE auto-update so a
                     # Watchtower image roll can't restart the container
                     # mid-drain (which would kill the in-flight eval the
-                    # feature exists to protect). Also flush the retry
-                    # queue here so any pending completion/score reports
-                    # leave the node before it terminates.
-                    if drain_mode_active(drain_cache):
-                        if not drain_logged:
-                            logging.info(
-                                "Drain sentinel present — skipping new claim_work; "
-                                "in-flight evals finish normally, auto-update suppressed"
-                            )
-                            drain_logged = True
-                        CLAIM_WORK_TOTAL.labels(result="draining").inc()
-                        if self.retry_queue.get_pending_count() > 0:
-                            self.retry_queue.process_pending()
-                        time.sleep(self.config.poll_interval)
+                    # feature exists to protect).
+                    if handle_drain_tick(
+                        self._drain_state,
+                        self.retry_queue,
+                        self.config.poll_interval,
+                        metric_counter=DRAIN_TICKS_TOTAL,
+                    ):
                         continue
-                    elif drain_logged:
-                        logging.info("Drain sentinel cleared — resuming claim_work")
-                        drain_logged = False
 
                     # Check for image updates every 5 minutes
                     if time.time() - self._last_update_check >= UPDATE_CHECK_INTERVAL:

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -36,6 +36,7 @@ from .weight_setter import WeightSetterThread
 from .retry_queue import LocalRetryQueue
 from .progress_reporter import ProgressReporter
 from .backoff import ExponentialBackoff
+from .drain import DRAIN_FILE, drain_mode_active
 from .models import CompletionRequest
 from subnet.sandbox import host_path, build_sandbox_command, SANDBOX_IMAGE
 
@@ -508,6 +509,9 @@ class Validator:
             f"Weight setter started (interval: {self.config.weight_update_interval}s)"
         )
 
+        drain_cache: dict[str, float] = {}
+        drain_logged = False
+
         try:
             while True:
                 try:
@@ -521,6 +525,25 @@ class Validator:
                         logging.warning(
                             f"Still tracking eval run {self._current_eval_run_id} - this should not happen!"
                         )
+
+                    # Drain mode: if an operator has flagged this validator
+                    # for drain (sentinel file present), skip the claim and
+                    # sleep. Any eval already in flight finishes normally —
+                    # the loop only short-circuits NEW claims. See DRAIN_FILE
+                    # docstring for the orchestrator-side contract.
+                    if drain_mode_active(drain_cache):
+                        if not drain_logged:
+                            logging.info(
+                                f"Drain mode active (sentinel: {DRAIN_FILE}) — "
+                                "skipping claim_work, finishing in-flight evals only"
+                            )
+                            drain_logged = True
+                        CLAIM_WORK_TOTAL.labels(result="draining").inc()
+                        time.sleep(self.config.poll_interval)
+                        continue
+                    elif drain_logged:
+                        logging.info("Drain mode cleared — resuming normal claim_work")
+                        drain_logged = False
 
                     # Claim work from Backend
                     logging.info("Claiming work from Backend...")

--- a/subnet/validator/metrics.py
+++ b/subnet/validator/metrics.py
@@ -25,7 +25,7 @@ CLAIM_WORK_SECONDS = Histogram(
 CLAIM_WORK_TOTAL = Counter(
     "validator_claim_work_total",
     "Outcome of claim_work polls",
-    labelnames=("result",),  # success | empty | error
+    labelnames=("result",),  # success | empty | error | draining
 )
 
 SANDBOX_ACTIVE = Gauge(

--- a/subnet/validator/metrics.py
+++ b/subnet/validator/metrics.py
@@ -25,7 +25,14 @@ CLAIM_WORK_SECONDS = Histogram(
 CLAIM_WORK_TOTAL = Counter(
     "validator_claim_work_total",
     "Outcome of claim_work polls",
-    labelnames=("result",),  # success | empty | error | draining
+    labelnames=("result",),  # success | empty | error
+)
+
+DRAIN_TICKS_TOTAL = Counter(
+    "validator_drain_ticks_total",
+    "Main-loop ticks short-circuited because the drain sentinel was present "
+    "(ORO-1150). Counter is independent of CLAIM_WORK_TOTAL so claim-success "
+    "dashboards aren't skewed by drain windows.",
 )
 
 SANDBOX_ACTIVE = Gauge(

--- a/subnet/validator/metrics.py
+++ b/subnet/validator/metrics.py
@@ -30,9 +30,8 @@ CLAIM_WORK_TOTAL = Counter(
 
 DRAIN_TICKS_TOTAL = Counter(
     "validator_drain_ticks_total",
-    "Main-loop ticks short-circuited because the drain sentinel was present "
-    "(ORO-1150). Counter is independent of CLAIM_WORK_TOTAL so claim-success "
-    "dashboards aren't skewed by drain windows.",
+    "Main-loop ticks short-circuited by the drain sentinel (ORO-1150). "
+    "Separate from CLAIM_WORK_TOTAL so claim-success rate stays clean.",
 )
 
 SANDBOX_ACTIVE = Gauge(

--- a/subnet/validator/retry_queue.py
+++ b/subnet/validator/retry_queue.py
@@ -76,8 +76,21 @@ class LocalRetryQueue:
         data = self._load()
         return len(data["pending"])
 
-    def process_pending(self) -> None:
-        """Attempt to process all pending completions."""
+    def process_pending(self, *, count_attempts: bool = True) -> None:
+        """Attempt to process all pending completions.
+
+        ``count_attempts``: when True (default), each transient failure
+        increments the entry's retry_count and the entry is dropped after
+        ``max_retries`` exhaustions — the right behavior for the post-eval
+        opportunistic flush in the normal loop.
+
+        When False, transient failures do NOT burn retry budget — the
+        entry stays in the queue at the same retry_count. Used by the
+        drain branch (ORO-1150) so a multi-minute drain + coincident
+        backend transient can't permanently drop completion/score reports
+        before instance termination. The next successful loop iteration
+        post-drain re-flushes against the unchanged budget.
+        """
         data = self._load()
         remaining = []
 
@@ -90,14 +103,15 @@ class LocalRetryQueue:
                 else:
                     logging.warning(f"Unknown entry type '{entry_type}', dropping")
             except _TransientRetry:
-                entry["retry_count"] += 1
-                if entry["retry_count"] >= self.max_retries:
-                    logging.error(
-                        f"Max retries ({self.max_retries}) exceeded for "
-                        f"{entry_type} {entry.get('eval_run_id')}, dropping"
-                    )
-                else:
-                    remaining.append(entry)
+                if count_attempts:
+                    entry["retry_count"] += 1
+                    if entry["retry_count"] >= self.max_retries:
+                        logging.error(
+                            f"Max retries ({self.max_retries}) exceeded for "
+                            f"{entry_type} {entry.get('eval_run_id')}, dropping"
+                        )
+                        continue
+                remaining.append(entry)
 
         data["pending"] = remaining
         self._save(data)

--- a/subnet/validator/retry_queue.py
+++ b/subnet/validator/retry_queue.py
@@ -79,17 +79,9 @@ class LocalRetryQueue:
     def process_pending(self, *, count_attempts: bool = True) -> None:
         """Attempt to process all pending completions.
 
-        ``count_attempts``: when True (default), each transient failure
-        increments the entry's retry_count and the entry is dropped after
-        ``max_retries`` exhaustions — the right behavior for the post-eval
-        opportunistic flush in the normal loop.
-
-        When False, transient failures do NOT burn retry budget — the
-        entry stays in the queue at the same retry_count. Used by the
-        drain branch (ORO-1150) so a multi-minute drain + coincident
-        backend transient can't permanently drop completion/score reports
-        before instance termination. The next successful loop iteration
-        post-drain re-flushes against the unchanged budget.
+        ``count_attempts=False`` skips the retry-budget increment so a
+        multi-minute drain (ORO-1150) plus a coincident backend transient
+        can't permanently drop reports before instance termination.
         """
         data = self._load()
         remaining = []


### PR DESCRIPTION
## Description

Adds a generic drain-mode hook to the validator main loop so it stops claiming NEW work when an operator flags it, but lets any in-flight eval finish cleanly. Closes [ORO-1150](https://linear.app/oroai/issue/ORO-1150).

The pre-1150 failure mode (2026-05-13 race): AWS ASG scale-down fired during an active race; the validator kept claim-and-immediately-evaluate looping; the existing drain script's "validator_active_runs == 0 for 60s" QUIET window never opened; the lifecycle hook timed out at 5400s; the ASG ABANDONed the instance mid-eval. 91 min from scale-down decision to instance gone, with in-flight evals lost and miners absorbing the failed runs.

With the drain hook, the orchestrator flips a sentinel file, the validator stops new claims within ~10s (cache TTL), in-flight finishes within ~1 max-eval-time (~5-8 min), the QUIET window opens, the lifecycle action completes CONTINUE cleanly.

## Changes Made

- New `subnet/validator/drain.py` — generic `drain_mode_active(cache)` helper. Reads `os.path.exists("/var/run/oro-validator/drain")` with a 10-second TTL cache to keep stat() off the hot path. Path is overridable via `ORO_DRAIN_FILE`.
- `subnet/validator/main.py` — imports the helper, persists a per-loop cache dict, checks it before each `claim_work`. On drain mode active: logs once, increments the `CLAIM_WORK_TOTAL{result="draining"}` counter, sleeps `poll_interval`, continues. On drain mode cleared (orchestrator removed the file): logs the resume and goes back to normal claim attempts.
- `subnet/validator/metrics.py` — adds `draining` to the documented label set on `CLAIM_WORK_TOTAL`.
- `docker-compose.yml` — bind-mounts `/var/run/oro-validator` from host into the validator container so the orchestrator (running on the host) can write a path the in-container validator reads.
- `subnet/tests/validator/test_drain_mode.py` — 5 unit tests: no-file/present-file/cache-stable-within-TTL/cache-refresh-after-TTL/default-path-namespaced. Pure-Python, no bittensor import chain.

## Issue Link

- Related to: #
- Closes: ORO-1150

## Testing

### Manual Testing

Not run on a live ASG yet — staging verification is the next step (scale up the staging extras ASG to 2, manually trigger a scale-down, confirm: (a) drain file appears on host, (b) validator logs the drain-mode entry, (c) `validator_active_runs` drains within ~max-eval-time, (d) lifecycle hook completes CONTINUE not ABANDON). The Infrastructure-side companion change (ORO-AI/Infrastructure PR — \`oro-asg-drain.sh\` touches the sentinel) needs to land in tandem; the validator hook is a no-op without it.

**Test Results:**

```
subnet/tests/validator/test_drain_mode.py::test_default_drain_file_constant_is_namespaced PASSED
subnet/tests/validator/test_drain_mode.py::test_no_drain_file_returns_false PASSED
subnet/tests/validator/test_drain_mode.py::test_present_drain_file_returns_true PASSED
subnet/tests/validator/test_drain_mode.py::test_cache_skips_filesystem_check_within_ttl PASSED
subnet/tests/validator/test_drain_mode.py::test_cache_picks_up_drain_clear_after_ttl PASSED
5 passed in 0.01s
```

### Automated Testing

**Test Command(s):**
\`\`\`bash
pytest subnet/tests/validator/test_drain_mode.py -v
\`\`\`

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**

Module-level docstring in `drain.py` documents the contract for orchestrators (touch the file → validator drains; remove it → validator resumes). Inline comment in `docker-compose.yml` points operators at `drain.py` for the contract. `ORO_DRAIN_FILE` env var documented in the helper docstring.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

**Deploy ordering:** This PR + the Infrastructure-side companion PR (oro-asg-drain.sh) are independent — either order works. Until both ship, the system behaves as it does today (validator doesn't know about drain mode, or script doesn't write the file). No regression in either intermediate state.

**Non-AWS operators:** the validator-side hook is generic. Any operator (bare metal, docker, k8s, anyone) can drain a validator gracefully by `touch /var/run/oro-validator/drain` (or `ORO_DRAIN_FILE=/your/path`). That's a useful primitive on its own, not AWS-specific.

**Scope rejected:** drain script killing the validator container with SIGTERM (faster, but harder to make robust under in-flight eval RPCs) — not done. Backend admin endpoint flipping a server-side drain flag — not done, more cross-system coupling. Both options noted in the original ticket; both rejected for this iteration.