### PR TITLE
fix(validator): retry inference-token smoke-test on transient 401

### DIFF
--- a/subnet/tests/validator/test_validate_inference_token.py
+++ b/subnet/tests/validator/test_validate_inference_token.py
@@ -52,13 +52,38 @@ class TestValidateInferenceToken:
         assert ok is True
         assert reason == ""
 
-    def test_401_returns_invalid(self):
-        with patch("validator.main.requests.post", return_value=self._mock_resp(401)):
+    def test_401_persists_fails_after_retries(self):
+        # A genuinely-bad key stays 401 through every attempt → fails fast.
+        with (
+            patch("validator.main.time.sleep") as mock_sleep,
+            patch(
+                "validator.main.requests.post", return_value=self._mock_resp(401)
+            ) as mock_post,
+        ):
             ok, reason = Validator._validate_inference_token(
                 "tok", "https://llm.chutes.ai/v1", "Qwen/Qwen3-32B-TEE"
             )
         assert ok is False
         assert "401" in reason
+        assert mock_post.call_count == 4  # 1 initial + 3 retries
+        assert mock_sleep.call_count == 3
+
+    def test_401_then_200_retries_and_passes(self):
+        # A freshly-minted key that 401s from propagation lag, then goes live.
+        with (
+            patch("validator.main.time.sleep") as mock_sleep,
+            patch(
+                "validator.main.requests.post",
+                side_effect=[self._mock_resp(401), self._mock_resp(200)],
+            ) as mock_post,
+        ):
+            ok, reason = Validator._validate_inference_token(
+                "tok", "https://llm.chutes.ai/v1", "Qwen/Qwen3-32B-TEE"
+            )
+        assert ok is True
+        assert reason == ""
+        assert mock_post.call_count == 2
+        assert mock_sleep.call_count == 1
 
     def test_402_returns_invalid_with_message(self):
         json_body = {"detail": {"message": "insufficient balance"}}

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -1217,11 +1217,9 @@ class Validator:
                 if resp.status_code == 401:
                     if attempt < max_401_retries:
                         logging.warning(
-                            "Inference token 401 (attempt %d/%d) — likely "
-                            "provider key-propagation lag, retrying in %.1fs",
-                            attempt + 1,
-                            max_401_retries + 1,
-                            backoff_seconds,
+                            f"Inference token 401 (attempt {attempt + 1}/"
+                            f"{max_401_retries + 1}) — likely provider "
+                            f"key-propagation lag, retrying in {backoff_seconds:.1f}s"
                         )
                         time.sleep(backoff_seconds)
                         continue

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -1185,47 +1185,69 @@ class Validator:
         against any OpenAI-compatible chat/completions endpoint. On
         transient errors (5xx, timeout, 429), returns (True, "") to avoid
         failing runs unnecessarily.
