### PR TITLE
sandbox: add POST /run_matrix endpoint

### DIFF
--- a/src/agent/sandbox_server.py
+++ b/src/agent/sandbox_server.py
@@ -1,8 +1,8 @@
 """HTTP wrapper around `execute_single_problem`.
 
-Exposes the sandbox executor as `POST /run` for callers that want to submit
-work over loopback instead of via the one-shot CLI. Running the agent inside
-this container preserves the same process isolation the CLI relies on.
+Exposes the sandbox executor over loopback so callers can submit work
+without using the one-shot CLI. Running agents inside this container
+preserves the same process isolation the CLI relies on.
 
 Run:
 
@@ -11,17 +11,23 @@ Run:
 Endpoints:
 
 * `GET /health` — liveness probe.
-* `POST /run` — body `{problem, agent_code, timeout}`; writes `agent_code`
-  to a tempfile, runs `execute_single_problem`, returns the canonical
-  envelope (same shape as the JSONL writer).
+* `POST /run` — body `{problem, agent_code, timeout}`; runs one
+  `(problem, agent)` pair, returns the canonical envelope.
+* `POST /run_matrix` — body `{problems, agents, pairs?, timeout,
+  max_workers?}`. Evaluates a cross-product of problems × agents (or
+  an explicit list of `(problem_idx, agent_idx)` cells) concurrently
+  inside this container. Lets a caller pay for each agent_code once
+  on the wire even when reusing it across many problems.
 """
 
 from __future__ import annotations
 
 import argparse
+from concurrent.futures import ThreadPoolExecutor
+from itertools import product
 from pathlib import Path
-from tempfile import NamedTemporaryFile
-from typing import Any
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+from typing import Any, Optional
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
@@ -31,12 +37,23 @@ from src.agent.sandbox_executor import build_result_envelope, execute_single_pro
 app = FastAPI()
 
 _MAX_AGENT_CODE_BYTES = 2 * 1024 * 1024
+_DEFAULT_BATCH_WORKERS = 15
 
 
 class RunRequest(BaseModel):
     problem: dict[str, Any]
     agent_code: str = Field(..., max_length=_MAX_AGENT_CODE_BYTES)
     timeout: float = Field(300.0, ge=1.0, le=900.0)
+
+
+class RunMatrixRequest(BaseModel):
+    problems: list[dict[str, Any]] = Field(..., min_length=1)
+    agents: list[str] = Field(..., min_length=1)
+    # Optional sparse selection. Each entry = (problem_idx, agent_idx).
+    # Default (None) = full cross-product problems × agents.
+    pairs: Optional[list[tuple[int, int]]] = None
+    timeout: float = Field(300.0, ge=1.0, le=900.0)
+    max_workers: Optional[int] = Field(None, ge=1)
 
 
 @app.get("/health")
@@ -49,7 +66,9 @@ def run(req: RunRequest) -> dict[str, Any]:
     if not req.agent_code.strip():
         raise HTTPException(status_code=400, detail="agent_code is empty")
 
-    with NamedTemporaryFile(mode="w", suffix=".py", delete=False, encoding="utf-8") as fh:
+    with NamedTemporaryFile(
+        mode="w", suffix=".py", delete=False, encoding="utf-8"
+    ) as fh:
         fh.write(req.agent_code)
         agent_path = fh.name
 
@@ -61,6 +80,50 @@ def run(req: RunRequest) -> dict[str, Any]:
         Path(agent_path).unlink(missing_ok=True)
 
     return build_result_envelope(result)
