### PR TITLE
weights: read burn rate from Backend per tick, collapse to single knob

### DIFF
--- a/subnet/tests/validator/test_weight_distribution.py
+++ b/subnet/tests/validator/test_weight_distribution.py
@@ -5,10 +5,10 @@ Determinism is load-bearing for Yuma consensus on subnet 15
 same race, the median collapses to 0 and the protection fails. The
 byte-identical test enforces that property at the API boundary.
 
-The model: top miner receives exactly `t_top` of normalised emission;
-burn uid + tail finishers together receive exactly `t_burn`. The tail's
-share comes out of `t_burn` so the top miner's share does not change
-with N.
+The model: single knob `t_burn` (Backend env var
+`emission_baseline_burn_rate`). Top miner gets `1 - t_burn`. When the
+tail integer-taper exceeds the burn budget (low-burn regime), the top
+miner absorbs the deficit; the tail's protection share is preserved.
 """
 
 from __future__ import annotations
@@ -50,9 +50,9 @@ def _share(value: int, total: int) -> float:
 
 
 def test_compute_pinned_weights_burn_dominant_no_tail():
-    """At t_top=0.25, t_burn=0.75 with no tail, burn pins at U16_MAX
-    and top is derived to give exactly the configured ratio."""
-    top, burn = compute_pinned_weights(0.25, 0.75, tail_sum=0)
+    """At t_burn=0.75 (today) with no tail, burn pins at U16_MAX and
+    top derives to give exactly 25% share."""
+    top, burn = compute_pinned_weights(0.75, tail_sum=0)
     assert burn == U16_MAX
     # Top derived: round(0.25 * 65535 / 0.75) = round(21845.0).
     assert top == 21845
@@ -63,73 +63,107 @@ def test_compute_pinned_weights_burn_dominant_no_tail():
 
 
 def test_compute_pinned_weights_top_share_invariant_under_tail_growth():
-    """The defining property: top miner's normalised share is exactly
-    `t_top` regardless of N (i.e. regardless of tail size). The tail
-    consumes only the burn share."""
+    """At t_burn >= t_top, the top miner's normalised share is exactly
+    `1 - t_burn` regardless of N (i.e. regardless of tail size). The
+    tail consumes only the burn share."""
     for tail_sum in [0, 105, 300, 1225, 5000]:
-        top, burn = compute_pinned_weights(0.25, 0.75, tail_sum=tail_sum)
+        top, burn = compute_pinned_weights(0.75, tail_sum=tail_sum)
         total = top + burn + tail_sum
-        # Top stays at 25.000% within rounding error (single-unit u16).
         assert abs(_share(top, total) - 0.25) < 1e-4
-        # Burn + tail together stay at 75.000%.
         assert abs(_share(burn + tail_sum, total) - 0.75) < 1e-4
 
 
 def test_compute_pinned_weights_top_dominant_pins_top_at_u16_max():
-    """Flipped ratio (t_top > t_burn): top pins, burn derives from share
-    minus the tail."""
-    top, burn = compute_pinned_weights(0.75, 0.25, tail_sum=0)
+    """t_burn < t_top (e.g. burn=0.25): top pins, burn derives from
+    share minus the tail."""
+    top, burn = compute_pinned_weights(0.25, tail_sum=0)
     assert top == U16_MAX
     # burn = round(0.25 * 65535 / 0.75) - 0 = 21845
     assert burn == 21845
 
 
 def test_compute_pinned_weights_equal_ratio_pins_burn():
-    """Equal split (0.5 / 0.5) — burn wins the tie-break and pins."""
-    top, burn = compute_pinned_weights(0.5, 0.5, tail_sum=0)
+    """Equal split (t_burn=0.5) — burn wins the tie-break and pins."""
+    top, burn = compute_pinned_weights(0.5, tail_sum=0)
     assert burn == U16_MAX
     assert top == U16_MAX
 
 
 def test_compute_pinned_weights_all_burn():
-    top, burn = compute_pinned_weights(0.0, 1.0, tail_sum=0)
+    top, burn = compute_pinned_weights(1.0, tail_sum=0)
     assert top == 0
     assert burn == U16_MAX
 
 
 def test_compute_pinned_weights_all_top():
-    top, burn = compute_pinned_weights(1.0, 0.0, tail_sum=0)
+    top, burn = compute_pinned_weights(0.0, tail_sum=0)
     assert top == U16_MAX
     assert burn == 0
 
 
+def test_compute_pinned_weights_burn_zero_absorbs_tail_into_top():
+    """ORO-1439: at t_burn=0, top miner absorbs the tail-share deficit.
+    Burn clamps to 0; top miner's effective share falls slightly below
+    1.0 to leave room for the tail's protection weights."""
+    tail_sum = 190  # M=19, race size 40
+    top, burn = compute_pinned_weights(0.0, tail_sum=tail_sum)
+    assert top == U16_MAX
+    assert burn == 0
+    total = top + burn + tail_sum
+    # Top effective share = U16_MAX / (U16_MAX + tail_sum).
+    assert abs(_share(top, total) - U16_MAX / (U16_MAX + tail_sum)) < 1e-9
+    # Tail share is exactly tail_sum / total.
+    assert abs(_share(tail_sum, total) - tail_sum / (U16_MAX + tail_sum)) < 1e-9
+
+
 @pytest.mark.parametrize(
-    "t_top, t_burn",
+    "t_burn",
     [
-        pytest.param(-0.1, 1.1, id="negative-top"),
-        pytest.param(1.1, -0.1, id="negative-burn"),
-        pytest.param(0.6, 0.5, id="sum-greater-than-1"),
-        pytest.param(0.6, 0.3, id="sum-less-than-1"),
-        pytest.param(0.0, 0.0, id="both-zero"),
+        pytest.param(-0.1, id="negative"),
+        pytest.param(1.1, id="above-1"),
     ],
 )
-def test_compute_pinned_weights_rejects_invalid_ratios(t_top, t_burn):
+def test_compute_pinned_weights_rejects_invalid_burn(t_burn):
     with pytest.raises(ValueError):