+
+        A freshly-minted scoped token can return 401 briefly while the
+        provider propagates the newly-created key. The token is valid, so a
+        401 is retried a few times before the run is failed. A genuinely
+        invalid/revoked key stays 401 through every attempt and still fails
+        fast, after which the run re-claims a fresh token.
         """
-        import requests
+        # Only the 401 path loops; every other outcome returns on first attempt.
+        max_401_retries = 3
+        backoff_seconds = 1.5
 
         url = f"{base_url.rstrip('/')}/chat/completions"
-        try:
-            resp = requests.post(
-                url,
-                headers={
-                    "Authorization": f"Bearer {access_token}",
-                    "Content-Type": "application/json",
-                },
-                json={
-                    "model": model,
-                    "messages": [{"role": "user", "content": "hi"}],
-                    "max_tokens": 1,
-                },
-                timeout=15,
-            )
-            if resp.status_code == 200:
-                return True, ""
-            if resp.status_code == 401:
-                return False, "Inference token invalid or expired (HTTP 401)"
-            if resp.status_code == 402:
-                detail = resp.json().get("detail", {})
-                msg = (
-                    detail.get("message", str(detail))
-                    if isinstance(detail, dict)
-                    else str(detail)
+        for attempt in range(max_401_retries + 1):
+            try:
+                resp = requests.post(
+                    url,
+                    headers={
+                        "Authorization": f"Bearer {access_token}",
+                        "Content-Type": "application/json",
+                    },
+                    json={
+                        "model": model,
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "max_tokens": 1,
+                    },
+                    timeout=15,
                 )
-                return False, f"Inference account has no credits ({msg})"
-            if resp.status_code == 429:
+                if resp.status_code == 200:
+                    return True, ""
+                if resp.status_code == 401:
+                    if attempt < max_401_retries:
+                        logging.warning(
+                            "Inference token 401 (attempt %d/%d) — likely "
+                            "provider key-propagation lag, retrying in %.1fs",
+                            attempt + 1,
+                            max_401_retries + 1,
+                            backoff_seconds,
+                        )
+                        time.sleep(backoff_seconds)
+                        continue
+                    return False, "Inference token invalid or expired (HTTP 401)"
+                if resp.status_code == 402:
+                    detail = resp.json().get("detail", {})
+                    msg = (
+                        detail.get("message", str(detail))
+                        if isinstance(detail, dict)
+                        else str(detail)
+                    )
+                    return False, f"Inference account has no credits ({msg})"
+                if resp.status_code == 429:
+                    return True, ""
+                logging.warning(
+                    "Inference token validation inconclusive: status=%s url=%s",
+                    resp.status_code,
+                    url,
+                )
                 return True, ""
-            logging.warning(
-                "Inference token validation inconclusive: status=%s url=%s",
-                resp.status_code,
-                url,
-            )
-            return True, ""
-        except Exception as exc:
-            logging.warning("Inference token validation error against %s: %s", url, exc)
-            return True, ""
+            except Exception as exc:
+                logging.warning("Inference token validation error against %s: %s", url, exc)
+                return True, ""
+
+        # Unreachable: the loop returns on every path, but keeps mypy happy.
+        return False, "Inference token invalid or expired (HTTP 401)"
 
     def _complete_with_failure(
         self,


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does. Include the motivation and context if relevant. -->

Before running an eval, the validator smoke-tests the miner's freshly-minted scoped inference token with a 1-token completion (`_validate_inference_token`). A newly-created provider key can return **401 briefly while the provider propagates it** — the token is valid and works moments later. The smoke test treated that 401 as a hard failure and failed the run immediately, even though the same token (or a re-claimed one) succeeds shortly after.

The function already treats 5xx / 429 / timeout as transient (proceeds without failing); this extends the same treatment to a propagation-lag 401 by retrying before giving up.

## Changes Made

<!-- List the key changes made in this PR: -->
- `subnet/validator/main.py`: `_validate_inference_token` now retries a 401 up to 3 times with a 1.5s backoff before returning invalid. 200 short-circuits to valid; 402 (no credits) and other statuses are unchanged. A genuinely invalid/revoked key stays 401 through every attempt and fails fast (~4.5s worst case), after which the run re-claims a fresh token as before.
- `subnet/tests/validator/test_validate_inference_token.py`: updated the persistent-401 test to assert it retries then fails (4 attempts, 3 sleeps, `time.sleep` patched); added a 401-then-200 test asserting the retry recovers to valid.

## Testing

### Manual Testing

`_validate_inference_token` unit tests: 13 passed. Broader validator suite: 184 passed.

**Test Command(s):**
```bash
pytest subnet/tests/validator/test_validate_inference_token.py -q
pytest subnet/tests/validator/ -q
```

## Additional Notes

Only the 401 path loops; happy-path latency is unchanged. Worst-case added latency is ~4.5s, and only on runs whose token initially 401s (rare). No config surface; retry count/backoff are local constants.