### PR TITLE
scoring: stop caching missing-product responses (cache poisoning fix)

### DIFF
--- a/src/agent/problem_scorer.py
+++ b/src/agent/problem_scorer.py
@@ -41,12 +41,15 @@ def get_product(product_id: str) -> Optional[dict]:
         product_id: Product ID to look up
 
     Returns:
-        Full product dict or None if not found
+        Full product dict, or None if the search-server returns empty/error
+        for this call. Misses are NOT cached: a transient empty response would
+        otherwise poison the cache for the rest of the validator's session and
+        flip every subsequent agent that recommended the same product to
+        FAILED. Only successful lookups are cached.
     """
     if not product_id:
         return None
 
-    # Check cache first
     if product_id in _product_cache:
         return _product_cache[product_id]
 
@@ -61,7 +64,6 @@ def get_product(product_id: str) -> Optional[dict]:
             if products and len(products) > 0:
                 _product_cache[product_id] = products[0]
                 return products[0]
-        _product_cache[product_id] = None
         return None
     except requests.RequestException as e:
         logging.warning(f"Failed to fetch product {product_id}: {e}")

--- a/tests/test_problem_scorer.py
+++ b/tests/test_problem_scorer.py
@@ -1052,3 +1052,86 @@ class TestLoggingOnErrors:
             f"Expected 3 format scoring warnings (one per broken step), "
             f"got {len(format_warnings)}: {format_warnings}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Negative cache poisoning regression
+# ---------------------------------------------------------------------------
+
+
+class TestGetProductNegativeCache:
+    """A transient empty response from search-server must NOT poison the
+    in-memory cache. Otherwise every subsequent agent that recommends the
+    same product is silently flipped to FAILED until the validator process
+    restarts."""
+
+    def test_empty_response_not_cached(self):
+        """resp.ok + empty list => function returns None but does not cache it."""
+        from src.agent import problem_scorer
+
+        problem_scorer.clear_product_cache()
+
+        class FakeResp:
+            ok = True
+            def json(self):
+                return []
+
+        with patch("src.agent.problem_scorer.requests.get", return_value=FakeResp()):
+            assert problem_scorer.get_product("4452706615") is None
+
+        assert "4452706615" not in problem_scorer._product_cache, (
+            "Empty response must not be cached; otherwise a transient search-server "
+            "hiccup poisons every subsequent lookup for the rest of the validator's "
+            "session and flips all agents recommending this product to FAILED."
+        )
+
+    def test_error_status_not_cached(self):
+        """resp.ok=False (5xx/4xx) returns None and does not cache."""
+        from src.agent import problem_scorer
+
+        problem_scorer.clear_product_cache()
+
+        class FakeResp:
+            ok = False
+            def json(self):
+                return []
+
+        with patch("src.agent.problem_scorer.requests.get", return_value=FakeResp()):
+            assert problem_scorer.get_product("4452706615") is None
+
+        assert "4452706615" not in problem_scorer._product_cache
+
+    def test_retry_after_transient_failure_succeeds(self):
+        """After a transient empty response, a follow-up call must hit the
+        search-server again (no negative-cache entry) and return the product."""
+        from src.agent import problem_scorer
+
+        problem_scorer.clear_product_cache()
+
+        empty = type("R", (), {"ok": True, "json": lambda self: []})()
+        good = type("R", (), {"ok": True, "json": lambda self: [{"product_id": "4452706615"}]})()
+
+        with patch("src.agent.problem_scorer.requests.get", side_effect=[empty, good]) as mock_get:
+            first = problem_scorer.get_product("4452706615")
+            second = problem_scorer.get_product("4452706615")
+
+        assert first is None
+        assert second == {"product_id": "4452706615"}
+        assert mock_get.call_count == 2, "Second call must reach search-server, not return cached None"
+        # And now the successful result IS cached
+        assert problem_scorer._product_cache.get("4452706615") == {"product_id": "4452706615"}
+
+    def test_successful_response_still_cached(self):
+        """Positive caching path is unchanged."""
+        from src.agent import problem_scorer
+
+        problem_scorer.clear_product_cache()
+
+        good = type("R", (), {"ok": True, "json": lambda self: [{"product_id": "p1", "price": 5.0}]})()
+
+        with patch("src.agent.problem_scorer.requests.get", return_value=good) as mock_get:
+            problem_scorer.get_product("p1")
+            problem_scorer.get_product("p1")
+
+        assert mock_get.call_count == 1, "Successful lookup must be cached, not re-fetched"
+        assert problem_scorer._product_cache["p1"] == {"product_id": "p1", "price": 5.0}


### PR DESCRIPTION
## Description

`get_product()` in `src/agent/problem_scorer.py` caches a `None` entry whenever the search-server returns a non-error response with an empty product list (or any `resp.ok == False`). `_product_cache` lives for the validator process lifetime, so a single transient hiccup at the start of an eval session poisons that product ID for every agent the validator scores after it. Each agent that recommends the poisoned ID is then silently scored as FAILED — `_eval_product` bails when `get_product` returns None, `rule_score` stays 0, `is_problem_successful` returns False.

The negative-cache line is the bug. Successful lookups should still be cached for performance, but empty/error responses must retry on the next call instead of permanently flipping every downstream agent.

## Changes Made

- Remove `_product_cache[product_id] = None` from the resp.ok-but-empty branch of `get_product()`.
- Expand the docstring to call out the invariant (only successful lookups are cached) and the failure mode it prevents.
- Add a `TestGetProductNegativeCache` regression suite covering: empty 200 not cached, non-ok response not cached, follow-up call after a transient miss reaches the server again, and the positive-cache path still works.

## Issue Link

- Related to: (Linear ticket pending — race 75 systemic search-server-FAILED investigation)

## Testing

### Manual Testing

Reproduced the systemic case via a query against prod problem progress for races 72/73/74/75. Race 75 alone showed 131 confirmed cases on `(problem 06a17b28, product 4452706615)` across four independent validators, all with identical recommend_product calls in S3 trajectories. The validator that scored SUCCESS for those same agents (ORO) had cached the product on its first successful lookup; the four that scored FAILED each cached `None` and stayed poisoned.

**Test Results:**

- 4/4 new regression tests pass.
- Full file: 40/40 tests pass, no regressions.

### Automated Testing

**Test Command(s):**

```bash
.venv/bin/python -m pytest tests/test_problem_scorer.py -v
```

```
======================= 40 passed in 0.08s =======================
```

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**

Docstring on `get_product()` now explains why misses are not cached and what regression it prevents (so this doesn't get re-introduced by a future caller chasing "consistency" with the success path).

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

The deeper root cause of WHY race 75's first request for `4452706615` failed on four validators concurrently is still being investigated (concentrated on one product on one problem, which is suspicious for a "purely transient" hiccup). This PR is the right behavior regardless of root cause — the cache should never have been able to poison itself this way — but a follow-up investigation will look at concurrent-load behavior of the search-server itself.