-        compute_pinned_weights(t_top, t_burn, tail_sum=0)
+        compute_pinned_weights(t_burn, tail_sum=0)
 
 
 def test_compute_pinned_weights_rejects_negative_tail_sum():
     with pytest.raises(ValueError):
-        compute_pinned_weights(0.25, 0.75, tail_sum=-1)
+        compute_pinned_weights(0.75, tail_sum=-1)
 
 
-def test_compute_pinned_weights_rejects_oversized_tail_at_top_dominant():
-    """Top dominant + tail bigger than burn share → would emit negative
-    burn. Fail loud rather than emit nonsense."""
-    # t_top=0.99, t_burn=0.01 → burn share at U16_MAX/0.99 ≈ 662.
-    # tail_sum=1000 exceeds that.
-    with pytest.raises(ValueError):
-        compute_pinned_weights(0.99, 0.01, tail_sum=1000)
+def test_compute_pinned_weights_oversized_tail_at_low_burn_absorbs_into_top():
+    """ORO-1439: top-dominant + tail bigger than burn budget — used to
+    raise ValueError. Now the top miner absorbs the deficit (burn
+    clamps to 0) and the vector still emits valid u16 weights."""
+    # t_burn=0.01 → burn would be round(0.01 * U16_MAX / 0.99) - 1000 = 662 - 1000 = -338
+    top, burn = compute_pinned_weights(0.01, tail_sum=1000)
+    assert top == U16_MAX
+    assert burn == 0
+
+
+# --- invariant: shares sum to 1.0 across burn sweep ---
+
+
+@pytest.mark.parametrize("t_burn", [0.0, 0.25, 0.5, 0.75, 1.0])
+@pytest.mark.parametrize("n", [10, 20, 40, 80])
+def test_total_shares_sum_to_one_across_burn_sweep(t_burn, n):
+    """Top + tail + burn shares always sum to 1.0 (single-knob
+    invariant), even in the low-burn deficit-absorption regime."""
+    finishers = _make_finishers(n, seed=n)
+    ranked = rank_finishers(finishers)
+    metagraph = ["burn_uid"] + [f.miner_hotkey for f in finishers]
+    _, weights = build_metagraph_weight_vector(
+        finishers,
+        metagraph,
+        t_burn=t_burn,
+        top_hotkey=ranked[0].miner_hotkey,
+    )
+    total = sum(weights)
+    assert total > 0
+    # Shares sum to 1.0 by construction; just make sure non-negative.
+    assert all(w >= 0 for w in weights)
 
 
 # --- ranking ---
@@ -157,25 +191,24 @@ def test_rank_finishers_stable_under_input_shuffle():
 
 
 @pytest.mark.parametrize("n", [10, 30, 50, 100])
