### PR TITLE
fix(validator): protect the survivor set, not top-50% of finishers

### DIFF
--- a/subnet/tests/validator/test_weight_distribution.py
+++ b/subnet/tests/validator/test_weight_distribution.py
@@ -1,4 +1,4 @@
-"""Tests for the deterministic top-50% weight distribution.
+"""Tests for the deterministic survivor-set weight distribution.
 
 Determinism is load-bearing for Yuma consensus on subnet 15
 (`kappa = 0.5`): if two validators emit different weight vectors for the
@@ -193,41 +193,42 @@ def test_rank_finishers_stable_under_input_shuffle():
 @pytest.mark.parametrize("n", [10, 30, 50, 100])
 @pytest.mark.parametrize("t_burn", [0.75, 0.25])
 def test_compute_hotkey_weights_shape_per_spec(n, t_burn):
-    """Rank 1 = top_u16 (sized for exact `1 - t_burn` share), ranks 2..K =
-    K+1-rank, bottom 50% absent."""
+    """Rank 1 = top_u16 (sized for exact `1 - t_burn` share), ranks 2..N =
+    N+1-rank. Every survivor (all N) gets an entry — no top-N cut."""
     finishers = _make_finishers(n, seed=n)
     ranked = rank_finishers(finishers)
     weights = compute_hotkey_weights(
         finishers, t_burn, top_hotkey=ranked[0].miner_hotkey
     )
 
-    k = n // 2
-    assert len(weights) == k
+    # Top slot + a taper entry for every other survivor.
+    assert len(weights) == n
 
-    tail_sum = sum(range(1, k))  # 1 + 2 + ... + (K-1)
+    tail_sum = sum(range(1, n))  # 1 + 2 + ... + (N-1)
     expected_top, _ = compute_pinned_weights(t_burn, tail_sum=tail_sum)
 
     assert weights[ranked[0].miner_hotkey] == expected_top
 
-    for idx in range(1, k):
-        rank_1based = idx + 1
-        assert weights[ranked[idx].miner_hotkey] == k + 1 - rank_1based
+    for idx in range(1, n):
+        assert weights[ranked[idx].miner_hotkey] == n - idx
 
-    assert weights[ranked[k - 1].miner_hotkey] == 1
-
-    for idx in range(k, n):
-        assert ranked[idx].miner_hotkey not in weights
+    assert weights[ranked[n - 1].miner_hotkey] == 1
 
     assert all(w >= 1 for w in weights.values())
 
 
-@pytest.mark.parametrize("n", [0, 1])
-def test_compute_hotkey_weights_empty_for_too_few_finishers(n):
-    """N=0 or N=1 → floor(N/2)=0, no protected tail entries. With no
-    `top_hotkey` either, the dict is empty; the burn uid still fires
+def test_compute_hotkey_weights_empty_for_zero_finishers():
+    """N=0 → no survivors, empty dict; the burn uid still fires
     unconditionally in `build_metagraph_weight_vector`."""
-    weights = compute_hotkey_weights(_make_finishers(n), 0.75)
-    assert weights == {}
+    assert compute_hotkey_weights(_make_finishers(0), 0.75) == {}
+
+
+def test_compute_hotkey_weights_single_survivor_gets_min_taper():
+    """N=1 → the lone survivor is protected. With no `top_hotkey` it takes
+    the single taper slot (weight 1); the burn uid carries the top share."""
+    finishers = _make_finishers(1)
+    weights = compute_hotkey_weights(finishers, 0.75)
+    assert weights == {finishers[0].miner_hotkey: 1}
 
 
 # --- top share is exactly (1 - t_burn) across N (the load-bearing property at high burn) ---
@@ -260,29 +261,29 @@ def test_top_miner_share_is_exactly_t_top_regardless_of_n(n):
 
 
 def test_compute_hotkey_weights_n30_top_share_25pct():
-    """N=30, K=15, tail_sum=105. Top = round(0.25*(65535+105)/0.75) = 21880."""
+    """N=30 survivors, tail=29, tail_sum=435. Top = round(0.25*(65535+435)/0.75) = 21990."""
     finishers = _make_finishers(30, seed=30)
     ranked = rank_finishers(finishers)
     weights = compute_hotkey_weights(
         finishers, 0.75, top_hotkey=ranked[0].miner_hotkey
     )
 
-    assert weights[ranked[0].miner_hotkey] == 21880
-    tail_sum = sum(weights[ranked[idx].miner_hotkey] for idx in range(1, 15))
-    assert tail_sum == 105
+    assert weights[ranked[0].miner_hotkey] == 21990
+    tail_sum = sum(weights[ranked[idx].miner_hotkey] for idx in range(1, 30))
+    assert tail_sum == 435
 
 
 def test_compute_hotkey_weights_n100_top_share_25pct():
-    """N=100, K=50, tail_sum=1225. Top = round(0.25*(65535+1225)/0.75) = 22253."""
+    """N=100 survivors, tail=99, tail_sum=4950. Top = round(0.25*(65535+4950)/0.75) = 23495."""
     finishers = _make_finishers(100, seed=100)
     ranked = rank_finishers(finishers)
     weights = compute_hotkey_weights(
         finishers, 0.75, top_hotkey=ranked[0].miner_hotkey
     )
 
-    assert weights[ranked[0].miner_hotkey] == 22253
-    tail_sum = sum(weights[ranked[idx].miner_hotkey] for idx in range(1, 50))
-    assert tail_sum == 1225
+    assert weights[ranked[0].miner_hotkey] == 23495
+    tail_sum = sum(weights[ranked[idx].miner_hotkey] for idx in range(1, 100))
+    assert tail_sum == 4950
 
 
 # --- determinism (the Yuma-consensus property) ---
@@ -365,19 +366,19 @@ def test_build_metagraph_vector_empty_metagraph_returns_empty():
 
 def test_top_hotkey_none_burns_top_share_no_synthesis():
     """ORO-1120: when no admin-designated top exists, do NOT synthesize
