### PR TITLE
scoring: log shadow + canonical encode timings, pre-cache e5-base-v2

### DIFF
--- a/docker/validator/Dockerfile
+++ b/docker/validator/Dockerfile
@@ -20,10 +20,10 @@ COPY docker/validator/pyproject.toml docker/validator/uv.lock /app/
 RUN uv sync --frozen --no-dev --no-install-project
 
 # Pre-cache SentenceTransformer models (avoids runtime download). The
-# canonical Qwen3 model is always loaded; the bge-small bundle is for the
-# optional ORO-1474 shadow scorer enabled via SHADOW_SCORE_MODEL at runtime.
+# canonical Qwen3 model is always loaded; the bge-small + e5-base bundles
+# are candidate shadow scorers enabled via SHADOW_SCORE_MODEL at runtime.
 ARG HF_TOKEN=""
-RUN HF_HUB_ENABLE_HF_TRANSFER=0 HF_TOKEN=${HF_TOKEN} .venv/bin/python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('Qwen/Qwen3-Embedding-0.6B'); SentenceTransformer('BAAI/bge-small-en-v1.5')"
+RUN HF_HUB_ENABLE_HF_TRANSFER=0 HF_TOKEN=${HF_TOKEN} .venv/bin/python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('Qwen/Qwen3-Embedding-0.6B'); SentenceTransformer('BAAI/bge-small-en-v1.5'); SentenceTransformer('intfloat/e5-base-v2')"
 
 # Copy validator code
 COPY subnet/ /app/subnet/

--- a/src/agent/rewards/orm.py
+++ b/src/agent/rewards/orm.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import time
 from collections import Counter
 
 SENTENCE_MODEL_NAME = "Qwen/Qwen3-Embedding-0.6B"
@@ -75,12 +76,32 @@ def _log_shadow_sim(product_title: str, gt_title: str, canonical_sim: float) -> 
     if shadow is None:
         return
     try:
+        t0 = time.perf_counter()
         product_emb = shadow.encode([product_title])
         gt_emb = shadow.encode([gt_title])
+        shadow_encode_ms = (time.perf_counter() - t0) * 1000
+        t1 = time.perf_counter()
         shadow_sim = float(shadow.similarity(product_emb, gt_emb)[0][0])
+        shadow_sim_ms = (time.perf_counter() - t1) * 1000
     except Exception as exc:  # noqa: BLE001
         _logger.warning("Shadow sim failed for product=%r gt=%r: %s", product_title[:60], gt_title[:60], exc)
         return
+
+    canonical = _get_sentence_model()
+    canonical_encode_ms = None
+    canonical_sim_ms = None
+    if canonical is not None:
+        try:
+            t0 = time.perf_counter()
+            c_product_emb = canonical.encode([product_title])
+            c_gt_emb = canonical.encode([gt_title])
+            canonical_encode_ms = (time.perf_counter() - t0) * 1000
+            t1 = time.perf_counter()
+            canonical.similarity(c_product_emb, c_gt_emb)
+            canonical_sim_ms = (time.perf_counter() - t1) * 1000
+        except Exception as exc:  # noqa: BLE001
+            _logger.warning("Canonical timing probe failed: %s", exc)
+
     _logger.info(
         "shadow_sim %s",
         json.dumps(
@@ -91,6 +112,14 @@ def _log_shadow_sim(product_title: str, gt_title: str, canonical_sim: float) -> 
                 "shadow_model": os.environ.get(SHADOW_MODEL_ENV, ""),
                 "product_title": product_title,
                 "gt_title": gt_title,
+                "shadow_encode_ms": round(shadow_encode_ms, 3),
+                "shadow_sim_ms": round(shadow_sim_ms, 3),
+                "canonical_encode_ms": (
+                    round(canonical_encode_ms, 3) if canonical_encode_ms is not None else None
+                ),
+                "canonical_sim_ms": (
+                    round(canonical_sim_ms, 3) if canonical_sim_ms is not None else None
+                ),
             }
         ),
     )

--- a/tests/test_scoring_perf.py
+++ b/tests/test_scoring_perf.py
@@ -93,6 +93,11 @@ def test_shadow_sim_logged_when_enabled(mock_get, mock_shadow, monkeypatch, capl
     assert payload["shadow_sim"] == pytest.approx(0.42)
     assert payload["shadow_model"] == "BAAI/bge-small-en-v1.5"
     assert payload["gt_title"] == "the gt title"
+    # Timing fields populated (real numbers, not None) when both models load.
+    assert isinstance(payload["shadow_encode_ms"], (int, float))
+    assert isinstance(payload["shadow_sim_ms"], (int, float))
+    assert isinstance(payload["canonical_encode_ms"], (int, float))
+    assert isinstance(payload["canonical_sim_ms"], (int, float))
 
 
 def test_shadow_sim_silent_when_disabled(monkeypatch, caplog):


### PR DESCRIPTION
## Description

Extend the opt-in shadow scoring log line with per-pair timing for both the canonical (Qwen3-Embedding-0.6B) and the configured shadow encoder, and pre-cache `intfloat/e5-base-v2` in the validator image so it can be enabled as a shadow candidate without a runtime download.

Local benchmark of 10 candidate sentence models on 167 production title pairs showed `intfloat/e5-base-v2` has the highest Pearson correlation with the canonical Qwen3 sims (0.7591 at 110M params) while running roughly 5.5× faster than Qwen3 on CPU. To quantify the speedup on production validator hardware (Graviton ARM, not Apple Silicon), we need per-pair encode timings logged side-by-side.

## Changes Made

- `src/agent/rewards/orm.py`: time both encode and similarity calls for shadow and canonical models, add the four `*_ms` fields to the `shadow_sim` JSON payload.
- `docker/validator/Dockerfile`: add `intfloat/e5-base-v2` to the pre-cache step alongside Qwen3 and bge-small.
- `tests/test_scoring_perf.py`: assert the new timing fields are present and numeric in the logged payload.

## Issue Link

- Related to: N/A (shadow scoring observability follow-up)
- Closes: N/A

## Testing

### Manual Testing
Ran the local pytest suite; the shadow scoring tests pass with the new timing assertions.

**Test Results:**
- `uv run pytest tests/test_scoring_perf.py -x -q` → 6 passed in 0.13s.

### Automated Testing
Existing unit tests cover both the enabled and disabled shadow paths. New assertions verify the timing fields appear in the payload when the shadow model loads successfully.

**Test Command(s):**
```bash
uv run pytest tests/test_scoring_perf.py -x -q
```

## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
N/A

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

The canonical timing probe adds one extra single-title encode pair per shadow log line. This is wasted compute outside of measurement, so the timing instrumentation is gated on the same `SHADOW_SCORE_MODEL` env var that gates the shadow log itself. When shadow scoring is disabled (production default), there is no additional cost.

Pre-caching e5-base-v2 increases the validator image by approximately 440 MB. The shadow scorer continues to no-op when `SHADOW_SCORE_MODEL` is unset, so this is purely opt-in plumbing.