-@pytest.mark.parametrize("t_top, t_burn", [(0.25, 0.75), (0.75, 0.25)])
-def test_compute_hotkey_weights_shape_per_spec(n, t_top, t_burn):
-    """Rank 1 = top_u16 (sized for exact `t_top` share), ranks 2..K =
+@pytest.mark.parametrize("t_burn", [0.75, 0.25])
+def test_compute_hotkey_weights_shape_per_spec(n, t_burn):
+    """Rank 1 = top_u16 (sized for exact `1 - t_burn` share), ranks 2..K =
     K+1-rank, bottom 50% absent."""
     finishers = _make_finishers(n, seed=n)
     ranked = rank_finishers(finishers)
     weights = compute_hotkey_weights(
-        finishers, t_top, t_burn, top_hotkey=ranked[0].miner_hotkey
+        finishers, t_burn, top_hotkey=ranked[0].miner_hotkey
     )
 
     k = n // 2
     assert len(weights) == k
 
     tail_sum = sum(range(1, k))  # 1 + 2 + ... + (K-1)
-    expected_top, _ = compute_pinned_weights(t_top, t_burn, tail_sum=tail_sum)
+    expected_top, _ = compute_pinned_weights(t_burn, tail_sum=tail_sum)
 
     assert weights[ranked[0].miner_hotkey] == expected_top
 
-    # Ranks 2..K = K + 1 - rank (linear taper, last entry weight=1).
     for idx in range(1, k):
         rank_1based = idx + 1
         assert weights[ranked[idx].miner_hotkey] == k + 1 - rank_1based
@@ -193,25 +226,23 @@ def test_compute_hotkey_weights_empty_for_too_few_finishers(n):
     """N=0 or N=1 → floor(N/2)=0, no protected tail entries. With no
     `top_hotkey` either, the dict is empty; the burn uid still fires
     unconditionally in `build_metagraph_weight_vector`."""
-    weights = compute_hotkey_weights(_make_finishers(n), 0.25, 0.75)
+    weights = compute_hotkey_weights(_make_finishers(n), 0.75)
     assert weights == {}
 
 
-# --- top share is exactly t_top across N (the load-bearing property) ---
+# --- top share is exactly (1 - t_burn) across N (the load-bearing property at high burn) ---
 
 
 @pytest.mark.parametrize("n", [10, 30, 50, 100])
 def test_top_miner_share_is_exactly_t_top_regardless_of_n(n):
-    """The whole point of pulling the tail out of t_burn (rather than
-    eating from both proportionally) is that the top miner's share is
-    invariant under N. Verify on the integrated metagraph vector."""
+    """At t_burn=0.75 the top miner's share is invariant under N. Verify
+    on the integrated metagraph vector."""
     finishers = _make_finishers(n, seed=n)
     ranked = rank_finishers(finishers)
     metagraph = ["hk_burn"] + [e.miner_hotkey for e in finishers]
     _, weights = build_metagraph_weight_vector(
         finishers,
         metagraph,
-        t_top=0.25,
         t_burn=0.75,
         top_hotkey=ranked[0].miner_hotkey,
     )
@@ -221,7 +252,6 @@ def test_top_miner_share_is_exactly_t_top_regardless_of_n(n):
     top_share = weights[rank1_idx] / total
     assert abs(top_share - 0.25) < 5e-4
 
-    # Burn + tail together = exactly t_burn.
     burn_plus_tail = total - weights[rank1_idx]
     assert abs(burn_plus_tail / total - 0.75) < 5e-4
 
@@ -234,7 +264,7 @@ def test_compute_hotkey_weights_n30_top_share_25pct():
     finishers = _make_finishers(30, seed=30)
     ranked = rank_finishers(finishers)
     weights = compute_hotkey_weights(
-        finishers, 0.25, 0.75, top_hotkey=ranked[0].miner_hotkey
+        finishers, 0.75, top_hotkey=ranked[0].miner_hotkey
     )
 
     assert weights[ranked[0].miner_hotkey] == 21880
@@ -247,7 +277,7 @@ def test_compute_hotkey_weights_n100_top_share_25pct():
     finishers = _make_finishers(100, seed=100)
     ranked = rank_finishers(finishers)
     weights = compute_hotkey_weights(
-        finishers, 0.25, 0.75, top_hotkey=ranked[0].miner_hotkey
+        finishers, 0.75, top_hotkey=ranked[0].miner_hotkey
     )
 
     assert weights[ranked[0].miner_hotkey] == 22253
@@ -266,13 +296,13 @@ def test_two_validators_with_same_inputs_emit_byte_identical_weights():
     random.Random(2).shuffle(finishers_b)
 
     metagraph_a = ["hk_burn"] + [e.miner_hotkey for e in finishers_a]
-    metagraph_b = list(metagraph_a)  # uids are chain-assigned, not per-validator
+    metagraph_b = list(metagraph_a)
 
     uids_a, weights_a = build_metagraph_weight_vector(
-        finishers_a, metagraph_a, t_top=0.25, t_burn=0.75
+        finishers_a, metagraph_a, t_burn=0.75
     )
     uids_b, weights_b = build_metagraph_weight_vector(
-        finishers_b, metagraph_b, t_top=0.25, t_burn=0.75
+        finishers_b, metagraph_b, t_burn=0.75
     )
 
     assert uids_a == uids_b
@@ -287,11 +317,11 @@ def test_build_metagraph_vector_places_burn_at_uid_0():
     metagraph = ["burn_hk"] + [e.miner_hotkey for e in finishers]
 
     _, weights = build_metagraph_weight_vector(
-        finishers, metagraph, t_top=0.25, t_burn=0.75
+        finishers, metagraph, t_burn=0.75
     )
 
-    assert weights[0] == U16_MAX  # burn slot pinned
-    assert weights[0] >= weights[1]  # burn dominates rank-1 in this regime
+    assert weights[0] == U16_MAX
+    assert weights[0] >= weights[1]
 
 
 def test_build_metagraph_vector_drops_hotkeys_missing_from_metagraph():
@@ -305,11 +335,9 @@ def test_build_metagraph_vector_drops_hotkeys_missing_from_metagraph():
     ]
 
     _, weights = build_metagraph_weight_vector(
-        finishers, metagraph, t_top=0.25, t_burn=0.75
+        finishers, metagraph, t_burn=0.75
     )
 
-    # Rank-1 hotkey is gone — no entry has the top u16.
-    # Burn slot still holds U16_MAX.
     assert weights[0] == U16_MAX
 
 
@@ -317,7 +345,7 @@ def test_build_metagraph_vector_returns_aligned_uids():
     finishers = _make_finishers(10, seed=10)
     metagraph = ["burn_hk"] + [e.miner_hotkey for e in finishers]
     uids, weights = build_metagraph_weight_vector(
-        finishers, metagraph, t_top=0.25, t_burn=0.75
+        finishers, metagraph, t_burn=0.75
     )
     assert uids == list(range(len(metagraph)))
     assert len(weights) == len(metagraph)
@@ -326,7 +354,7 @@ def test_build_metagraph_vector_returns_aligned_uids():
 def test_build_metagraph_vector_empty_metagraph_returns_empty():
     finishers = _make_finishers(10, seed=10)
     uids, weights = build_metagraph_weight_vector(
-        finishers, [], t_top=0.25, t_burn=0.75
+        finishers, [], t_burn=0.75
     )
     assert uids == []
     assert weights == []
@@ -343,13 +371,10 @@ def test_top_hotkey_none_burns_top_share_no_synthesis():
     ranked = rank_finishers(finishers)
     k = len(finishers) // 2
 
-    weights = compute_hotkey_weights(finishers, 0.25, 0.75, top_hotkey=None)
+    weights = compute_hotkey_weights(finishers, 0.75, top_hotkey=None)
 
-    # No top entry: every entry is a tail entry with a small u16 weight.
-    # In particular, rank-1 does NOT receive top_u16.
-    expected_top_u16, _ = compute_pinned_weights(0.25, 0.75, tail_sum=k * (k + 1) // 2)
+    expected_top_u16, _ = compute_pinned_weights(0.75, tail_sum=k * (k + 1) // 2)
     assert weights[ranked[0].miner_hotkey] != expected_top_u16
-    # Full top-K populates the tail (M = K, weights K, K-1, ..., 1).
     assert weights[ranked[0].miner_hotkey] == k
     assert weights[ranked[k - 1].miner_hotkey] == 1
     assert len(weights) == k
@@ -363,18 +388,14 @@ def test_top_hotkey_override_promotes_non_winner_to_top_slot():
     rank1 = ranked[0].miner_hotkey
     rank2 = ranked[1].miner_hotkey
 
-    weights = compute_hotkey_weights(finishers, 0.25, 0.75, top_hotkey=rank2)
+    weights = compute_hotkey_weights(finishers, 0.75, top_hotkey=rank2)
 
-    # Rank2 (the new "current top") receives the top u16 slot.
     top_u16 = max(weights.values())
     assert weights[rank2] == top_u16
-    # Old rank-1 is still in the tail (top half of finishers, dereg-protected).
     assert rank1 in weights
     assert weights[rank1] != top_u16
-    # Old rank-1 takes the largest tail weight (M = K-1) since they are now
-    # rank-1 of the tail's existing rank order.
     k = len(finishers) // 2
-    m = k - 1  # rank2 was in the protected set, so tail size = K - 1
+    m = k - 1
     assert weights[rank1] == m
 
 
@@ -387,29 +408,26 @@ def test_top_hotkey_not_in_finishers_keeps_old_winner_in_tail():
     rank1 = ranked[0].miner_hotkey
     new_top = "hk_brand_new_agent"
 
-    weights = compute_hotkey_weights(finishers, 0.25, 0.75, top_hotkey=new_top)
+    weights = compute_hotkey_weights(finishers, 0.75, top_hotkey=new_top)
 
     top_u16 = max(weights.values())
     assert weights[new_top] == top_u16
-    # Old rank-1 takes the largest tail weight (M = K, full top-K tail).
     k = len(finishers) // 2
     assert weights[rank1] == k
 
 
 def test_top_hotkey_override_top_share_remains_t_top():
     """The top miner's share of the chain-normalised vector stays at
