### PR TITLE
validator: re-attach per-problem score to end-of-run progress flush

### DIFF
--- a/subnet/tests/validator/test_progress_batcher.py
+++ b/subnet/tests/validator/test_progress_batcher.py
@@ -1,0 +1,73 @@
+"""Tests for progress_batcher helpers."""
+
+from uuid import uuid4
+
+from oro_sdk.models import ProblemStatus
+from oro_sdk.types import UNSET
+
+from validator.progress_batcher import problem_result_to_update
+from validator.types import ProblemResult
+
+
+def _make_result(**overrides) -> ProblemResult:
+    defaults = dict(
+        problem_id=str(uuid4()),
+        category="product",
+        status=ProblemStatus.SUCCESS,
+        score=1.0,
+        score_dict={},
+        inference_failures=0,
+        inference_total=0,
+    )
+    defaults.update(overrides)
+    return ProblemResult(**defaults)
+
+
+class TestProblemResultToUpdate:
+    def test_carries_score_and_status(self):
+        r = _make_result(score=1.0, status=ProblemStatus.SUCCESS)
+        u = problem_result_to_update(r)
+        assert u.score == 1.0
+        assert u.status == ProblemStatus.SUCCESS
+
+    def test_zero_score_preserved(self):
+        r = _make_result(score=0.0, status=ProblemStatus.FAILED)
+        u = problem_result_to_update(r)
+        assert u.score == 0.0
+        assert u.status == ProblemStatus.FAILED
+
+    def test_logs_s3_key_default_unset(self):
+        r = _make_result()
+        u = problem_result_to_update(r)
+        assert u.logs_s3_key is UNSET
+
+    def test_logs_s3_key_passthrough(self):
+        r = _make_result()
+        u = problem_result_to_update(r, logs_s3_key="k/path/x.json")
+        assert u.logs_s3_key == "k/path/x.json"
+
+    def test_reasoning_summary_only_when_scored(self):
+        r_no = _make_result(reasoning_score=None)
+        assert problem_result_to_update(r_no).score_components_summary is None
+
+        r_yes = _make_result(
+            reasoning_score=0.9,
+            reasoning_explanation="looks good",
+            reasoning_model="anthropic/claude-haiku-4.5",
+        )
+        u = problem_result_to_update(r_yes)
+        assert u.score_components_summary == {
+            "reasoning_explanation": "looks good",
+            "reasoning_model": "anthropic/claude-haiku-4.5",
+        }
+
+    def test_inference_counts_gated_on_total(self):
+        r_zero = _make_result(inference_failures=0, inference_total=0)
+        u_zero = problem_result_to_update(r_zero)
+        assert u_zero.inference_failure_count is None
+        assert u_zero.inference_total is None
+
+        r_run = _make_result(inference_failures=1, inference_total=5)
+        u_run = problem_result_to_update(r_run)
+        assert u_run.inference_failure_count == 1
+        assert u_run.inference_total == 5

--- a/subnet/tests/validator/test_progress_reporter_envelope.py
+++ b/subnet/tests/validator/test_progress_reporter_envelope.py
@@ -176,3 +176,22 @@ class TestSweepNarrowing:
         assert reporter._results[_P1].status == ProblemStatus.TIMED_OUT
         assert reporter._results[_P2].status == ProblemStatus.TIMED_OUT
         assert reporter._results[_P3].status == ProblemStatus.TIMED_OUT
+
+
+class TestGetResult:
+    def test_returns_populated_result(self, reporter, tmp_path):
+        _write_envelope(
+            tmp_path / "output.jsonl",
+            problem_id=_P1,
+            status="FAILED",
+            dialogue=None,
+            error={"type": "RuntimeError", "message": "x"},
+        )
+        reporter._envelope_dispatcher.read_and_dispatch()
+        result = reporter.get_result(_P1)
+        assert result is not None
+        assert result.status == ProblemStatus.FAILED
+        assert result.score == 0.0
+
+    def test_returns_none_for_unknown(self, reporter):
+        assert reporter.get_result(_P1) is None

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -37,6 +37,7 @@ from .resource_collector import collect_resource_metrics
 from .version_collector import collect_service_versions
 from .weight_setter import WeightSetterThread
 from .retry_queue import LocalRetryQueue
+from .progress_batcher import problem_result_to_update
 from .progress_reporter import ProgressReporter
 from .backoff import ExponentialBackoff
 from .drain import handle_drain_tick
