### PR TITLE
Revert "validator: revert REASONING_MAX_WORKERS default 8 → 4"

### DIFF
--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -151,7 +151,7 @@ class Validator:
         parser.add_argument(
             "--reasoning-max-workers",
             type=int,
-            default=int(os.environ.get("REASONING_MAX_WORKERS") or "4"),
+            default=int(os.environ.get("REASONING_MAX_WORKERS") or "8"),
             help="Number of parallel reasoning judge workers (env: REASONING_MAX_WORKERS).",
         )
         # Backend API configuration


### PR DESCRIPTION
## Summary

Restores `REASONING_MAX_WORKERS` default to 8 from #197. The #199 revert was premature — its analysis cherry-picked one validator-eval pair and didn't normalize for the simultaneous race-phase rollout (#436) that doubled the per-eval problem count, naturally inflating `judge_inference_total`.

Looking at the broader dataset:
- Post-#197 window: 0% / 0% / 0% / 3.2% / 9.1% / 10.5% / 26% judge call failure across validators — wide variance, no uniform regression.
- Pre-#197: already had outliers up to **49%** (`av=06a39f66` on `val=5DZseyPD` 2026-06-24 19:06 UTC).

Specific failing agents like `amazing` (4 of 6 runs tripped infra-failure) appear to be a trajectory-side issue: unparseable 200s in 1-2 of 3 chutes judge models, not a workers-count issue.

## Change

```diff
- default=int(os.environ.get("REASONING_MAX_WORKERS") or "4"),
+ default=int(os.environ.get("REASONING_MAX_WORKERS") or "8"),
```

Reverts `6dd5142` from #199.

## Test plan

- [ ] CI (lint + unit + integration) green.
- [ ] No further action — `latest` tag + Watchtower roll will pick this up when the next tagged release happens; no validator currently differs from `v1.1.11` behavior.