### PR TITLE
scoring: opt-in shadow cosine logger + revert canonical to Qwen3 (ORO-1474)

### DIFF
--- a/docker/validator/Dockerfile
+++ b/docker/validator/Dockerfile
@@ -19,9 +19,11 @@ WORKDIR /app
 COPY docker/validator/pyproject.toml docker/validator/uv.lock /app/
 RUN uv sync --frozen --no-dev --no-install-project
 
-# Pre-cache SentenceTransformer model (avoids runtime download)
+# Pre-cache SentenceTransformer models (avoids runtime download). The
+# canonical Qwen3 model is always loaded; the bge-small bundle is for the
+# optional ORO-1474 shadow scorer enabled via SHADOW_SCORE_MODEL at runtime.
 ARG HF_TOKEN=""
-RUN HF_HUB_ENABLE_HF_TRANSFER=0 HF_TOKEN=${HF_TOKEN} .venv/bin/python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('BAAI/bge-small-en-v1.5')"
+RUN HF_HUB_ENABLE_HF_TRANSFER=0 HF_TOKEN=${HF_TOKEN} .venv/bin/python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('Qwen/Qwen3-Embedding-0.6B'); SentenceTransformer('BAAI/bge-small-en-v1.5')"
 
 # Copy validator code
 COPY subnet/ /app/subnet/

--- a/src/agent/rewards/orm.py
+++ b/src/agent/rewards/orm.py
@@ -1,10 +1,24 @@
+import json
+import logging
+import os
 from collections import Counter
 
-SENTENCE_MODEL_NAME = "BAAI/bge-small-en-v1.5"
-TITLE_SIM_THRESHOLD = 0.95
+SENTENCE_MODEL_NAME = "Qwen/Qwen3-Embedding-0.6B"
+TITLE_SIM_THRESHOLD = 0.7
+
+# ORO-1474 shadow scoring: when SHADOW_SCORE_MODEL is set, encode the same
+# (product_title, gt_title) pair with the candidate model and log the
+# canonical + shadow cosine similarity so we can grep CW Logs Insights and
+# replay any threshold offline before promoting a model swap. Threshold is
+# never enforced by shadow — we only need the raw similarity.
+SHADOW_MODEL_ENV = "SHADOW_SCORE_MODEL"
 
 _sentence_model = None
 _sentence_model_unavailable = False
+_shadow_model = None
+_shadow_unavailable = False
+
+_logger = logging.getLogger(__name__)
 
 
 def _get_sentence_model():
@@ -19,11 +33,67 @@ def _get_sentence_model():
         try:
             from sentence_transformers import SentenceTransformer
 
-            _sentence_model = SentenceTransformer(SENTENCE_MODEL_NAME)
+            _sentence_model = SentenceTransformer(
+                SENTENCE_MODEL_NAME,
+                model_kwargs={"torch_dtype": "bfloat16"},
+            )
         except ImportError:
             _sentence_model_unavailable = True
             return None
     return _sentence_model
+
+
+def _get_shadow_model():
+    """Lazy-load the shadow sentence model named by SHADOW_SCORE_MODEL."""
+    global _shadow_model, _shadow_unavailable
+    if _shadow_unavailable:
+        return None
+    name = os.environ.get(SHADOW_MODEL_ENV)
+    if not name:
+        return None
+    if _shadow_model is None:
+        try:
+            from sentence_transformers import SentenceTransformer
+
+            _shadow_model = SentenceTransformer(name)
+        except (ImportError, OSError, ValueError) as exc:
+            _logger.warning("Shadow scorer disabled — failed to load %s: %s", name, exc)
+            _shadow_unavailable = True
+            return None
+    return _shadow_model
+
+
+def _log_shadow_sim(product_title: str, gt_title: str, canonical_sim: float) -> None:
+    """Encode the same title pair with the shadow model and log both sims.
+
+    No-op when ``SHADOW_SCORE_MODEL`` is unset or the shadow model failed to
+    load. One JSON line per pair; grep CW Logs Insights with ``shadow_sim``
+    and apply any threshold offline to estimate the per-row effect of a
+    swap. ORO-1474.
+    """
+    shadow = _get_shadow_model()
+    if shadow is None:
+        return
+    try:
+        product_emb = shadow.encode([product_title])
+        gt_emb = shadow.encode([gt_title])
+        shadow_sim = float(shadow.similarity(product_emb, gt_emb)[0][0])
+    except Exception as exc:  # noqa: BLE001
+        _logger.warning("Shadow sim failed for product=%r gt=%r: %s", product_title[:60], gt_title[:60], exc)
+        return
+    _logger.info(
+        "shadow_sim %s",
+        json.dumps(
+            {
+                "canonical_sim": canonical_sim,
+                "shadow_sim": shadow_sim,
+                "canonical_model": SENTENCE_MODEL_NAME,
+                "shadow_model": os.environ.get(SHADOW_MODEL_ENV, ""),
+                "product_title": product_title,
+                "gt_title": gt_title,
+            }
+        ),
+    )
 
 
 def batch_encode_titles(titles: list[str]) -> list:
@@ -87,6 +157,7 @@ def rule_score_reward(product: dict, reward: dict, product_title_emb=None) -> tu
                     if sim >= TITLE_SIM_THRESHOLD:
                         hit_count += 1
                         hit_counter["title"] += 1
+                    _log_shadow_sim(product["title"], title, float(sim))
     # price
     if "price" in reward:
         price = product["price"]

--- a/tests/test_scoring_perf.py
+++ b/tests/test_scoring_perf.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from src.agent.rewards.orm import rule_score_reward
 
 
@@ -50,10 +52,63 @@ def test_non_gt_calls_encode(mock_get):
     )
 
     assert m.encode.call_count >= 1