-    exactly `t_top` regardless of whether the override pulls from inside
-    or outside the protected tail."""
+    exactly `1 - t_burn` regardless of whether the override pulls from
+    inside or outside the protected tail."""
     finishers = _make_finishers(20, seed=99)
     ranked = rank_finishers(finishers)
 
     for top_hk in [ranked[0].miner_hotkey, ranked[5].miner_hotkey, "hk_outsider"]:
-        weights = compute_hotkey_weights(finishers, 0.25, 0.75, top_hotkey=top_hk)
-        # Burn slot is implicit (uid 0); compute it from compute_pinned_weights
-        # using the actual tail sum.
+        weights = compute_hotkey_weights(finishers, 0.75, top_hotkey=top_hk)
         m = sum(1 for v in weights.values() if v != max(weights.values()))
         tail_sum = m * (m + 1) // 2
-        top_u16, burn_u16 = compute_pinned_weights(0.25, 0.75, tail_sum)
+        top_u16, burn_u16 = compute_pinned_weights(0.75, tail_sum)
         total = top_u16 + burn_u16 + tail_sum
         assert _share(top_u16, total) == pytest.approx(0.25, abs=2e-4)
 
@@ -425,20 +443,17 @@ def test_build_metagraph_vector_top_hotkey_promoted_to_top_slot():
     uids, weights = build_metagraph_weight_vector(
         finishers,
         metagraph_hotkeys=metagraph_hotkeys,
-        t_top=0.25,
         t_burn=0.75,
         top_hotkey=rank2_hk,
     )
     rank2_idx = metagraph_hotkeys.index(rank2_hk)
     rank1_idx = metagraph_hotkeys.index(ranked[0].miner_hotkey)
-    # uid 0 is the burn slot (pinned at U16_MAX under t_top<t_burn) — exclude
-    # it when checking "top" among non-burn slots.
     non_burn = [w if i != 0 else 0 for i, w in enumerate(weights)]
 
-    assert weights[rank2_idx] == max(non_burn)  # rank2 promoted to top
-    assert weights[rank1_idx] > 0  # old rank-1 still in tail
+    assert weights[rank2_idx] == max(non_burn)
+    assert weights[rank1_idx] > 0
     assert weights[rank1_idx] < weights[rank2_idx]
-    assert weights[0] > 0  # burn slot non-zero
+    assert weights[0] > 0
 
 
 def test_build_metagraph_vector_top_hotkey_not_in_metagraph_burns_top_share():
@@ -454,18 +469,14 @@ def test_build_metagraph_vector_top_hotkey_not_in_metagraph_burns_top_share():
     uids, weights = build_metagraph_weight_vector(
         finishers,
         metagraph_hotkeys=metagraph_hotkeys,
-        t_top=0.25,
         t_burn=0.75,
         top_hotkey="hk_deregistered",
     )
 
-    # Burn uid pinned at U16_MAX (it dominates the vector). No rank-1
-    # promotion: the rank-1 finisher only receives its small tail weight.
     assert weights[0] == U16_MAX
     rank1_idx = metagraph_hotkeys.index(rank1_hk)
     k = len(finishers) // 2
-    assert weights[rank1_idx] == k  # full top-K tail; rank-1 gets weight = K
-    # Burn dominates the chain-normalised vector — top share ≈ 0%.
+    assert weights[rank1_idx] == k
     total = sum(weights)
     burn_share = weights[0] / total
     assert burn_share > 0.99
@@ -483,20 +494,16 @@ def test_build_metagraph_vector_no_top_hotkey_burns_top_share():
     uids, weights = build_metagraph_weight_vector(
         finishers,
         metagraph_hotkeys=metagraph_hotkeys,
-        t_top=0.25,
         t_burn=0.75,
         top_hotkey=None,
     )
 
-    assert weights[0] == U16_MAX  # burn pinned
-    # Rank-1 finisher does NOT receive top_u16 — they only get a tail weight.
+    assert weights[0] == U16_MAX
     rank1_idx = metagraph_hotkeys.index(ranked[0].miner_hotkey)
     k = len(finishers) // 2
-    assert weights[rank1_idx] == k  # full top-K tail, M=K
-    # Burn dominates: top share ≈ 0%.
+    assert weights[rank1_idx] == k
     total = sum(weights)
     assert weights[0] / total > 0.99
-    # Bottom-half finishers still get 0.
     for idx in range(k, len(finishers)):
         bottom_idx = metagraph_hotkeys.index(ranked[idx].miner_hotkey)
         assert weights[bottom_idx] == 0
@@ -509,7 +516,6 @@ def test_build_metagraph_vector_no_top_hotkey_no_finishers_burns_everything():
     uids, weights = build_metagraph_weight_vector(
         [],
         metagraph_hotkeys=metagraph_hotkeys,
-        t_top=0.25,
         t_burn=0.75,
         top_hotkey=None,
     )
