### PR TITLE
compose: pass SHADOW_SCORE_MODEL through to validator + test runner

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,6 +131,10 @@ services:
       - SUBTENSOR_NETWORK=${SUBTENSOR_NETWORK:-finney}
       - ORO_BACKEND_URL=${BACKEND_URL:-https://api.oroagents.com}
       - WATCHTOWER_TOKEN=${WATCHTOWER_TOKEN:-oro-watchtower-token}
+      # Opt-in shadow scoring. When set, the validator computes a
+      # second cosine sim per (product, gt) title pair with the named model
+      # and logs both sims for offline comparison. Unset = no behaviour change.
+      - SHADOW_SCORE_MODEL=${SHADOW_SCORE_MODEL:-}
     command:
       - "--wallet.name"
       - "${WALLET_NAME:-default}"
@@ -232,6 +236,8 @@ services:
       - CHUTES_API_KEY=${CHUTES_API_KEY:-}
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
       - INFERENCE_PROVIDER=${INFERENCE_PROVIDER:-}
+      # Opt-in shadow scoring (mirrors the validator service).
+      - SHADOW_SCORE_MODEL=${SHADOW_SCORE_MODEL:-}
     # Use the venv interpreter — bare `python` is the system Python and
     # has no project dependencies installed (e.g. `requests`).
     entrypoint: [".venv/bin/python", "-m", "subnet.test_runner"]


### PR DESCRIPTION
## Description

The opt-in shadow rule-score logger added in #205 reads the model name from \`SHADOW_SCORE_MODEL\` in the container's process environment. Docker Compose only forwards env vars listed in the service \`environment\` block, so without this pass-through the variable set on the host (\`.env\` or shell) never reaches the validator process.

Adds the same \`\${SHADOW_SCORE_MODEL:-}\` pattern we already use for every other knob (sandbox workers, reasoning workers, watchtower token, …) to both the validator service and the test runner so local replay scripts behave the same way operationally. Behaviour unchanged when the variable is unset.

## Changes Made

- \`docker-compose.yml\`: add \`SHADOW_SCORE_MODEL=\${SHADOW_SCORE_MODEL:-}\` to the \`validator\` service \`environment\` block.
- Same on the \`test\` runner so \`docker compose run test ...\` matches operational behaviour.

## Issue Link

- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing

Verified locally and on a remote validator: with the env var set on the host and the equivalent pass-through line in compose, \`docker exec oro-validator-1 env | grep SHADOW\` returns the configured model name. Without the pass-through it returns nothing.

**Test Results:** Pass-through works as expected.

### Automated Testing

N/A — config-only change.

**Test Command(s):**

\`\`\`bash
docker compose --profile validator config | grep SHADOW
\`\`\`

## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:** Inline comments on both env entries explain the opt-in semantics.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

External validator operators see no behaviour change unless they explicitly set \`SHADOW_SCORE_MODEL\` in their \`.env\`.