### PR TITLE
docker: bundle py-spy (validator) + async-profiler (search-server)

### DIFF
--- a/docker/search-server/Dockerfile
+++ b/docker/search-server/Dockerfile
@@ -2,6 +2,26 @@ FROM ghcr.io/oro-ai/oro/search-server-base:latest
 
 WORKDIR /app
 
+# Bundle async-profiler so we can JVMTI-attach to the embedded Lucene JVM
+# (pyserini) at runtime without restarting the container. ~5 MiB; opt-in
+# only — never invoked unless an operator runs `asprof` manually inside
+# the container.
+ARG ASPROF_VERSION=3.0
+RUN set -eux; \
+    arch="$(uname -m)"; case "$arch" in \
+        x86_64) asprof_arch=x64 ;; \
+        aarch64|arm64) asprof_arch=arm64 ;; \
+        *) echo "unsupported arch: $arch" >&2; exit 1 ;; \
+    esac; \
+    apt-get update && apt-get install -y --no-install-recommends curl ca-certificates; \
+    mkdir -p /opt/async-profiler; \
+    curl -fsSL "https://github.com/async-profiler/async-profiler/releases/download/v${ASPROF_VERSION}/async-profiler-${ASPROF_VERSION}-linux-${asprof_arch}.tar.gz" \
+        | tar xz --strip-components=1 -C /opt/async-profiler; \
+    ln -s /opt/async-profiler/bin/asprof /usr/local/bin/asprof; \
+    apt-get purge -y curl; \
+    apt-get autoremove -y; \
+    rm -rf /var/lib/apt/lists/*
+
 # Only the code layer — changes on every release
 COPY src/search_engine /app/src/search_engine
 COPY src/__init__.py /app/src/

--- a/docker/validator/pyproject.toml
+++ b/docker/validator/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "oro-sdk==1.0.73",
     "prometheus-client>=0.20.0",
     "psutil>=5.9.0",
+    "py-spy>=0.4.1",
     "requests==2.33.0",
     "sentence-transformers==5.3.0",
     "torch>=2.11.0,<3",

--- a/docker/validator/uv.lock
+++ b/docker/validator/uv.lock
@@ -1386,6 +1386,7 @@ dependencies = [
     { name = "oro-sdk" },
     { name = "prometheus-client" },
     { name = "psutil" },
+    { name = "py-spy" },
     { name = "requests" },
     { name = "sentence-transformers" },
     { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
@@ -1401,6 +1402,7 @@ requires-dist = [
     { name = "oro-sdk", specifier = "==1.0.73" },
     { name = "prometheus-client", specifier = ">=0.20.0" },
     { name = "psutil", specifier = ">=5.9.0" },
+    { name = "py-spy", specifier = ">=0.4.1" },
     { name = "requests", specifier = "==2.33.0" },
     { name = "sentence-transformers", specifier = "==5.3.0" },
     { name = "torch", specifier = ">=2.11.0,<3", index = "https://download.pytorch.org/whl/cpu" },
@@ -1574,6 +1576,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/98/ff/fec109ceb715d2a6b4c4a85a61af3b40c723a961e8828319fbcb15b868dc/py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719", size = 207796, upload-time = "2021-11-04T17:17:01.377Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/f0/10642828a8dfb741e5f3fbaac830550a518a775c7fff6f04a007259b0548/py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378", size = 98708, upload-time = "2021-11-04T17:17:00.152Z" },
+]
+
+[[package]]
+name = "py-spy"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/d8/5b71371f50cf153b1307e5a11ac8a4ce4d85651dae946bd7e9a064146545/py_spy-0.4.2.tar.gz", hash = "sha256:90e600b27bb6bb40479637baca5a5b4bc2ba3395c93d889e672315d93042c4ae", size = 286374, upload-time = "2026-04-24T22:08:54.906Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/21/ec030145a0c7992bd4b9eafb2f06f56358b3a5339eab4a16534baf3c69aa/py_spy-0.4.2-py2.py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:1ccf688393105111684435f035bc14ec3f22117dd2b85b2414612cf27a22755a", size = 3743992, upload-time = "2026-04-24T22:08:45.438Z" },
+    { url = "https://files.pythonhosted.org/packages/50/80/de5fd27243c2be03692ecd317bf0dbe24b4c6f78f689ce111e7277a7cb09/py_spy-0.4.2-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:a0e6f6810ccf0fc5e64e85e0182a5b626c4496eec01b14fb8755154b363a4831", size = 1859057, upload-time = "2026-04-24T22:08:46.946Z" },
+    { url = "https://files.pythonhosted.org/packages/89/23/3eb4c23c684ebd667674ce1d076ae855e0621d1d9bd5e052aa3f7982f757/py_spy-0.4.2-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:142887e984a4e541071c99a4401ff8c3770f255d329dbd0f64e8c1dd51882cce", size = 2828136, upload-time = "2026-04-24T22:08:48.519Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/01/6314152cf9ad3310ebacbf2c47b5ed858086530f8e12b1a665725ca5e0f4/py_spy-0.4.2-py2.py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f1c6d9b0e2379ead5bf792df43f4cf36153aa79e6dda4fb8ac7740cf8017110", size = 2857707, upload-time = "2026-04-24T22:08:49.677Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1f/0960a129d504728d28a51dbd5a04ce94031eb75bac676341da7aefdd8232/py_spy-0.4.2-py2.py3-none-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:24720573f95230653b457671a1dcc3c5a381fcf4e92677761e328a430ad251b2", size = 2301852, upload-time = "2026-04-24T22:08:51.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/34/dd7d3c763a00b7b965e25a5eab0acd1a345dbaf0f45fffe595278873a1c0/py_spy-0.4.2-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:aeb0323409199c785f730645e9f4bb7a7b9ca2c481f2c331a55642b5d13fa52f", size = 2936518, upload-time = "2026-04-24T22:08:52.264Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ed/1409cdb557e558a6c98003ab12fdd4284699e158c167c187cb0f124eea4c/py_spy-0.4.2-py2.py3-none-win_amd64.whl", hash = "sha256:8b06a353c177677e4e1701b288d8c58e2f8d4208ee81a8048d9f72ba800918f8", size = 1894002, upload-time = "2026-04-24T22:08:53.811Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bundle two profilers in the images so we can flame-graph the hot path inside each container without restarting the service or rebuilding from scratch. Both are zero overhead at runtime — only active when explicitly invoked.

Needed because the public host-metrics snapshot tells us total container CPU but not which process or stack frame is burning it. External validators (e.g. tao.bot at sustained ~96% CPU) cost us scoring quality and we have no way to attribute it.

## Changes

- `docker/validator/pyproject.toml` + `uv.lock`: pin `py-spy>=0.4.1`. Lock regenerated via `uv lock`.
- `docker/search-server/Dockerfile`: download `async-profiler` 3.0 release tarball for x64/arm64, symlink `asprof` onto `PATH`. ~5 MiB added per arch.

## How to use

**Validator (Python):**
```bash
docker exec oro-validator-1 .venv/bin/py-spy dump --pid 1
docker exec oro-validator-1 .venv/bin/py-spy record -o /tmp/v.svg --pid 1 -d 30
docker cp oro-validator-1:/tmp/v.svg .
```

**Search-server (JVM):**
```bash
docker exec shoppingbench-search-server asprof -d 30 -f /tmp/s.html 1
docker cp shoppingbench-search-server:/tmp/s.html .
```

Open the resulting `.svg` / `.html` in a browser.

## Test plan

- [ ] CI green (lint, tests, image build for both validator + search-server).
- [ ] After tagged release + rollout to staging, verify `docker exec` invocations succeed against a running staging validator + search-server.
- [ ] No change to runtime behavior with the tools idle.