-    one from rank-1 of finishers. The dict carries the full top-K tail
+    one from rank-1 of finishers. The dict carries the full survivor tail
     (no top entry); the caller burns the 25% top share."""
     finishers = _make_finishers(20, seed=42)
     ranked = rank_finishers(finishers)
-    k = len(finishers) // 2
+    n = len(finishers)
 
     weights = compute_hotkey_weights(finishers, 0.75, top_hotkey=None)
 
-    expected_top_u16, _ = compute_pinned_weights(0.75, tail_sum=k * (k + 1) // 2)
+    expected_top_u16, _ = compute_pinned_weights(0.75, tail_sum=n * (n + 1) // 2)
     assert weights[ranked[0].miner_hotkey] != expected_top_u16
-    assert weights[ranked[0].miner_hotkey] == k
-    assert weights[ranked[k - 1].miner_hotkey] == 1
-    assert len(weights) == k
+    assert weights[ranked[0].miner_hotkey] == n
+    assert weights[ranked[n - 1].miner_hotkey] == 1
+    assert len(weights) == n
 
 
 def test_top_hotkey_override_promotes_non_winner_to_top_slot():
@@ -394,15 +395,15 @@ def test_top_hotkey_override_promotes_non_winner_to_top_slot():
     assert weights[rank2] == top_u16
     assert rank1 in weights
     assert weights[rank1] != top_u16
-    k = len(finishers) // 2
-    m = k - 1
+    # Tail = all survivors except the promoted top; rank-1 leads it.
+    m = len(finishers) - 1
     assert weights[rank1] == m
 
 
 def test_top_hotkey_not_in_finishers_keeps_old_winner_in_tail():
     """When `top_hotkey` is a brand-new hotkey not present in last-race
-    finishers, the override hotkey gets the top slot and the full top-K
-    of finishers (including old rank-1) populates the tail."""
+    finishers, the override hotkey gets the top slot and the full survivor
+    set (including old rank-1) populates the tail."""
     finishers = _make_finishers(20, seed=11)
     ranked = rank_finishers(finishers)
     rank1 = ranked[0].miner_hotkey
@@ -412,8 +413,8 @@ def test_top_hotkey_not_in_finishers_keeps_old_winner_in_tail():
 
     top_u16 = max(weights.values())
     assert weights[new_top] == top_u16
-    k = len(finishers) // 2
-    assert weights[rank1] == k
+    # rank-1 leads the survivor tail at taper max = N.
+    assert weights[rank1] == len(finishers)
 
 
 def test_top_hotkey_override_top_share_remains_t_top():
@@ -475,8 +476,8 @@ def test_build_metagraph_vector_top_hotkey_not_in_metagraph_burns_top_share():
 
     assert weights[0] == U16_MAX
     rank1_idx = metagraph_hotkeys.index(rank1_hk)
