### PR TITLE
feat(validator): in-process watchdog to recover a wedged validator (ORO-1414)

### DIFF
--- a/subnet/tests/test_watchdog.py
+++ b/subnet/tests/test_watchdog.py
@@ -1,0 +1,76 @@
+"""Tests for the validator progress watchdog (ORO-1414, Follow-up 2).
+
+The main loop stamps a liveness beat each iteration; if it stops progressing
+(e.g. the host disk fills and the loop wedges) the watchdog aborts the process
+so docker's ``restart: unless-stopped`` brings a fresh validator back up.
+
+Pure unit (injectable clock) so it lives in subnet/tests/, not the heavy
+validator conftest dir.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from validator.watchdog import ProgressWatchdog
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def __call__(self) -> float:
+        return self.t
+
+
+def test_not_stalled_before_timeout():
+    clk = _FakeClock()
+    wd = ProgressWatchdog(timeout_seconds=100, now=clk)  # last beat at t=0
+    clk.t = 99
+    assert wd.stalled() is False
+
+
+def test_stalled_after_timeout():
+    clk = _FakeClock()
+    wd = ProgressWatchdog(timeout_seconds=100, now=clk)
+    clk.t = 101
+    assert wd.stalled() is True
+
+
+def test_beat_resets_the_timer():
+    clk = _FakeClock()
+    wd = ProgressWatchdog(timeout_seconds=100, now=clk)
+    clk.t = 150
+    assert wd.stalled() is True
+
+    wd.beat()  # last beat now at t=150
+    clk.t = 200
+    assert wd.stalled() is False  # 200 - 150 = 50 < 100
+
+
+def test_monitor_thread_aborts_when_stalled():
+    clk = _FakeClock()
+    fired = threading.Event()
+    wd = ProgressWatchdog(
+        timeout_seconds=100, now=clk, on_stall=fired.set, check_interval=0.01
+    )
+    clk.t = 1000  # already far past the timeout
+    wd.start()
+    try:
+        assert fired.wait(2.0) is True
+    finally:
+        wd.stop()
+
+
+def test_monitor_thread_quiet_while_healthy():
+    clk = _FakeClock()
+    fired = threading.Event()
+    wd = ProgressWatchdog(
+        timeout_seconds=100, now=clk, on_stall=fired.set, check_interval=0.01
+    )
+    wd.start()
+    try:
+        # clock never advances past the timeout, so on_stall must not fire
+        assert fired.wait(0.2) is False
+    finally:
+        wd.stop()

--- a/subnet/tests/test_watchdog.py
+++ b/subnet/tests/test_watchdog.py
@@ -10,8 +10,10 @@ validator conftest dir.
 
 from __future__ import annotations
 
+import logging
 import threading
 
+from validator import watchdog as watchdog_module
 from validator.watchdog import ProgressWatchdog
 
 
@@ -60,6 +62,22 @@ def test_monitor_thread_aborts_when_stalled():
         assert fired.wait(2.0) is True
     finally:
         wd.stop()
+
+
+def test_abort_logs_stable_alert_token(monkeypatch, caplog):
+    # _abort calls os._exit, which would kill pytest; stub it so we can assert
+    # the WATCHDOG_ABORT token a CloudWatch metric filter alarms on is emitted.
+    exited: dict[str, int] = {}
+    monkeypatch.setattr(
+        watchdog_module.os, "_exit", lambda code: exited.__setitem__("code", code)
+    )
+    clk = _FakeClock()
+    wd = ProgressWatchdog(timeout_seconds=100, now=clk)
+    clk.t = 500
+    with caplog.at_level(logging.ERROR):
+        wd._abort()
+    assert exited["code"] == 1
+    assert "WATCHDOG_ABORT" in caplog.text
 
 
 def test_monitor_thread_quiet_while_healthy():

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -21,6 +21,7 @@ from oro_sdk.types import Unset
 from src.agent.scoring import blend_final_score
 from src.agent.types import ProblemDict, SandboxMetadata
 from .backend_client import BackendClient, BackendError
+from .watchdog import ProgressWatchdog
 from .heartbeat_manager import HeartbeatManager
 from .output_split import split_output_by_problem
 from .metrics import (
@@ -104,6 +105,17 @@ class Validator:
             type=int,
             default=int(os.environ.get("SANDBOX_TIMEOUT") or "1800"),
             help="Timeout in seconds for the entire sandbox subprocess (env: SANDBOX_TIMEOUT, default: 1800 = 30 min).",
+        )
+        parser.add_argument(
+            "--validator-watchdog-timeout",
+            type=float,
+            default=float(os.environ.get("VALIDATOR_WATCHDOG_TIMEOUT") or "5400"),
+            help=(
+                "Seconds the main loop may go without progress before the watchdog "
+                "aborts the process so the container restart policy recovers it "
+                "(env: VALIDATOR_WATCHDOG_TIMEOUT, default: 5400 = 90 min). Must "
+                "exceed the longest legitimate single iteration. 0 disables (ORO-1414)."
+            ),
         )
         parser.add_argument(
             "--sandbox-max-workers",
@@ -509,10 +521,23 @@ class Validator:
             f"Weight setter started (interval: {self.config.weight_update_interval}s)"
         )
 
+        # Recover a wedged validator: if the loop stops making progress (e.g. the
+        # host disk fills and an iteration hangs), abort so the container's
+        # restart policy brings a fresh one up (ORO-1414).
+        watchdog: Optional[ProgressWatchdog] = None
+        if self.config.validator_watchdog_timeout > 0:
+            watchdog = ProgressWatchdog(self.config.validator_watchdog_timeout)
+            watchdog.start()
+            logging.info(
+                f"Watchdog started (timeout: {self.config.validator_watchdog_timeout}s)"
+            )
+
         self._drain_state: dict = {}
 
         try:
             while True:
+                if watchdog is not None:
+                    watchdog.beat()
                 try:
                     # Drain check sits ABOVE auto-update so a Watchtower
                     # image roll can't restart mid-drain (ORO-1150).
@@ -639,6 +664,8 @@ class Validator:
         except KeyboardInterrupt:
             logging.info("Keyboard interrupt detected, shutting down...")
         finally:
+            if watchdog is not None:
+                watchdog.stop()
             weight_setter.stop()
             logging.info("Validator stopped.")
 

--- a/subnet/validator/watchdog.py
+++ b/subnet/validator/watchdog.py
@@ -1,0 +1,90 @@
+"""In-process liveness watchdog for the validator main loop (ORO-1414, Follow-up 2).
+
+The validator container has ``restart: unless-stopped``, which only fires when
+the container *exits*. In the 2026-06-23 incident the process wedged (host disk
+filled) without exiting, so the container stayed ``Up`` (0B) and never
+restarted. This watchdog turns a stalled main loop into a process exit: the
+loop calls :meth:`beat` each iteration, and a background thread aborts the
+process if no beat lands within ``timeout_seconds`` so the restart policy can
+bring a fresh validator back up.
+
+Known limitation (accepted): if the whole interpreter is hard-hung (e.g. GIL
+deadlock), the watchdog thread itself is starved and cannot fire.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Callable
+
+# The loop beats once per iteration, so the default must exceed the longest
+# legitimate single iteration. Worst case is a hung update check (~900s) plus a
+# full eval (sandbox_timeout 1800s + scoring/reasoning ~900s+) in the same pass,
+# ~3600-3900s; 5400s leaves margin so a healthy busy validator never trips it,
+# while a truly wedged loop is still recycled within ~90 min. Tighter recovery
+# would require beating from the heartbeat thread (fires every 30s during an
+# eval) — see ORO-1414 follow-up.
+_DEFAULT_TIMEOUT_SECONDS = 5400.0
+_DEFAULT_CHECK_INTERVAL = 30.0
+
+
+class ProgressWatchdog:
+    """Abort the process if the main loop stops beating within ``timeout_seconds``."""
+
+    def __init__(
+        self,
+        timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+        *,
+        check_interval: float = _DEFAULT_CHECK_INTERVAL,
+        now: Callable[[], float] = time.monotonic,
+        on_stall: Callable[[], None] | None = None,
+    ) -> None:
+        self._timeout = timeout_seconds
+        self._check_interval = check_interval
+        self._now = now
+        self._on_stall = on_stall or self._abort
+        self._last_beat = now()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def beat(self) -> None:
+        """Record forward progress; resets the stall timer."""
+        self._last_beat = self._now()
+
+    def stalled(self) -> bool:
+        return (self._now() - self._last_beat) > self._timeout
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._thread = threading.Thread(
+            target=self._run, name="validator-watchdog", daemon=True
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self._check_interval + 1.0)
+            self._thread = None
+
+    def _run(self) -> None:
+        while not self._stop.wait(self._check_interval):
+            if self.stalled():
+                self._on_stall()
+                return
+
+    def _abort(self) -> None:
+        elapsed = self._now() - self._last_beat
+        logging.error(
+            "Validator watchdog: no progress for %.0fs (timeout %.0fs) — aborting "
+            "so the container restart policy recovers the validator (ORO-1414).",
+            elapsed,
+            self._timeout,
+        )
+        # os._exit, not sys.exit: bypass cleanup/atexit so a wedged process can't
+        # swallow the exit; the container exits and `restart: unless-stopped` fires.
+        os._exit(1)