+
+
+@app.post("/run_matrix")
+def run_matrix(req: RunMatrixRequest) -> dict[str, list[dict[str, Any]]]:
+    """Evaluate problems × agents (or selected cells) in parallel."""
+    for ai, code in enumerate(req.agents):
+        if not code.strip():
+            raise HTTPException(status_code=400, detail=f"agents[{ai}] is empty")
+
+    n_p, n_a = len(req.problems), len(req.agents)
+    if req.pairs is None:
+        cells = list(product(range(n_p), range(n_a)))
+    else:
+        for k, (pi, ai) in enumerate(req.pairs):
+            if not (0 <= pi < n_p) or not (0 <= ai < n_a):
+                raise HTTPException(
+                    status_code=400, detail=f"pairs[{k}] out of range: ({pi}, {ai})"
+                )
+        cells = req.pairs
+
+    workers = req.max_workers or min(len(cells), _DEFAULT_BATCH_WORKERS)
+
+    with TemporaryDirectory(prefix="sandbox_batch_") as batch_dir:
+        agent_paths: list[str] = []
+        for ai, code in enumerate(req.agents):
+            path = Path(batch_dir) / f"agent_{ai}.py"
+            path.write_text(code, encoding="utf-8")
+            agent_paths.append(str(path))
+
+        def _eval(cell: tuple[int, int]) -> Any:
+            pi, ai = cell
+            return execute_single_problem(
+                req.problems[pi], req.timeout, agent_paths[ai]
+            )
+
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            envelopes = list(pool.map(_eval, cells))
+
+    return {
+        "results": [
+            {"problem_idx": pi, "agent_idx": ai, "envelope": build_result_envelope(env)}
+            for (pi, ai), env in zip(cells, envelopes)
+        ]
+    }
 
 
 def main() -> None:

--- a/tests/test_sandbox_server.py
+++ b/tests/test_sandbox_server.py
@@ -2,28 +2,59 @@
 
 from unittest.mock import patch
 
+import pytest
 from fastapi.testclient import TestClient
 
 from src.agent.sandbox_executor import ExecutionResult
-from src.agent.sandbox_status import SandboxProblemStatus
 from src.agent.sandbox_server import app
+from src.agent.sandbox_status import SandboxProblemStatus
 
-client = TestClient(app)
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
 
 
-def test_health() -> None:
+def _mk_result(problem_id: str, *, success: bool = True) -> ExecutionResult:
+    return ExecutionResult(
+        query=f"q-{problem_id}",
+        success=success,
+        result=[{"action": "noop"}] if success else None,
+        execution_time=0.5,
+        problem_id=problem_id,
+        status=SandboxProblemStatus.SUCCESS if success else SandboxProblemStatus.FAILED,
+    )
+
+
+def _patched_executor(results_by_pid: dict[str, ExecutionResult], capture=None):
+    """Patch execute_single_problem to return canned results keyed by problem_id."""
+
+    def fake(problem, timeout, agent_file):
+        if capture is not None:
+            capture(problem, timeout, agent_file)
+        return results_by_pid[problem["problem_id"]]
+
+    return patch("src.agent.sandbox_server.execute_single_problem", side_effect=fake)
+
+
+# ---------------------------------------------------------------------------
+# /health + /run
+# ---------------------------------------------------------------------------
+
+
+def test_health(client: TestClient) -> None:
     r = client.get("/health")
     assert r.status_code == 200
     assert r.json() == {"status": "ok"}
 
 
-def test_run_rejects_empty_agent_code() -> None:
+def test_run_rejects_empty_agent_code(client: TestClient) -> None:
     r = client.post("/run", json={"problem": {"query": "x"}, "agent_code": "   "})
     assert r.status_code == 400
 
 