-    k = len(finishers) // 2
-    assert weights[rank1_idx] == k
+    # Full survivor tail — rank-1 leads it at taper max = N.
+    assert weights[rank1_idx] == len(finishers)
     total = sum(weights)
     burn_share = weights[0] / total
     assert burn_share > 0.99
@@ -500,13 +501,14 @@ def test_build_metagraph_vector_no_top_hotkey_burns_top_share():
 
     assert weights[0] == U16_MAX
     rank1_idx = metagraph_hotkeys.index(ranked[0].miner_hotkey)
-    k = len(finishers) // 2
-    assert weights[rank1_idx] == k
+    # Full survivor tail — rank-1 leads it at taper max = N, every survivor
+    # gets a nonzero entry (no bottom-half cut).
+    assert weights[rank1_idx] == len(finishers)
     total = sum(weights)
     assert weights[0] / total > 0.99
-    for idx in range(k, len(finishers)):
-        bottom_idx = metagraph_hotkeys.index(ranked[idx].miner_hotkey)
-        assert weights[bottom_idx] == 0
+    for f in finishers:
+        idx = metagraph_hotkeys.index(f.miner_hotkey)
+        assert weights[idx] >= 1
 
 
 def test_build_metagraph_vector_no_top_hotkey_no_finishers_burns_everything():
@@ -554,8 +556,9 @@ def test_two_validators_with_top_override_emit_byte_identical_weights():
 
 
 def test_build_metagraph_vector_burn_zero_emits_top_dominant_vector():
-    """At t_burn=0, top miner takes ~99.7% (M=19 race), tail keeps its
-    rank-j integer taper, burn uid stamps 0."""
+    """At t_burn=0, top miner absorbs the deficit. Survivor tail M=39
+    (N=40, minus top), tail_sum=780, so top share = 65535/(65535+780) ≈
+    0.9882. Burn uid stamps 0."""
     finishers = _make_finishers(40, seed=1439)
     ranked = rank_finishers(finishers)
     metagraph = ["burn_uid"] + [f.miner_hotkey for f in finishers]
@@ -569,4 +572,4 @@ def test_build_metagraph_vector_burn_zero_emits_top_dominant_vector():
     assert weights[rank1_idx] == U16_MAX
     assert weights[0] == 0  # burn slot empty
     total = sum(weights)
-    assert weights[rank1_idx] / total == pytest.approx(0.9971, abs=1e-3)
+    assert weights[rank1_idx] / total == pytest.approx(0.9882, abs=1e-3)