-    assert hits["title"] == 1   # similarity 0.95 >= TITLE_SIM_THRESHOLD
+    assert hits["title"] == 1   # similarity 0.95 >= TITLE_SIM_THRESHOLD (0.7)
     assert hits["price"] == 1   # 15 <= 20
     assert hits["service"] == 1
     assert score == 1.0         # 3/3
+
+
+@patch("src.agent.rewards.orm._get_shadow_model")
+@patch("src.agent.rewards.orm._get_sentence_model")
+def test_shadow_sim_logged_when_enabled(mock_get, mock_shadow, monkeypatch, caplog):
+    """When SHADOW_SCORE_MODEL is set, every non-GT title pair logs a
+    structured JSON line with the canonical + shadow cosine similarity.
+    """
+    import json
+    import logging
+
+    monkeypatch.setenv("SHADOW_SCORE_MODEL", "BAAI/bge-small-en-v1.5")
+
+    canonical = MagicMock()
+    canonical.encode.return_value = [[0.1, 0.2]]
+    canonical.similarity.return_value = [[0.95]]
+    canonical.get_sentence_embedding_dimension.return_value = 2
+    mock_get.return_value = canonical
+
+    shadow = MagicMock()
+    shadow.encode.return_value = [[0.0, 1.0]]
+    shadow.similarity.return_value = [[0.42]]
+    mock_shadow.return_value = shadow
+
+    with caplog.at_level(logging.INFO, logger="src.agent.rewards.orm"):
+        rule_score_reward(
+            _product(pid="A"),
+            _reward(pid="Z", titles=["the gt title"]),
+        )
+
+    shadow_lines = [r for r in caplog.records if r.msg.startswith("shadow_sim")]
+    assert len(shadow_lines) == 1
+    payload = json.loads(shadow_lines[0].args[0])
+    assert payload["canonical_sim"] == pytest.approx(0.95)
+    assert payload["shadow_sim"] == pytest.approx(0.42)
+    assert payload["shadow_model"] == "BAAI/bge-small-en-v1.5"
+    assert payload["gt_title"] == "the gt title"
+
+
+def test_shadow_sim_silent_when_disabled(monkeypatch, caplog):
+    """Without SHADOW_SCORE_MODEL set the title path emits no shadow lines."""
+    import logging
+    from src.agent.rewards import orm
+
+    monkeypatch.delenv("SHADOW_SCORE_MODEL", raising=False)
+    # Reset cached singleton in case a prior test loaded a real shadow model.
+    orm._shadow_model = None
+    orm._shadow_unavailable = False
+
+    with caplog.at_level(logging.INFO, logger="src.agent.rewards.orm"):
+        orm._log_shadow_sim("foo", "bar", 0.5)
+
+    assert not [r for r in caplog.records if r.msg.startswith("shadow_sim")]
 
 
 @patch("src.agent.rewards.orm._get_sentence_model")


### PR DESCRIPTION
## Description

The v1.1.12 bge-small swap regressed the prod scoring distribution ~17pp before we caught it via miner reports. Pre-deploy validation sampled three bottom-band agents on a fresh staging suite; that under-represented the "almost-correct" rate top miners hit on the prod suite, which is exactly where bge@0.95 disagrees with Qwen3@0.7. Stable was rolled back to v1.1.11.

Adds a minimal observability hook so the next attempt is measured against the actual prod scoring distribution before any swap.

## Changes Made

- \`src/agent/rewards/orm.py\`:
  - Canonical model + threshold reverted to \`Qwen/Qwen3-Embedding-0.6B\` + 0.7 so the in-tree code matches what the deployed \`v1.1.11\` stable image runs.
  - When \`SHADOW_SCORE_MODEL\` is set, the title-similarity loop encodes the same \`(product_title, gt_title)\` pair with the named candidate model and emits one JSON line (\`shadow_sim\` prefix) carrying both cosines + both model names + both titles. Threshold is never enforced by the shadow path — analysis applies thresholds offline against the raw similarity column.
  - No DB write, no metric publish, no behaviour change to canonical scoring.
- \`docker/validator/Dockerfile\`: pre-cache both Qwen3 and bge-small so enabling the shadow at runtime doesn't trigger an unexpected HF download.
- \`tests/test_scoring_perf.py\`: positive + negative coverage of the shadow log path; existing canonical tests unchanged.

## Issue Link

- Related to: ORO-1474
- Closes: N/A — observability piece; the actual re-attempt of the swap is gated on the decision criteria spelled out in the Linear ticket (one week of data, top-20 agent canonical-vs-shadow delta within run-to-run noise).

## Testing

### Manual Testing

Unit suite. End-to-end manual test is the operational rollout itself — set \`SHADOW_SCORE_MODEL=BAAI/bge-small-en-v1.5\` on the official ORO validator after this lands, watch CW Logs for \`shadow_sim\` lines, run \`filter @message like /shadow_sim/\` in Insights to confirm pair-level emission and absence of any canonical regression.

**Test Results:** 6/6 tests pass locally including two new shadow-path cases.

### Automated Testing

**Test Command(s):**

\`\`\`bash
.venv/bin/python -m pytest tests/test_scoring_perf.py -v
\`\`\`

## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:** Inline docstrings cover the env-var contract + the per-pair log shape so a future replay script can rely on the field names.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged — none required; this is the dependent change for the data collection.

## Additional Notes

The shadow log is opt-in via env var so external validator operators see no behaviour change. The Dockerfile pre-cache costs ~150MB image-size for bge-small + ~600MB for Qwen3 (Qwen3 was already preloaded before the bge swap); no runtime cost when the env var is unset.