@@ -521,15 +527,14 @@ def test_build_metagraph_vector_no_top_hotkey_no_finishers_burns_everything():
 
 def test_two_validators_with_top_override_emit_byte_identical_weights():
     """Determinism property still holds when `top_hotkey` is supplied:
-    same `(top_hotkey, finishers, t_top, t_burn)` → byte-identical vectors."""
+    same `(top_hotkey, finishers, t_burn)` → byte-identical vectors."""
     finishers = _make_finishers(50, seed=2026)
     metagraph_hotkeys = ["burn_uid"] + [f.miner_hotkey for f in finishers]
-    top_hk = finishers[7].miner_hotkey  # arbitrary middle-rank hotkey
+    top_hk = finishers[7].miner_hotkey
 
     a_uids, a_weights = build_metagraph_weight_vector(
         finishers,
         metagraph_hotkeys=metagraph_hotkeys,
-        t_top=0.25,
         t_burn=0.75,
         top_hotkey=top_hk,
     )
@@ -538,9 +543,30 @@ def test_two_validators_with_top_override_emit_byte_identical_weights():
     b_uids, b_weights = build_metagraph_weight_vector(
         shuffled,
         metagraph_hotkeys=metagraph_hotkeys,
-        t_top=0.25,
         t_burn=0.75,
         top_hotkey=top_hk,
     )
     assert a_uids == b_uids
     assert a_weights == b_weights
+
+
+# --- ORO-1439: burn-from-backend, deficit absorption ---
+
+
+def test_build_metagraph_vector_burn_zero_emits_top_dominant_vector():
+    """At t_burn=0, top miner takes ~99.7% (M=19 race), tail keeps its
+    rank-j integer taper, burn uid stamps 0."""
+    finishers = _make_finishers(40, seed=1439)
+    ranked = rank_finishers(finishers)
+    metagraph = ["burn_uid"] + [f.miner_hotkey for f in finishers]
+    _, weights = build_metagraph_weight_vector(
+        finishers,
+        metagraph,
+        t_burn=0.0,
+        top_hotkey=ranked[0].miner_hotkey,
+    )
+    rank1_idx = metagraph.index(ranked[0].miner_hotkey)
+    assert weights[rank1_idx] == U16_MAX
+    assert weights[0] == 0  # burn slot empty
+    total = sum(weights)
+    assert weights[rank1_idx] / total == pytest.approx(0.9971, abs=1e-3)

--- a/subnet/tests/validator/test_weight_distribution.py
+++ b/subnet/tests/validator/test_weight_distribution.py
@@ -102,8 +102,8 @@ def test_compute_pinned_weights_all_top():
 
 
 def test_compute_pinned_weights_burn_zero_absorbs_tail_into_top():
-    """ORO-1439: at t_burn=0, top miner absorbs the tail-share deficit.
-    Burn clamps to 0; top miner's effective share falls slightly below
+    """At t_burn=0, the top miner absorbs the tail-share deficit. Burn
+    clamps to 0; the top miner's effective share falls slightly below
     1.0 to leave room for the tail's protection weights."""
     tail_sum = 190  # M=19, race size 40
     top, burn = compute_pinned_weights(0.0, tail_sum=tail_sum)
@@ -134,9 +134,9 @@ def test_compute_pinned_weights_rejects_negative_tail_sum():
 
 
 def test_compute_pinned_weights_oversized_tail_at_low_burn_absorbs_into_top():
-    """ORO-1439: top-dominant + tail bigger than burn budget — used to
-    raise ValueError. Now the top miner absorbs the deficit (burn
-    clamps to 0) and the vector still emits valid u16 weights."""
+    """Top-dominant + tail bigger than burn budget — used to raise
+    ValueError. Now the top miner absorbs the deficit (burn clamps to
+    0) and the vector still emits valid u16 weights."""
     # t_burn=0.01 → burn would be round(0.01 * U16_MAX / 0.99) - 1000 = 662 - 1000 = -338
     top, burn = compute_pinned_weights(0.01, tail_sum=1000)
     assert top == U16_MAX
@@ -550,7 +550,7 @@ def test_two_validators_with_top_override_emit_byte_identical_weights():
     assert a_weights == b_weights
 
 
-# --- ORO-1439: burn-from-backend, deficit absorption ---
+# --- burn-from-backend, deficit absorption ---
 
 
 def test_build_metagraph_vector_burn_zero_emits_top_dominant_vector():

--- a/subnet/tests/validator/test_weight_setter.py
+++ b/subnet/tests/validator/test_weight_setter.py
@@ -102,7 +102,7 @@ class TestWeightSetterThread:
         setter.stop()
         assert not setter._thread.is_alive()
 
-    def test_invalid_ratio_raises_at_construction(
+    def test_invalid_burn_fallback_raises_at_construction(
         self, mock_backend_client, mock_subtensor, mock_metagraph, mock_wallet
     ):
         with pytest.raises(ValueError):
@@ -112,8 +112,7 @@ class TestWeightSetterThread:
                 metagraph=mock_metagraph,
                 wallet=mock_wallet,
                 netuid=1,
-                t_top=0.6,
-                t_burn=0.5,  # sum > 1
+                t_burn_fallback=1.1,  # > 1
             )
 
     # --- race-based path (only path remaining) ---
@@ -194,7 +193,7 @@ class TestWeightSetterThread:
 
         weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
         # K=3, tail (ranks 2..3) = [2, 1] → tail_sum_actual = 3.
-        top_u16, burn_u16 = compute_pinned_weights(0.25, 0.75, tail_sum=3)
+        top_u16, burn_u16 = compute_pinned_weights(0.75, tail_sum=3)
         assert weights[0] == burn_u16
         assert weights[1] == top_u16
         assert weights[2] == 2
@@ -247,7 +246,7 @@ class TestWeightSetterThread:
         for call in mock_backend_client.get_race_detail.call_args_list:
             assert call.args == (completed_id,) or call.kwargs == {"race_id": completed_id}
         weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
