### PR TITLE
fix(validator): drain logs use bittensor logger (ORO-1150 follow-up)

### DIFF
--- a/subnet/tests/validator/test_drain_mode.py
+++ b/subnet/tests/validator/test_drain_mode.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import validator.metrics  # noqa: F401 — needed so patch() can resolve the lazy import target
+
 from validator.drain import drain_mode_active, handle_drain_tick
 
 
@@ -26,7 +28,7 @@ def test_drain_mode_fails_closed_on_oserror(tmp_path):
     """Mount-misconfig → fail-CLOSED + WARNING (prevents silent-claim)."""
     parent = tmp_path / "nope"
     parent.write_text("not a directory")  # NotADirectoryError on stat()
-    with patch("validator.drain.logging") as log:
+    with patch("validator.drain._log") as log:
         assert drain_mode_active(drain_file=str(parent / "drain")) is True
         assert any("fail-CLOSED" in str(c) for c in log.warning.call_args_list)
 
@@ -38,7 +40,7 @@ def test_handle_drain_tick_draining_flushes_no_burn(drain_file):
     rq.get_pending_count.return_value = 3
     state: dict = {}
     with patch("validator.metrics.DRAIN_TICKS_TOTAL") as metric, patch(
-        "validator.drain.logging"
+        "validator.drain._log"
     ) as log:
         for _ in range(2):
             assert handle_drain_tick(state, rq, 0.0, drain_file=drain_file) is True
@@ -59,7 +61,7 @@ def test_handle_drain_tick_absent_passes_through(drain_file):
 
 def test_handle_drain_tick_logs_resume_on_clear(drain_file):
     state = {"logged": True}
-    with patch("validator.drain.logging") as log:
+    with patch("validator.drain._log") as log:
         assert handle_drain_tick(state, MagicMock(), 0.0, drain_file=drain_file) is False
         assert state["logged"] is False
         assert any("cleared" in str(c) for c in log.info.call_args_list)

--- a/subnet/validator/drain.py
+++ b/subnet/validator/drain.py
@@ -12,6 +12,11 @@ import time
 
 DRAIN_FILE = os.environ.get("ORO_DRAIN_FILE", "/var/run/oro-validator/drain")
 
+# bittensor's btlogging configures a stdlib StreamHandler on the "bittensor"
+# logger; the root logger has none. Use the named logger so drain messages
+# actually reach docker logs (rest of the validator does the same).
+_log = logging.getLogger("bittensor")
+
 
 def drain_mode_active(*, drain_file: str = DRAIN_FILE) -> bool:
     """True iff drain_file exists. Fail-CLOSED on unreadable path
@@ -24,7 +29,7 @@ def drain_mode_active(*, drain_file: str = DRAIN_FILE) -> bool:
     except FileNotFoundError:
         return False
     except OSError as e:
-        logging.warning(
+        _log.warning(
             f"Drain sentinel path unreadable ({type(e).__name__}: {e}) — "
             "fail-CLOSED. Check the host bind mount."
         )
@@ -42,7 +47,7 @@ def handle_drain_tick(
     """
     if drain_mode_active(drain_file=drain_file):
         if not state.get("logged"):
-            logging.info("Drain sentinel present — pausing claim_work")
+            _log.info("Drain sentinel present — pausing claim_work")
             state["logged"] = True
         # Lazy import: module-level import triggers dual-registration when
         # test_auto_update imports via `validator.metrics` while this file
@@ -55,6 +60,6 @@ def handle_drain_tick(
         time.sleep(poll_interval)
         return True
     if state.get("logged"):
-        logging.info("Drain sentinel cleared — resuming claim_work")
+        _log.info("Drain sentinel cleared — resuming claim_work")
         state["logged"] = False
     return False


### PR DESCRIPTION
## Description

Follow-up to PR #181 (ORO-1150). Caught while testing drain on staging.

Drain functional behavior is correct (`validator_drain_ticks_total` incremented during the test, `claim_work` short-circuited, recovered cleanly on sentinel removal). But the "Drain sentinel present" / "Drain sentinel cleared" log lines never surfaced in container output.

## Changes Made

- \`drain.py\`: use \`logging.getLogger("bittensor")\` instead of root logger
- Tests: patch \`validator.drain._log\` instead of \`validator.drain.logging\`; eagerly import \`validator.metrics\` so the lazy-import patch target resolves in a fresh venv

## Issue Link

- Related to: ORO-1150
- Follows up: #181

## Testing

### Manual Testing
Verified on staging (oro-validator-staging, AWS):
1. Touched \`/var/run/oro-validator/drain\` on host
2. \`validator_drain_ticks_total\` went 0 → 10 over ~5 min (poll_interval=30s) — confirms loop short-circuit + metric tick path
3. \`claim_work\` log silenced
4. Removed sentinel — \`claim_work\` resumed immediately, \`drain_ticks_total\` froze

### Automated Testing

**Test Command(s):**
\`\`\`bash
.venv/bin/pytest subnet/tests/validator/test_drain_mode.py -v
\`\`\`
6/6 pass.

## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated

**Documentation Changes:**
N/A

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

Other validator modules also use stdlib \`logging\` on the root logger and presumably have the same drop. Not addressing those here to keep this PR minimal — they emit only on rare paths and we haven't validated that breakage.