### PR TITLE
validator: revert REASONING_MAX_WORKERS default 8 → 4

### DIFF
--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -151,7 +151,7 @@ class Validator:
         parser.add_argument(
             "--reasoning-max-workers",
             type=int,
-            default=int(os.environ.get("REASONING_MAX_WORKERS") or "8"),
+            default=int(os.environ.get("REASONING_MAX_WORKERS") or "4"),
             help="Number of parallel reasoning judge workers (env: REASONING_MAX_WORKERS).",
         )
         # Backend API configuration


### PR DESCRIPTION
## Summary

PR #197 bumped both `SANDBOX_MAX_WORKERS` (15→30) and `REASONING_MAX_WORKERS` (4→8). Sandbox bump is fine. The reasoning bump caused a clear judge-inference regression on prod once validators picked up the new image (Watchtower roll completed around 19:00 UTC today).

## Evidence

Same agent (`datacenter`), same validator hotkey, before vs after the validator image roll:

| Validator | Time (UTC) | judge_inference_failed / total | % |
|---|---|---|---|
| 5D2Q5RFr | 03:55 (pre) | 2 / 32 | 6% |
| 5D2Q5RFr | 19:00 (post) | 21 / 81 | **26%** |
| 5EPhLUkE | 19:00 (post) | 6 / 66 | 9% |

Trajectory unchanged. Provider monitor (`rate_limit_ratio_5m` from the Backend) still reports 0.000 for the chutes judge models, so the upstream rate-limit signal isn't tripping. But the validator-side judge call denominator roughly doubled (1.07 → 2.70 avg attempts/problem), which means most calls are now needing a model rotation + retry — consistent with intra-batch collisions on the small (3-model) judge rotation when 8 workers fire concurrently against the same TEE instances.

Today's `amazing` agent (06a3d670-…) hit the 50% infra-failure threshold on 4 of 6 runs because of this — agent-side trajectories that used to pass at ~10% judge fail rate now push past the cutoff. Other agents pass eval, but with 2× the judge inference calls (cost + latency).

## Change

One-line revert of the reasoning default. `SANDBOX_MAX_WORKERS=30` stays (clean in the 4-phase sandbox max-workers testing earlier today).

```diff
- default=int(os.environ.get("REASONING_MAX_WORKERS") or "8"),
+ default=int(os.environ.get("REASONING_MAX_WORKERS") or "4"),
```

External validators already setting `REASONING_MAX_WORKERS` explicitly via env get no change.

## Test plan

- [ ] Watchtower roll picks up the new image on prod validators
- [ ] Re-pick a recent agent and verify `judge_inference_failed/total` returns to the pre-#197 ratio (target: ≤ 5% on the typical agent)
- [ ] No `Reasoning judge infrastructure failure` on subsequent runs of agents that were previously hitting it