-        top_u16, _ = compute_pinned_weights(0.25, 0.75, tail_sum=3)
+        top_u16, _ = compute_pinned_weights(0.75, tail_sum=3)
         assert weights[1] == top_u16
 
     def test_drift_correction_when_protected_finishers_deregistered(
@@ -286,7 +285,7 @@ class TestWeightSetterThread:
 
         weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
         # Tail dereg'd → tail_sum_actual = 0 → recompute pins top, burn.
-        top_u16, burn_u16 = compute_pinned_weights(0.25, 0.75, tail_sum=0)
+        top_u16, burn_u16 = compute_pinned_weights(0.75, tail_sum=0)
         assert weights[0] == burn_u16
         assert weights[1] == top_u16
         # Submitted top share matches t_top exactly.

--- a/subnet/validator/weight_distribution.py
+++ b/subnet/validator/weight_distribution.py
@@ -31,17 +31,24 @@ U16_MAX = 65535
 
 # Allocation model
 # ----------------
-# Top miner receives exactly `t_top` of normalised emission. Burn uid +
-# tail (top-half ranks 2..K) together receive exactly `t_burn`.
-# `t_top + t_burn == 1` is required — there is no third bucket.
+# Single knob: `t_burn`, the baseline burn rate (0..1). The top miner's
+# share is implicitly `t_top = 1.0 - t_burn` — there is no third bucket.
 #
-# Concretely with `t_top=0.25`, `t_burn=0.75`:
+# When `t_burn >= t_top` (e.g. 0.75 / 0.25 today):
 #   * burn slot pinned at U16_MAX = 65535
 #   * total = (U16_MAX + tail_sum) / t_burn
 #   * top u16 = round(t_top * total)
-# so the top miner's share is invariant under `tail_sum` (i.e. under N),
-# and the tail "comes out of" the burn allocation rather than from both
-# top and burn proportionally.
+# The tail (top-half ranks 2..K, integer taper M, M-1, ..., 1) comes out
+# of the burn allocation; top miner stays at exactly `t_top` regardless
+# of race size.
+#
+# When `t_burn < t_top` (low-burn regime, e.g. burn=0):
+#   * top slot pinned at U16_MAX
+#   * burn = round(t_burn * U16_MAX / t_top) - tail_sum, clamped at 0
+# If the tail exceeds the burn budget, the top miner absorbs the
+# deficit — their effective share falls from `t_top` to
+# `U16_MAX / (U16_MAX + tail_sum)`. The tail's protection share is
+# preserved; only the burn-vs-top split shifts.
 
 
 @dataclass(frozen=True)
@@ -71,15 +78,9 @@ def rank_finishers(qualifiers: Iterable[RankedFinisher]) -> list[RankedFinisher]
     )
 
 
-def _validate_ratios(t_top: float, t_burn: float) -> None:
-    if t_top < 0 or t_burn < 0:
-        raise ValueError("t_top and t_burn must be non-negative")
-    if abs((t_top + t_burn) - 1.0) > 1e-9:
-        raise ValueError(
-            "t_top + t_burn must equal 1; the tail comes out of t_burn's share"
-        )
-    if t_top == 0 and t_burn == 0:
-        raise ValueError("at least one of t_top / t_burn must be > 0")
+def _validate_burn(t_burn: float) -> None:
+    if t_burn < 0 or t_burn > 1:
+        raise ValueError("t_burn must be in [0, 1]")
 
 
 def _tail_sum_for(k: int) -> int:
@@ -92,56 +93,54 @@ def _tail_sum_for(k: int) -> int:
     return (k - 1) * k // 2
 
 
-def compute_pinned_weights(
-    t_top: float, t_burn: float, tail_sum: int
-) -> tuple[int, int]:
-    """Return `(top_u16, burn_u16)` such that the chain-normalised vector
-    yields exactly `t_top` for the top miner and `t_burn` for the burn uid
-    plus tail combined.
+def compute_pinned_weights(t_burn: float, tail_sum: int) -> tuple[int, int]:
+    """Return `(top_u16, burn_u16)` for the chain-normalised vector.
 
-    The tail allocation comes out of `t_burn`'s share, not from both
-    proportionally — top miner stays at exactly `t_top` regardless of N.
+    `t_top` is derived as `1.0 - t_burn` — the two are always
+    complementary, so a single knob suffices. Backend's
+    `emission_baseline_burn_rate` is the source of truth.
 