@@ -118,7 +119,9 @@ class Validator:
         parser.add_argument(
             "--sandbox-log-max-bytes",
             type=int,
-            default=int(os.environ.get("SANDBOX_LOG_MAX_BYTES") or str(256 * 1024 * 1024)),
+            default=int(
+                os.environ.get("SANDBOX_LOG_MAX_BYTES") or str(256 * 1024 * 1024)
+            ),
             help=(
                 "Max bytes captured per sandbox stdout/stderr log before truncation "
                 "(env: SANDBOX_LOG_MAX_BYTES, default: 256 MiB). Bounds disk use so a "
@@ -1082,16 +1085,29 @@ class Validator:
                         last_s3_key = s3_key
                         logging.info(f"Uploaded logs to {s3_key}")
 
-            # Report S3 keys back to Backend so download endpoint can find them
+            # Report S3 keys back to Backend so download endpoint can find them.
+            # Also re-attach per-problem score + reasoning: `_upload_logs` runs
+            # post-scoring, so `progress_reporter._results` is fully populated
+            # here. `ProgressBatcher.batch_report` may have silently failed
+            # earlier (swallowed at `progress_batcher.py:108`); resending here
+            # is idempotent on the backend and stops null-score rows leaking
+            # into problem_progress on fast evals.
             if uploaded_keys:
-                progress_updates = [
-                    ProblemProgressUpdate(
-                        problem_id=pid,
-                        status=progress_reporter.get_problem_status(str(pid)),
-                        logs_s3_key=s3_key,
-                    )
-                    for pid, s3_key in uploaded_keys.items()
-                ]
+                progress_updates = []
+                for pid, s3_key in uploaded_keys.items():
+                    result = progress_reporter.get_result(str(pid))
+                    if result is not None:
+                        progress_updates.append(
+                            problem_result_to_update(result, logs_s3_key=s3_key)
+                        )
+                    else:
+                        progress_updates.append(
+                            ProblemProgressUpdate(
+                                problem_id=pid,
+                                status=progress_reporter.get_problem_status(str(pid)),
+                                logs_s3_key=s3_key,
+                            )
+                        )
                 try:
                     self.backend_client.report_progress(eval_run_id, progress_updates)
                     logging.info(

--- a/subnet/validator/progress_batcher.py
+++ b/subnet/validator/progress_batcher.py
@@ -17,6 +17,7 @@ import requests
 from bittensor.utils.btlogging import logging
 
 from oro_sdk.models import ProblemProgressUpdate
+from oro_sdk.types import UNSET, Unset
 
 from src.agent.types import ScoreComponentsSummary
 
@@ -26,6 +27,38 @@ from .types import ProblemResult
 
 # Report to backend at most every N seconds
 REPORT_INTERVAL_SECONDS = 10.0
+
+
+def problem_result_to_update(
+    result: ProblemResult, logs_s3_key: str | Unset = UNSET
+) -> ProblemProgressUpdate:
+    """Build a ProblemProgressUpdate from a scored ProblemResult.
+
+    Shared by ProgressBatcher.batch_report (periodic score push) and
+    Validator._upload_logs (post-scoring flush that also carries the
+    per-problem log S3 key). Backend upsert is idempotent so calling both
+    is safe — this guards against ProgressBatcher silently dropping scores
+    on fast evals (see progress_batcher.py:108).
+    """
+    scs: Optional[ScoreComponentsSummary] = None
+    if result.reasoning_score is not None:
+        scs = {
+            "reasoning_explanation": result.reasoning_explanation,
+            "reasoning_model": result.reasoning_model,
+        }
+    return ProblemProgressUpdate(
+        problem_id=UUID(result.problem_id),
+        status=result.status,
+        score=result.score,
+        reasoning_score=result.reasoning_score,
+        score_components_summary=scs,
+        inference_failure_count=result.inference_failures
+        if result.inference_total > 0
+        else None,
+        inference_total=result.inference_total if result.inference_total > 0 else None,
+        execution_time=result.execution_time,
+        logs_s3_key=logs_s3_key,
+    )
 
 
 class ProgressBatcher:
@@ -76,29 +109,7 @@ class ProgressBatcher:
         if not results:
             return
 
-        updates = []
-        for r in results:
-            # Include per-problem reasoning data if judge ran
-            scs: Optional[ScoreComponentsSummary] = None
-            if r.reasoning_score is not None:
-                scs = {
-                    "reasoning_explanation": r.reasoning_explanation,
-                    "reasoning_model": r.reasoning_model,
-                }
-
-            update = ProblemProgressUpdate(
-                problem_id=UUID(r.problem_id),
-                status=r.status,
-                score=r.score,
-                reasoning_score=r.reasoning_score,
-                score_components_summary=scs,
-                inference_failure_count=r.inference_failures
-                if r.inference_total > 0
-                else None,
-                inference_total=r.inference_total if r.inference_total > 0 else None,
-                execution_time=r.execution_time,
-            )
-            updates.append(update)
+        updates = [problem_result_to_update(r) for r in results]
 
         try:
             self._backend_client.report_progress(self._eval_run_id, updates)

--- a/subnet/validator/progress_reporter.py
+++ b/subnet/validator/progress_reporter.py
@@ -218,6 +218,10 @@ class ProgressReporter:
             return result.status
         return ProblemStatus.FAILED
 
+    def get_result(self, problem_id: str) -> Optional[ProblemResult]:
+        with self._lock:
+            return self._results.get(problem_id)
+
     def _run(self) -> None:
         """Main monitoring loop.
 


### PR DESCRIPTION
## Description

`ProgressBatcher.batch_report` silently swallows transient backend errors (`progress_batcher.py:108`) and does not retry. Fast evals (~60–100s sandbox) finish scoring in one burst, so the batcher's periodic ticks never fire — the whole run hits the batcher exactly once at completion. If that single request drops, every per-problem `score` is lost. The subsequent `_upload_logs` progress call only carried `{status, logs_s3_key}`, so nothing repaired the null `score` field.

Frontend consensus grid (`consensus-grid.tsx:28`) colors cells green iff `score === 1.0`. Runs affected by the drop rendered as almost-all-wrong even when 25/30 problems succeeded — the run-level score was still 0.83 because backend's `compute_score_from_progress` falls back to status-based scoring (`validator.py:791`), which also emits the observed `WARNING Backend scoring: 29/30 problems missing score field` log line.

## Changes Made

- Refactor `ProblemProgressUpdate` construction into a shared `problem_result_to_update(result, logs_s3_key=UNSET)` helper in `progress_batcher.py`.
- `ProgressBatcher.batch_report` uses the helper.
- `_upload_logs` uses the helper for scored problems; falls back to the old status-only shape only when `progress_reporter.get_result(pid)` returns `None`.
- Add `ProgressReporter.get_result` accessor so main.py can pull the full `ProblemResult` when building the flush payload.
- Backend upsert is already idempotent (`validator.py:1365`), so the redundant score writes across both paths are safe.

## Issue Link

- Related to: N/A (bug found via prod diagnosis on 2026-06-30/07-01)
- Closes: N/A

## Testing

### Manual Testing
Verified the null-score pattern in prod for two affected agents (Kaizer, DE_Kaizer). Confirmed the backend fallback warning in CloudWatch at the exact `complete_run` timestamps for both runs. Confirmed via direct DB query that `problem_progress` JSONB has `status` + `logs_s3_key` but no `score` on 29/30 problems for one representative run.

**Test Results:**
- 4 fallback warnings in the last 24 h across 2 agents, all with sandbox durations under 105 s.
- With the fix, `_upload_logs` sends the same shape the batcher sends periodically, so at least one of the two paths must succeed for `score` to land.

### Automated Testing

- 6 new tests for `problem_result_to_update` cover: score passthrough, zero-score preserved, `logs_s3_key` default UNSET vs passed-through, reasoning-summary gating on `reasoning_score`, inference counts gated on `inference_total`.
- 2 new tests for `ProgressReporter.get_result` cover populated and missing results.
- Full existing validator unit suite still passes (107 tests) — the batcher refactor is behavior-preserving.

**Test Command(s):**
```bash
uv run pytest subnet/tests/validator/test_progress_batcher.py subnet/tests/validator/test_progress_reporter_envelope.py -v
uv run pytest subnet/tests/validator/ -q --ignore=subnet/tests/validator/test_validator_integration.py
```

## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
Inline docstring on `problem_result_to_update` explains why both paths exist and the idempotency assumption. Inline block comment in `_upload_logs` calls out the intent.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

There is a pre-existing latent bug in the failure branch: `main.py:1117` calls `self.retry_queue.add_progress(...)`, but `RetryQueue` has no `add_progress` method. It would `AttributeError` if `report_progress` failed. Not touched in this PR; will file a separate ticket.