--- a/subnet/validator/watchdog.py
+++ b/subnet/validator/watchdog.py
@@ -79,9 +79,14 @@ class ProgressWatchdog:
 
     def _abort(self) -> None:
         elapsed = self._now() - self._last_beat
+        # WATCHDOG_ABORT is a stable token so a CloudWatch Logs metric filter can
+        # alarm on validator self-recoveries (otherwise a restart loop is
+        # invisible unless someone reads container logs). A Prometheus counter
+        # would not work here: the process exits immediately, before the next
+        # scrape, and the counter resets to 0 on restart (ORO-1414).
         logging.error(
-            "Validator watchdog: no progress for %.0fs (timeout %.0fs) — aborting "
-            "so the container restart policy recovers the validator (ORO-1414).",
+            "WATCHDOG_ABORT: validator made no progress for %.0fs (timeout %.0fs); "
+            "aborting so the container restart policy recovers the validator (ORO-1414).",
             elapsed,
             self._timeout,
         )


### PR DESCRIPTION
## Description
Adds an in-process liveness watchdog so a wedged validator auto-recovers. The container already has `restart: unless-stopped`, but that only fires on a clean **exit**. In the 2026-06-23 incident the process wedged when the host disk filled (it stopped making progress without exiting), so the container stayed `Up` with `0B` in `docker stats` and never recovered until a manual `systemctl restart` ~90 min later (PD #257/#258). This is ORO-1414 Follow-up 2.

## Changes Made
- Add `subnet/validator/watchdog.py` — `ProgressWatchdog`: a daemon thread that aborts the process via `os._exit(1)` when the main loop hasn't beaten within the timeout, so the restart policy brings a fresh validator up. `os._exit` (not `sys.exit`) bypasses cleanup/atexit so a wedged process can't swallow the exit.
- Wire it into `run()`: the main loop calls `watchdog.beat()` at the top of each iteration; started after the weight setter, stopped in the shutdown `finally`.
- Add `--validator-watchdog-timeout` (env `VALIDATOR_WATCHDOG_TIMEOUT`, default **5400s = 90 min**; `0` disables).

## Design notes
- **No false-kills:** the beat is once per outer-loop iteration, so the timeout must exceed the longest legitimate iteration. Worst case is a hung update check (~900s) + a full eval (sandbox 1800s + scoring/reasoning ~900s+) ≈ 3600–3900s; the 5400s default leaves margin. A true total wedge is recycled within ~90 min.
- **Tighter recovery (follow-up):** beating from the heartbeat thread (which already fires every 30s *during* an eval) would decouple the timeout from eval duration and allow a much shorter timeout. Deferred because `HeartbeatManager` pulls in deps I couldn't verify locally; tracked on ORO-1414.
- **Accepted limitation:** a hard interpreter hang (GIL deadlock) starves the watchdog thread too; this catches the realistic "loop stopped progressing" case (the incident), not a full deadlock.
- **`os._exit` skips the in-flight eval-dir cleanup.** Bounded: PR #191 caps each log at 256 MiB and the watchdog fires only on a real wedge, so a leaked dir is small. A startup sweep of orphaned `eval_*` dirs is a sensible related follow-up (also closes an ORO-675 gap).

## Issue Link
- Related to: ORO-1414 (Follow-up 2: auto-restart the validator on a wedge)

## Testing

### Automated Testing
**Test Command(s):**
```bash
pytest subnet/tests/test_watchdog.py -v
```
5 passed: not-stalled-before-timeout, stalled-after-timeout, beat-resets-the-timer, monitor-thread-aborts-when-stalled (injected `on_stall`), monitor-thread-quiet-while-healthy. Pure unit via an injectable clock — no real waiting, deterministic.

Note: the full validator suite couldn't run in my local env (its conftest needs the heavier validator deps); CI runs it. `py_compile` + ruff clean on the changed files.

## Documentation
- [ ] README updated
- [x] Code comments added/updated
- [x] Configuration documentation updated (new `--validator-watchdog-timeout` / `VALIDATOR_WATCHDOG_TIMEOUT`, self-documented in `--help`)

## Checklist
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors (ruff clean, compiles)
- [x] I have added tests that prove my fix works
- [ ] New and existing unit tests pass locally (new tests pass; full suite deferred to CI)

## Additional Notes
- Independent of #191 (the stdout cap) — both are ORO-1414 follow-ups but touch different paths; either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)