### PR TITLE
compose: raise search-server + proxy cpu_shares 1024 → 2048

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,12 @@ services:
       com.centurylinklabs.watchtower.scope: "oro-validator"
     networks:
       - main
+    # Match sandbox container's --cpu-shares=2048 (see subnet/sandbox.py).
+    # Search-server sits on the sandbox's hot path (every find_product /
+    # view_product call). Leaving it at Docker's 1024 default lets the
+    # sandbox starve it on saturated hosts, elongating sandbox phase and
+    # tripping per-problem timeouts.
+    cpu_shares: 2048
     restart: unless-stopped
 
   proxy:
@@ -52,6 +58,11 @@ services:
       start_period: 10s
     labels:
       com.centurylinklabs.watchtower.scope: "oro-validator"
+    # Match sandbox container's --cpu-shares=2048. Proxy fans every
+    # /inference and /search call from sandbox + reasoning judge; if
+    # sandbox outweighs proxy under CPU pressure, both inference and
+    # search round-trips stall.
+    cpu_shares: 2048
     restart: unless-stopped
 
   sandbox:


### PR DESCRIPTION
## Summary

PR #195 raised sandbox container `--cpu-shares` 512→2048 (≈4× weight). On CPU-saturated hosts, cgroup weight math now gives sandbox ~40% of host CPU while leaving search-server and proxy at Docker's 1024 default (~20% each). Both of those services sit directly on the sandbox's critical path (every `/search/find_product` and every `/inference/*` call from the in-sandbox agent), so starving them stretches sandbox wall time.

## Evidence

External validator `tao.bot` (hotkey `5E2LP6E…`) reports sustained ~96% host CPU, sandbox phase 2-3× the cohort's on the same agents (~404s vs Kraken's 65-218s), and eval scores ~10% below average. Our own official validator (5Et5W6p3) sits at ~42% CPU on identical configuration and produces normal scores — i.e. shares only matter under saturation, but where they do, the current ratio works against us.

## Change

```diff
@@ search-server: @@
+ cpu_shares: 2048
@@ proxy: @@
+ cpu_shares: 2048
```

No-op on hosts that never hit saturation; rebalances toward the path the sandbox is actually waiting on when CPU is contended.

## Why not autotune `SANDBOX_MAX_WORKERS`

`SANDBOX_MAX_WORKERS=30` is a deliberate floor for evaluation throughput — we want at least this many parallel problems per eval, and ideally more — so capping it on smaller hosts is not the right fix. Rebalancing the share weights between services on the sandbox's hot path is the cheaper move.

## Test plan

- [ ] CI lint + tests green.
- [ ] After tag + Watchtower roll: re-check tao.bot host metrics — expect sandbox slice to drop from 40% → ~33% and search-server/proxy slices to rise from 20% → ~33% each.
- [ ] Re-pull sandbox phase wall time for tao.bot on the next eval — expect to converge toward the cohort median.