-def test_run_invokes_executor_and_returns_envelope() -> None:
-    fake_result = ExecutionResult(
+def test_run_invokes_executor_and_returns_envelope(client: TestClient) -> None:
+    fake = ExecutionResult(
         query="test",
         success=True,
         result=[{"action": "search", "args": {"q": "x"}}],
@@ -31,7 +62,9 @@ def test_run_invokes_executor_and_returns_envelope() -> None:
         problem_id="p-1",
         status=SandboxProblemStatus.SUCCESS,
     )
-    with patch("src.agent.sandbox_server.execute_single_problem", return_value=fake_result) as m:
+    with patch(
+        "src.agent.sandbox_server.execute_single_problem", return_value=fake
+    ) as m:
         r = client.post(
             "/run",
             json={
@@ -40,7 +73,6 @@ def test_run_invokes_executor_and_returns_envelope() -> None:
                 "timeout": 30.0,
             },
         )
-
     assert r.status_code == 200
     body = r.json()
     assert body["problem_id"] == "p-1"
@@ -49,9 +81,130 @@ def test_run_invokes_executor_and_returns_envelope() -> None:
     assert m.call_args.kwargs["timeout"] == 30.0
 
 
-def test_run_rejects_timeout_out_of_range() -> None:
+def test_run_rejects_timeout_out_of_range(client: TestClient) -> None:
     r = client.post(
         "/run",
         json={"problem": {"query": "x"}, "agent_code": "x = 1\n", "timeout": 0.1},
     )
     assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# /run_matrix
+# ---------------------------------------------------------------------------
+
+
+def _matrix_body(*, n_problems: int, n_agents: int, **kwargs) -> dict:
+    return {
+        "problems": [
+            {"query": f"q-{i}", "problem_id": f"p{i}"} for i in range(n_problems)
+        ],
+        "agents": [f"# agent {a}\nx = {a}\n" for a in range(n_agents)],
+        "timeout": 30.0,
+        **kwargs,
+    }
+
+
+def _result_for_problem(problem_id: str, *, success: bool = True) -> ExecutionResult:
+    return _mk_result(problem_id, success=success)
+
+
+def test_run_matrix_returns_cross_product_in_order(client: TestClient) -> None:
+    body = _matrix_body(n_problems=3, n_agents=2)
+    fakes = {f"p{i}": _result_for_problem(f"p{i}") for i in range(3)}
+
+    with _patched_executor(fakes):
+        r = client.post("/run_matrix", json=body)
+
+    assert r.status_code == 200
+    results = r.json()["results"]
+    assert len(results) == 6
+    assert [(c["problem_idx"], c["agent_idx"]) for c in results] == [
+        (0, 0),
+        (0, 1),
+        (1, 0),
+        (1, 1),
+        (2, 0),
+        (2, 1),
+    ]
+    assert all(c["envelope"]["status"] == "SUCCESS" for c in results)
+
+
+def test_run_matrix_honors_sparse_pairs(client: TestClient) -> None:
+    body = _matrix_body(n_problems=3, n_agents=3, pairs=[[0, 1], [2, 0], [1, 2]])
+    fakes = {f"p{i}": _result_for_problem(f"p{i}") for i in range(3)}
+
+    with _patched_executor(fakes):
+        r = client.post("/run_matrix", json=body)
+
+    assert r.status_code == 200
+    results = r.json()["results"]
+    assert [(c["problem_idx"], c["agent_idx"]) for c in results] == [
+        (0, 1),
+        (2, 0),
+        (1, 2),
+    ]
+
+
+def test_run_matrix_writes_each_agent_once(client: TestClient) -> None:
+    """Agents list defines the on-disk files. 4×3 matrix → 3 agent files."""
+    body = _matrix_body(n_problems=4, n_agents=3)
+    fakes = {f"p{i}": _result_for_problem(f"p{i}") for i in range(4)}
+    seen_paths: set[str] = set()
+
+    with _patched_executor(fakes, capture=lambda p, t, f: seen_paths.add(f)):
+        r = client.post("/run_matrix", json=body)
+
+    assert r.status_code == 200
+    assert len(seen_paths) == 3
+
+
+def test_run_matrix_rejects_empty_agent(client: TestClient) -> None:
+    body = _matrix_body(n_problems=1, n_agents=2)
+    body["agents"][1] = "   "
+    r = client.post("/run_matrix", json=body)
+    assert r.status_code == 400
+    assert "agents[1]" in r.json()["detail"]
+
+
+@pytest.mark.parametrize("pair", [(-1, 0), (0, -1), (1, 0), (0, 1)])
+def test_run_matrix_rejects_out_of_range_pair(client: TestClient, pair) -> None:
+    body = _matrix_body(n_problems=1, n_agents=1, pairs=[list(pair)])
+    r = client.post("/run_matrix", json=body)
+    assert r.status_code == 400
+    assert "out of range" in r.json()["detail"]
+
+
+def test_run_matrix_e2e_with_real_executor(client: TestClient) -> None:
+    """No mocks: actually fan out forkserver children and confirm wiring."""
+    agent_code = (
+        "def agent_main(problem):\n"
+        "    return [{'think': 'noop', 'response': 'done', 'extra_info': {}}]\n"
+    )
+    body = {
+        "problems": [
+            {"query": "q-0", "problem_id": "p0"},
+            {"query": "q-1", "problem_id": "p1"},
+        ],
+        "agents": [agent_code, agent_code.replace("noop", "alt")],
+        "timeout": 10.0,
+    }
+    r = client.post("/run_matrix", json=body)
+
+    assert r.status_code == 200
+    results = r.json()["results"]
+    assert len(results) == 4
+    assert [(c["problem_idx"], c["agent_idx"]) for c in results] == [
+        (0, 0),
+        (0, 1),
+        (1, 0),
+        (1, 1),
+    ]
+    for c in results:
+        env = c["envelope"]
+        assert env["status"] == "SUCCESS"
+        assert env["execution_time"] > 0
+        assert env["dialogue"] is not None
+    # Cell (0,0) and (1,0) share agent 0 (noop); (0,1) and (1,1) share agent 1 (alt)
+    assert results[0]["envelope"]["dialogue"][0]["think"] == "noop"
+    assert results[1]["envelope"]["dialogue"][0]["think"] == "alt"


### PR DESCRIPTION
## Description

Adds `POST /run_matrix` to the sandbox HTTP server. Callers send a list of `problems` and a list of `agents` (and optionally a sparse `pairs` list of `[problem_idx, agent_idx]` cells) — the server runs the cross-product (or the listed pairs) in parallel and returns one envelope per cell.

Key wire-level win: each agent_code travels once, regardless of how many problems it runs against. A workload that evaluates 6 agents across 30 problems sends 6 × |agent| bytes instead of 180 × |agent|.

Each cell still runs in its own forkserver-backed child process — isolation guarantees match `/run`.

## Changes Made

- `src/agent/sandbox_server.py`:
  - New `RunMatrixRequest` pydantic model: `problems`, `agents`, optional `pairs`, `timeout`, `max_workers`.
  - New `@app.post(\"/run_matrix\")` handler. Validates non-empty `agents` and in-range `pairs` (returns 400 with the offending index). Writes one tempfile per agent inside a per-request `TemporaryDirectory`. `ThreadPoolExecutor + pool.map` fans out concurrent cells and preserves cell order in the response.
  - Default `max_workers` = `min(num_cells, 15)`.
  - Response shape: `{results: [{problem_idx, agent_idx, envelope}, ...]}`.
- `tests/test_sandbox_server.py`:
  - Cross-product order test.
  - Sparse `pairs` selection test.
  - Each-agent-written-once accounting test.
  - Empty-agent rejection.
  - Out-of-range pair rejection (parametrised over 4 corners).
  - End-to-end no-mock test: runs two real agents against two real problems via forkserver children and confirms wiring + per-agent dialogue.

## Issue Link

- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing
N/A — endpoint exercised by the new test suite. The end-to-end test spawns real forkserver children inside the test process.

**Test Results:**
13 tests pass.

### Automated Testing

\`\`\`bash
uv run pytest tests/test_sandbox_server.py -q
# 13 passed
\`\`\`

**Test Command(s):**
\`\`\`bash
uv run ruff check src/agent/sandbox_server.py tests/test_sandbox_server.py
uv run ruff format src/agent/sandbox_server.py tests/test_sandbox_server.py
uv run pytest tests/test_sandbox_server.py -v
\`\`\`

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**

Module docstring on `sandbox_server.py` now describes the new endpoint and its motivation.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

- Backwards-compatible: `/run` is unchanged.
- Sparse `pairs` lets callers retry or rerun only specific cells without resubmitting the whole matrix.