--- a/subnet/tests/validator/test_weight_setter.py
+++ b/subnet/tests/validator/test_weight_setter.py
@@ -1,4 +1,5 @@
 import time
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 from uuid import UUID, uuid4
@@ -43,7 +44,12 @@ def _race_detail(qualifiers: list[dict]):
 
     Each dict needs `miner_hotkey`, `agent_version_id`, `race_score` and may
     optionally provide `is_discarded` (defaults to False — set True to
-    exercise the ORO-1111 filter path).
+    exercise the ORO-1111 filter path) or `eliminated_at` (defaults to None —
+    set to a timestamp to exercise the survivor-set filter path).
+
+    Both flags are set explicitly: a bare `MagicMock` auto-returns a truthy
+    child mock for any unset attribute, which would make every qualifier
+    look eliminated/discarded.
     """
     detail = MagicMock()
     detail.qualifiers = []
@@ -53,6 +59,7 @@ def _race_detail(qualifiers: list[dict]):
         m.agent_version_id = q["agent_version_id"]
         m.race_score = q["race_score"]
         m.is_discarded = q.get("is_discarded", False)
+        m.eliminated_at = q.get("eliminated_at", None)
         detail.qualifiers.append(m)
     return detail
 
@@ -157,12 +164,13 @@ class TestWeightSetterThread:
 
         assert mock_backend_client.get_race_history.call_count >= 2
 
-    def test_race_path_distributes_to_top_half(
+    def test_race_path_distributes_to_survivors(
         self, mock_backend_client, mock_subtensor, mock_wallet
     ):
-        """6 finishers, all in metagraph: top 3 (floor(6/2)) get u16; bottom 3 zero.
-        With every protected finisher present, no drift correction needed —
-        top_u16 lands at 25% of the submitted vector exactly.
+        """6 survivors, all in metagraph: the top slot goes to 5HK0 and the
+        other 5 survivors all get a taper entry (5,4,3,2,1) — no bottom cut.
+        With every survivor present, no drift correction needed — top_u16
+        lands at 25% of the submitted vector exactly.
         """
         finishers = [
             {"miner_hotkey": f"5HK{i}", "agent_version_id": str(uuid4()), "race_score": 0.9 - i * 0.05}
@@ -192,15 +200,15 @@ class TestWeightSetterThread:
         setter.stop()
 
         weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
-        # K=3, tail (ranks 2..3) = [2, 1] → tail_sum_actual = 3.
-        top_u16, burn_u16 = compute_pinned_weights(0.75, tail_sum=3)
+        # Survivor tail (ranks 2..6) = [5, 4, 3, 2, 1] → tail_sum_actual = 15.
+        top_u16, burn_u16 = compute_pinned_weights(0.75, tail_sum=15)
         assert weights[0] == burn_u16
         assert weights[1] == top_u16
-        assert weights[2] == 2
-        assert weights[3] == 1
-        assert weights[4] == 0
-        assert weights[5] == 0
-        assert weights[6] == 0
+        assert weights[2] == 5
+        assert weights[3] == 4
+        assert weights[4] == 3
+        assert weights[5] == 2
+        assert weights[6] == 1
 
     def test_race_path_skips_in_progress_and_uses_prior_completed_race(
         self, mock_backend_client, mock_subtensor, mock_wallet
@@ -246,7 +254,7 @@ class TestWeightSetterThread:
         for call in mock_backend_client.get_race_detail.call_args_list:
             assert call.args == (completed_id,) or call.kwargs == {"race_id": completed_id}
         weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
-        top_u16, _ = compute_pinned_weights(0.75, tail_sum=3)
+        top_u16, _ = compute_pinned_weights(0.75, tail_sum=15)
         assert weights[1] == top_u16
 
     def test_drift_correction_when_protected_finishers_deregistered(
@@ -256,8 +264,8 @@ class TestWeightSetterThread:
         top_u16 / burn_u16 are recomputed from the *actual* tail_sum so the
         top miner's normalised share stays at exactly t_top.
         """
-        # 6 finishers; rank 2 (5HK1) and rank 3 (5HK2) are deregistered →
-        # protected set drops from 3 (K=floor(6/2)) to 1 in the metagraph.
+        # 6 survivors; only rank-1 (5HK0, the top) is in the metagraph, so the
+        # entire survivor tail (5HK1..5HK5) is deregistered → tail_sum → 0.
         finishers = [
             {"miner_hotkey": f"5HK{i}", "agent_version_id": str(uuid4()), "race_score": 0.9 - i * 0.05}
             for i in range(6)
@@ -326,5 +334,44 @@ class TestQualifiersToFinishersIsDiscarded:
 
     def test_unset_is_discarded_treated_as_false(self):
         qualifiers = [self._q("5HKunset", 0.6, is_discarded=UNSET)]
+        finishers = _qualifiers_to_finishers(qualifiers)
+        assert [f.miner_hotkey for f in finishers] == ["5HKunset"]
+
+
+class TestQualifiersToFinishersEliminated:
+    """Survivor-set filter: drop `eliminated_at` qualifiers (bottom-cut at
+    race end) so the protected tail tracks the survivor set, not a fixed
+    top-N. An agent that finished but was eliminated keeps its non-null
+    `race_score`, so only this filter removes it."""
+
+    @staticmethod
+    def _q(hotkey: str, score: float, *, eliminated_at=None, with_field: bool = True):
+        attrs = {
+            "miner_hotkey": hotkey,
+            "agent_version_id": uuid4(),
+            "race_score": score,
+        }
+        if with_field:
+            attrs["eliminated_at"] = eliminated_at
+        return SimpleNamespace(**attrs)
+
+    def test_drops_eliminated_keeps_survivors(self):
+        elim_ts = datetime(2026, 7, 8, tzinfo=timezone.utc)
+        qualifiers = [
+            self._q("5HKsurvivor", 0.9),
+            self._q("5HKeliminated", 0.85, eliminated_at=elim_ts),
+            self._q("5HKalsoSurvivor", 0.8),
+        ]
+        finishers = _qualifiers_to_finishers(qualifiers)
+        assert {f.miner_hotkey for f in finishers} == {"5HKsurvivor", "5HKalsoSurvivor"}
+
+    def test_missing_eliminated_at_field_defaults_to_kept(self):
+        """Forward-compat with SDK builds pre-dating `eliminated_at`: missing = keep."""
+        qualifiers = [self._q("5HKlegacy", 0.7, with_field=False)]
+        finishers = _qualifiers_to_finishers(qualifiers)
+        assert [f.miner_hotkey for f in finishers] == ["5HKlegacy"]
+
+    def test_unset_eliminated_at_treated_as_kept(self):
+        qualifiers = [self._q("5HKunset", 0.6, eliminated_at=UNSET)]
         finishers = _qualifiers_to_finishers(qualifiers)
         assert [f.miner_hotkey for f in finishers] == ["5HKunset"]

--- a/subnet/validator/weight_distribution.py
+++ b/subnet/validator/weight_distribution.py
@@ -1,17 +1,20 @@
-"""Deterministic weight distribution for the top half of race finishers.
+"""Deterministic weight distribution for the survivor set of a race.
 
-A finisher is a qualifier from the most recent completed race that
-actually finished the race (has a non-null `race_score`). Qualifiers
-that DNF'd or were eliminated mid-race land in the public race detail
-with `race_score=null` and are dropped at the boundary in
-`weight_setter._qualifiers_to_finishers`. By the time finishers reach
-this module the list is already filtered.
+A finisher here is a *survivor*: a qualifier from the most recent
+completed race that finished (non-null `race_score`) and was neither
+eliminated (bottom-cut at race end, `eliminated_at`) nor discarded
+(`is_discarded`). DNF/never-executed qualifiers carry `race_score=null`;
+all three exclusions are applied at the boundary in
+`weight_setter._qualifiers_to_finishers`, so by the time finishers reach
+this module the list is already the survivor set.
 
-The protection target is the half of last race's finishers with the
-highest scores: those who actively competed and did not finish at the
-bottom of the pack. They keep `Emission[uid] > 0` between races and
-survive `get_neuron_to_prune` (which ranks by emission asc, reg_block
-asc, uid asc) when their `immunity_period` expires.
+The protection target is every survivor — the agents that advance to the
+next race. They keep `Emission[uid] > 0` between races and survive
+`get_neuron_to_prune` (which ranks by emission asc, reg_block asc, uid
+asc) when their `immunity_period` expires. Tying the protected set to the
+survivor set (rather than a fixed top-N of finishers) keeps it aligned
+with the elimination fraction automatically — no second threshold to
+hand-sync when that fraction changes.
 
 The function in this module is pure — same `(finishers, t_top, t_burn)`
 yields byte-identical u16 weight vectors across validators. That
@@ -38,7 +41,7 @@ U16_MAX = 65535
 #   * burn slot pinned at U16_MAX = 65535
 #   * total = (U16_MAX + tail_sum) / t_burn
 #   * top u16 = round(t_top * total)
-# The tail (top-half ranks 2..K, integer taper M, M-1, ..., 1) comes out
+# The tail (all survivors ranks 2..N, integer taper M, M-1, ..., 1) comes out
 # of the burn allocation; top miner stays at exactly `t_top` regardless
 # of race size.
 #
@@ -156,21 +159,25 @@ def compute_hotkey_weights(
     from rank-1 of finishers: the 25% slot belongs to the admin-designated
     top only.
 
-    The tail is the top 50% of last-race finishers minus the top hotkey if
-    they overlap. Tail entries receive a linear taper M, M-1, ..., 1 in rank
-    order, where M is the number of tail entries. The tail's share comes
-    out of `t_burn` — the top miner's share does not move with N.
+    The tail is the full survivor set — every non-eliminated, non-discarded
+    finisher (the caller filters those upstream in
+    `_qualifiers_to_finishers`) minus the top hotkey if they overlap. Tail
+    entries receive a linear taper M, M-1, ..., 1 in rank order, where M is
+    the number of tail entries. The tail's share comes out of `t_burn` — the
+    top miner's share does not move with N.
 
-    Bottom 50% (and ties at the rank-K boundary, by tiebreak) get no entry.
+    Protecting the survivor set (rather than a fixed top 50%) keeps the
+    protected set aligned with the elimination fraction automatically: an
+    agent is protected iff it advances to the next race, so there is no
+    second threshold to hand-sync when the elimination fraction changes.
     """
     ranked = rank_finishers(qualifiers)
-    k = len(ranked) // 2  # floor — protected-set size
 
-    # Tail = top-K finishers excluding `top_hotkey` if they overlap.
-    # When `top_hotkey` is None the filter never matches, so the tail is
-    # the full top-K. When `top_hotkey` is rank-1 of finishers, the tail
-    # is ranks 2..K (the historical shape).
-    tail_finishers = [f for f in ranked[:k] if f.miner_hotkey != top_hotkey]
+    # Tail = all survivors excluding `top_hotkey` if present. Every `ranked`
+    # entry already survived the race (eliminated/discarded dropped upstream)
+    # and advances to the next one, so all of them must keep Emission[uid] > 0
+    # to avoid deregistration.
+    tail_finishers = [f for f in ranked if f.miner_hotkey != top_hotkey]
     m = len(tail_finishers)
     tail_sum = m * (m + 1) // 2  # M + (M-1) + ... + 1
 

--- a/subnet/validator/weight_setter.py
+++ b/subnet/validator/weight_setter.py
@@ -1,6 +1,6 @@
 """Background thread for periodic weight updates.
 
-Builds a deterministic top-50% race-finisher weight vector via
+Builds a deterministic survivor-set race-finisher weight vector via
 `weight_distribution.build_metagraph_weight_vector` and submits it to the
 chain. Determinism across validators is load-bearing for Yuma consensus on
 subnet 15 (`kappa = 0.5`).
@@ -28,24 +28,25 @@ from .weight_distribution import (
 def _qualifiers_to_finishers(qualifiers) -> list[RankedFinisher]:
     """Reduce SDK `RaceQualifierPublic` records to ranked finishers.
 
-    A "finisher" is a qualifier with a non-null `race_score` — i.e.
-    the agent ran the race to completion and got scored. Qualifiers
-    with `race_score=null` (DNF, eliminated mid-race, never executed)
-    are intentionally dropped: they did not finish the race, so they
-    are not protected from deregistration by this mechanism. A
-    `race_score=0.0` finisher is still a finisher (they completed but
-    scored zero) and competes for a top-half slot like everyone else;
-    the linear taper naturally drops them out of the protected set
-    when other finishers outscore them.
+    A "finisher" here is the deregistration-protection *survivor* set:
+    a qualifier with a non-null `race_score` that was NOT eliminated or
+    discarded — i.e. the agent ran the race to completion, got scored,
+    and advances to the next race. Qualifiers with `race_score=null`
+    (DNF, never executed) are dropped: they did not finish. A
+    `race_score=0.0` survivor is still a finisher (completed but scored
+    zero) and takes the smallest taper slot.
 
     Also drops entries without a `miner_hotkey` defensively so a
     partial-data Backend response can't poison the ranking.
 
-    Discarded agents (admin- or auto-discarded, surfaced via
-    `is_discarded` on the SDK record) are dropped so they stop earning
-    emissions via the rank-1 fallback or the protected tail set.
-    Missing or `UNSET` `is_discarded` defaults to False for forward
-    compatibility with older Backend builds that pre-date the field.
+    Discarded agents (admin- or auto-discarded, `is_discarded`) AND
+    eliminated agents (bottom-cut at race end, `eliminated_at`) are
+    dropped so they stop earning emissions via the rank-1 fallback or
+    the protected tail. Tying the protected set to the survivor set
+    keeps it aligned with the elimination fraction automatically — there
+    is no second top-N threshold to hand-sync when that fraction moves.
+    Missing or `UNSET` fields default to not-excluded for forward
+    compatibility with older Backend builds that pre-date them.
     """
     finishers: list[RankedFinisher] = []
     for q in qualifiers:
@@ -64,6 +65,15 @@ def _qualifiers_to_finishers(qualifiers) -> list[RankedFinisher]:
                 f"hotkey={hotkey} agent_version_id={q.agent_version_id}"
             )
             continue
+        eliminated_at = getattr(q, "eliminated_at", None)
+        if eliminated_at is UNSET:
+            eliminated_at = None
+        if eliminated_at is not None:
+            logging.info(
+                "Dropping eliminated agent from race finishers: "
+                f"hotkey={hotkey} agent_version_id={q.agent_version_id}"
+            )
+            continue
         finishers.append(
             RankedFinisher(
                 miner_hotkey=str(hotkey),
@@ -75,7 +85,7 @@ def _qualifiers_to_finishers(qualifiers) -> list[RankedFinisher]:
 
 
 class WeightSetterThread:
-    """Periodically computes the top-50% weight vector and submits it on-chain.
+    """Periodically computes the survivor-set weight vector and submits it on-chain.
 
     Runs in a background thread, independent of the evaluation loop.
     """


### PR DESCRIPTION
## Description

The validator's deregistration-protection tail was defined as the **top 50% of last race's finishers**, independent of the elimination fraction (the bottom-cut applied at race end). With today's 65% elimination cut, finishers ranking between the survival line (top 35%) and the 50% tail line were **eliminated yet still received emission weight**. Two thresholds — the elimination fraction and the fixed 50% tail — had to be kept in sync by hand, and nothing enforced it.

This ties the protected tail to the **survivor set** instead: an agent is protected iff it survived the race (finished, not eliminated, not discarded) and advances to the next one. The protected set now tracks the elimination fraction automatically — no second threshold to maintain.

No backend or SDK change is required: the public `RaceQualifierPublic` record already exposes `eliminated_at`.

## Changes Made

- `_qualifiers_to_finishers`: drop `eliminated_at` qualifiers alongside the existing `is_discarded` drop, so `finishers` is the survivor set.
- `compute_hotkey_weights`: distribute the linear taper across **all survivors** rather than the top 50% (removed the `len(ranked) // 2` cut).
- Updated module/function docstrings from "top-50%" to the survivor-set contract.
- Migrated `test_weight_distribution.py` and `test_weight_setter.py` to the survivor-set contract; added a `TestQualifiersToFinishersEliminated` class covering the eliminated drop (including forward-compat for missing/UNSET fields). Fixed the `_race_detail` mock helper to set `eliminated_at` explicitly — a bare `MagicMock` returns a truthy child for unset attributes, which would make every qualifier look eliminated.

## Issue Link

- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing

Backtested the new logic against the most recent completed race (399 finishers: 258 eliminated, 141 survivors) on the live metagraph, and validated the harness by recomputing the **old** logic and confirming it reproduces the current on-chain vector exactly.

**Test Results:**

Harness validation — old logic recomputed from race finishers reproduces the live on-chain validator vector byte-for-byte:
```
on-chain:      top 85.52%   102 nonzero
old-recomputed top 85.52%   102 nonzero   ✓ match
```

Effect of the fix (`emission_baseline_burn_rate = 0.0`, current prod):
```
                 top miner   protected tail   -> eliminated agents
OLD (top-50%)     85.52%       101 entries          0.878%
NEW (survivor)    91.59%        76 entries          0.000%
```

Decomposition of the tail change (top gain = tail loss):
```
OLD tail = 14.484%  = survivors 13.606% + eliminated 0.878%
NEW tail =  8.412%  = survivors  8.412% + eliminated 0.000%
top gain = +6.072%  = survivors-reduced 5.194% + eliminated-removed 0.878%
```

Notes on the +6% top-miner increase (reviewed and accepted): with `t_burn = 0` there is no burn slot to absorb the freed tail budget, so the top miner (pinned at `U16_MAX`) takes a larger normalized share when the tail shrinks. ~5.2% of the shift is survivors receiving smaller taper values (the taper scales to tail size `M`, which drops from ~199 to ~140); 0.878% is the removed eliminated leak. Under any `t_burn > 0` the top stays pinned at exactly `t_top` and the freed share flows to burn instead — the "top share invariant under N" property still holds (covered by `test_top_miner_share_is_exactly_t_top_regardless_of_n`).

Sample NEW chain vector (u16 = submitted weights):
```
uid   u16     share    role
 25  65535   91.59%    top
204    140    0.20%    survivor
146    139    0.19%    survivor
...    (taper 140→1 across 76 registered survivors)
rest     0             not protected
```

### Automated Testing

**Test Command(s):**
```bash
python -m pytest subnet/tests/validator/test_weight_setter.py subnet/tests/validator/test_weight_distribution.py -q
# 78 passed
```

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:** Module and function docstrings updated to describe the survivor-set contract and why it decouples protection from the elimination fraction.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

Determinism (byte-identical vectors across validators) is preserved — the survivor set is deterministic shared state (`eliminated_at` is the same for every validator), so the property is as strong as before. This changes on-chain emission behavior, so it warrants careful review before it ships.