-    The larger of `t_top` / `t_burn` is pinned at `U16_MAX`; the smaller
-    is derived from the ratio + the tail sum so the integrated total
-    sums to the right normalised shares.
+    When `t_burn >= t_top` (e.g. today's 0.75 / 0.25 split), burn is
+    pinned at `U16_MAX` and top derives from the ratio; the tail's
+    share comes out of `t_burn`'s budget, so the top miner stays at
+    exactly `t_top` regardless of N.
+
+    When `t_burn < t_top` (lower-burn regime) AND the rank-j tail
+    exceeds what the burn budget can fund, the deficit is absorbed by
+    the top miner — burn clamps to 0 and the top miner's effective
+    share falls slightly below `t_top` (specifically to
+    `U16_MAX / (U16_MAX + tail_sum)`). The tail's protection share is
+    never compromised; only the burn-vs-top split shifts.
     """
-    _validate_ratios(t_top, t_burn)
+    _validate_burn(t_burn)
     if tail_sum < 0:
         raise ValueError("tail_sum must be non-negative")
 
+    t_top = 1.0 - t_burn
+
     if t_burn >= t_top:
-        # Pin burn slot at U16_MAX. Burn share equals (burn + tail) / total,
-        # so total = (U16_MAX + tail_sum) / t_burn and top = t_top * total.
-        burn = U16_MAX
+        # Pin burn at U16_MAX. total = (U16_MAX + tail_sum) / t_burn,
+        # top = t_top * total. Tail's share fits inside t_burn's budget.
         if t_burn == 0:
             return 0, 0
         total = (U16_MAX + tail_sum) / t_burn
         top = round(t_top * total) if t_top > 0 else 0
-        return top, burn
+        return top, U16_MAX
 
-    # Pin top at U16_MAX. Total = U16_MAX / t_top; burn slot is the
-    # share of t_burn that's left after the tail consumes its part.
-    top = U16_MAX
-    if t_top == 0:
+    # t_burn < t_top: pin top at U16_MAX. Burn = remaining share after
+    # the tail consumes its rank-j integers. Clamp at 0 — the top miner
+    # absorbs the deficit when the tail would push burn negative.
+    if t_top == 0:  # unreachable given t_burn < t_top branch, defensive
         return 0, 0
     total = U16_MAX / t_top
     burn = round(t_burn * total) - tail_sum
     if burn < 0:
-        # Tail consumed more than the burn share — the configured t_burn
-        # is too small for the race size at this t_top. The caller would
-        # need to either drop t_top, raise t_burn, or shrink K. Fail loud
-        # rather than silently emitting a negative burn.
-        raise ValueError(
-            f"tail_sum {tail_sum} exceeds burn share at "
-            f"t_top={t_top}, t_burn={t_burn}; lower N or adjust ratios"
-        )
-    return top, burn
+        burn = 0
+    return U16_MAX, burn
 
 
 def compute_hotkey_weights(
     qualifiers: Iterable[RankedFinisher],
-    t_top: float,
     t_burn: float,
     top_hotkey: str | None = None,
 ) -> dict[str, int]:
@@ -175,7 +174,7 @@ def compute_hotkey_weights(
     m = len(tail_finishers)
     tail_sum = m * (m + 1) // 2  # M + (M-1) + ... + 1
 
-    top_u16, _ = compute_pinned_weights(t_top, t_burn, tail_sum)
+    top_u16, _ = compute_pinned_weights(t_burn, tail_sum)
     weights: dict[str, int] = {}
     if top_hotkey is not None:
         weights[top_hotkey] = top_u16
@@ -188,7 +187,6 @@ def compute_hotkey_weights(
 def build_metagraph_weight_vector(
     qualifiers: Iterable[RankedFinisher],
     metagraph_hotkeys: list[str],
-    t_top: float,
     t_burn: float,
     top_hotkey: str | None = None,
 ) -> tuple[list[int], list[int]]:
@@ -235,7 +233,7 @@ def build_metagraph_weight_vector(
     effective_top = top_hotkey if has_eligible_top else None
 
     hotkey_weights = compute_hotkey_weights(
-        list(qualifiers), t_top, t_burn, top_hotkey=effective_top
+        list(qualifiers), t_burn, top_hotkey=effective_top
     )
 
     # Place the tail. The top entry (if any) is pinned below from the
@@ -255,7 +253,7 @@ def build_metagraph_weight_vector(
     # Pin top + burn from the *actual* tail sum so the top miner lands at
     # exactly `t_top` of the submitted vector. Additive assignment handles
     # the rare testnet case where uid 0 is itself the top hotkey.
-    top_u16, burn_u16 = compute_pinned_weights(t_top, t_burn, tail_sum_actual)
+    top_u16, burn_u16 = compute_pinned_weights(t_burn, tail_sum_actual)
     weights[0] += burn_u16
     if has_eligible_top:
         weights[hotkey_to_idx[top_hotkey]] += top_u16

--- a/subnet/validator/weight_setter.py
+++ b/subnet/validator/weight_setter.py
@@ -19,6 +19,7 @@ from oro_sdk.types import UNSET
 from .backend_client import BackendClient, BackendError
 from .weight_distribution import (
     RankedFinisher,
+    _validate_burn,
     build_metagraph_weight_vector,
     compute_pinned_weights,
 )
@@ -86,6 +87,11 @@ class WeightSetterThread:
     # cadence (one in-progress + a handful of completed) without paging.
     _RACE_HISTORY_SCAN_LIMIT = 5
 
+    # Fallback burn rate when Backend policy is unreachable. Matches the
+    # historical default; ops can flip the live value via Backend env
+    # without a validator release.
+    _DEFAULT_BURN_RATE = 0.75
+
     def __init__(
         self,
         backend_client: BackendClient,
@@ -94,8 +100,7 @@ class WeightSetterThread:
         wallet,
         netuid: int,
         interval_seconds: int = 300,
-        t_top: float = 0.25,
-        t_burn: float = 0.75,
+        t_burn_fallback: float = _DEFAULT_BURN_RATE,
     ):
         self.backend_client = backend_client
         self.subtensor = subtensor
@@ -103,14 +108,12 @@ class WeightSetterThread:
         self.wallet = wallet
         self.netuid = netuid
         self.interval_seconds = interval_seconds
-        self.t_top = t_top
-        self.t_burn = t_burn
+        self.t_burn_fallback = t_burn_fallback
 
-        # Fail fast on misconfiguration — the validator process should not
-        # start setting weights with invalid ratios. tail_sum=0 is the
-        # smallest case (any t_top + t_burn = 1 will pass), validating the
-        # ratio constraint without requiring a representative N.
-        compute_pinned_weights(t_top, t_burn, tail_sum=0)
+        # Fail fast on misconfiguration of the fallback value. The live
+        # value pulled from Backend is validated each tick by
+        # `compute_pinned_weights`.
+        compute_pinned_weights(t_burn_fallback, tail_sum=0)
 
         self._stop_event = threading.Event()
         self._thread: Optional[threading.Thread] = None
@@ -166,30 +169,53 @@ class WeightSetterThread:
                 return _qualifiers_to_finishers(qualifiers)
         return None
 
-    def _fetch_top_hotkey(self) -> Optional[str]:
-        """Return the canonical "current top miner" hotkey for emissions.
+    def _fetch_top_state(self) -> tuple[Optional[str], float]:
+        """Return `(top_hotkey, t_burn)` from `GET /v1/public/top`.
 
-        Reads `GET /v1/public/top` (the score-to-beat designation). Returns
-        None when there's no admin-designated top (fresh subnet, suite
-        switch, or designated top was discarded) or the request fails. In
-        all such cases `build_metagraph_weight_vector` burns the 25% top
-        share rather than synthesizing a top from rank-1 of finishers —
-        the top slot belongs to the admin-designated top only.
+        `top_hotkey` is the canonical "current top miner" for emissions.
+        None when no admin-designated top exists (fresh subnet, suite
+        switch, or designated top was discarded) — in those cases the
+        top share folds into the burn slot.
+
+        `t_burn` is the live `emission_baseline_burn_rate` from the
+        Backend policy block. Lets ops flip burn (CDK env var) without
+        a validator release. On any Backend error OR a missing/invalid
+        policy value, falls back to `self.t_burn_fallback`.
         """
         try:
             top = self.backend_client.get_top_miner()
         except BackendError as e:
             logging.warning(
-                f"Top-miner fetch failed, falling back to last-race rank-1: {e}"
+                f"Top fetch failed, using fallback burn rate: {e}"
             )
-            return None
+            return None, self.t_burn_fallback
+
         hk = top.top_miner_hotkey
-        if hk is None or hk is UNSET:
-            return None
-        return str(hk)
+        top_hotkey = (
+            str(hk) if hk is not None and hk is not UNSET else None
+        )
+
+        t_burn = self.t_burn_fallback
+        policy = top.policy
+        if policy is not None and policy is not UNSET:
+            try:
+                value = policy["emission_baseline_burn_rate"]
+                t_burn = float(value)
+                _validate_burn(t_burn)
+            except (KeyError, TypeError, ValueError) as e:
+                logging.warning(
+                    f"Invalid emission_baseline_burn_rate in policy, "
+                    f"using fallback {self.t_burn_fallback}: {e}"
+                )
+                t_burn = self.t_burn_fallback
+
+        return top_hotkey, t_burn
 
     def _build_weights_from_race(
-        self, finishers: list[RankedFinisher], top_hotkey: Optional[str]
+        self,
+        finishers: list[RankedFinisher],
+        top_hotkey: Optional[str],
+        t_burn: float,
     ) -> tuple[list[int], list[int]]:
         """Compute the full `(uids, u16 weights)` vector for the metagraph.
 
@@ -213,13 +239,12 @@ class WeightSetterThread:
         if top_hotkey is not None and top_hotkey not in present:
             logging.warning(
                 f"Designated top miner {top_hotkey} not in current metagraph; "
-                f"falling back to rank-1 of last-race finishers for top slot"
+                f"top share folds into burn slot"
             )
         return build_metagraph_weight_vector(
             finishers,
             metagraph_hotkeys=metagraph_hotkeys,
-            t_top=self.t_top,
-            t_burn=self.t_burn,
+            t_burn=t_burn,
             top_hotkey=top_hotkey,
         )
 
@@ -255,13 +280,13 @@ class WeightSetterThread:
             )
             return
 
-        top_hotkey = self._fetch_top_hotkey()
-        uids, weights = self._build_weights_from_race(finishers, top_hotkey)
+        top_hotkey, t_burn = self._fetch_top_state()
+        uids, weights = self._build_weights_from_race(finishers, top_hotkey, t_burn)
         non_zero = sum(1 for w in weights if w > 0)
         logging.info(
             f"Race-based weight vector: N={len(finishers)} finishers, "
             f"top={top_hotkey or '(none — top share burns)'}, "
-            f"{non_zero} non-zero metagraph slots"
+            f"t_burn={t_burn:.3f}, {non_zero} non-zero metagraph slots"
         )
 
         if not weights:


### PR DESCRIPTION
## Description

The validator's `WeightSetterThread` currently hardcodes `t_top=0.25, t_burn=0.75` and ignores the Backend `emission_baseline_burn_rate` policy field, which is therefore display-only on `/v1/public/top`. This PR aligns the two: the validator reads the burn rate from Backend each tick so operators can adjust it via a single Backend env-var change without a validator release.

## Changes Made

- `WeightSetterThread._fetch_top_state` reads `top_miner_hotkey` and `emission_baseline_burn_rate` from the existing `GET /v1/public/top` policy block in a single call. Falls back to a configurable `t_burn_fallback` (default 0.75) if Backend is unreachable or the policy value is missing / invalid. Live `t_burn` is logged per tick.
- `weight_distribution` collapses to a single `t_burn` parameter. `t_top` is always derived as `1.0 - t_burn`; `_validate_ratios` already enforced the sum-to-1 constraint. `compute_pinned_weights(t_burn, tail_sum)`, `compute_hotkey_weights`, and `build_metagraph_weight_vector` all drop the redundant `t_top` parameter.
- Deficit absorption when burn budget is insufficient. Previously `compute_pinned_weights(t_top=1.0, t_burn=0.0, tail_sum>0)` raised `ValueError`. Now the top miner absorbs the deficit: burn clamps to 0 and the top miner's effective share falls slightly below `1 - t_burn` by `tail_sum / (U16_MAX + tail_sum)`. Tail's rank-j protection share is preserved; only the burn-vs-top split shifts.

At race size 40 (M=19), `t_burn=0` yields:
- top miner: 99.71%
- tail (top 50% finisher dereg shield): 0.29%
- burn: 0%

## Issue Link

- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing

Not manually exercised on a live validator yet — only relevant when ops chooses to flip the Backend env. Logic is exercised end-to-end by the existing weight_setter integration tests, which mock the Backend response.

**Test Results:**

All 194 validator-suite unit tests pass locally (existing 11 weight_setter tests, expanded 64 weight_distribution tests including new `t_burn=0` deficit-absorption coverage).

### Automated Testing

Added tests:
- `test_compute_pinned_weights_burn_zero_absorbs_tail_into_top` — verifies the clamp path
- `test_compute_pinned_weights_oversized_tail_at_low_burn_absorbs_into_top` — replaces the prior fail-loud test; now succeeds with burn clamped at 0
- `test_total_shares_sum_to_one_across_burn_sweep` — parametric over `t_burn ∈ {0.0, 0.25, 0.5, 0.75, 1.0}` × `N ∈ {10, 20, 40, 80}`
- `test_build_metagraph_vector_burn_zero_emits_top_dominant_vector` — end-to-end at burn=0 confirms top miner takes ~99.7% and tail keeps integer taper
- `test_invalid_burn_fallback_raises_at_construction` — replaces the prior `t_top + t_burn != 1` test

**Test Command(s):**
```bash
python -m pytest subnet/tests/validator/test_weight_distribution.py subnet/tests/validator/test_weight_setter.py -v
```

## Documentation

- [x] README updated
- [x] Code comments added/updated
- [x] API documentation updated
- [x] Configuration documentation updated
- [x] Other documentation updated (please specify): N/A

**Documentation Changes:**

Updated the `weight_distribution.py` module docstring with the single-knob model and the deficit-absorption case. Updated `WeightSetterThread._fetch_top_state` docstring to describe the Backend policy read.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

Determinism note: `_fetch_top_state` reads the policy once per tick and uses the same value throughout the tick. Two validators on the same tick reading at slightly different wall times may disagree across a single tick boundary when ops flips the env, but Yuma tolerates a one-tick skew. Subsequent ticks converge.

Backwards compatibility: the `t_burn_fallback` default is 0.75 (the historical value), so a validator running this code against a Backend that does not return policy continues to behave identically to today.