### PR TITLE
fix(grader): normalize attribute matching + same-key token-subset

### DIFF
--- a/src/agent/rewards/orm.py
+++ b/src/agent/rewards/orm.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import os
+import re
+import unicodedata
 from collections import Counter
 
 SENTENCE_MODEL_NAME = "BAAI/bge-small-en-v1.5"
@@ -19,6 +21,88 @@ _shadow_model = None
 _shadow_unavailable = False
 
 _logger = logging.getLogger(__name__)
+
+# ── Attribute matching ──────────────────────────────────────────────
+# Reward attribute/sku values were historically matched to the product by
+# exact (key, value) tuple. That produced false-negatives when a valid
+# product encodes the same attribute under a different key spelling or with
+# extra descriptor tokens (e.g. reward "size":"48mm" vs product "size":
+# "1pcs 2#- 48mm"; reward "color family" vs product "color_family"). These
+# helpers add value + key string-normalization and a *same-key* token-subset
+# match. Everything stays exact-after-normalize — no fuzzy/embedding — so
+# distinct values (43≠42, blue≠black) never collide. Semantic cross-key
+# aliases (color↔color_family) are intentionally NOT handled here; they need
+# corpus-derived key co-occurrence stats and are a separate change.
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+
+def normalize_attr_value(value) -> str:
+    """NFKC + lowercase, strip bracket chars (full-width incl.) and collapse
+    whitespace. Values are still compared for *exact equality* after this."""
+    s = unicodedata.normalize("NFKC", str(value)).lower()
+    s = re.sub(r"[【】\[\]\(\)（）]", " ", s)
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def normalize_attr_key(key) -> str:
+    """Collapse a key to its comparison form: NFKC + lowercase, drop spaces/
+    underscores, and strip a single trailing plural 's'. Makes
+    `color family`==`color_family`==`colorfamily` and `flavors`==`flavor`."""
+    k = unicodedata.normalize("NFKC", str(key)).lower()
+    k = re.sub(r"[_\s]+", "", k)
+    if len(k) > 3 and k.endswith("s"):
+        k = k[:-1]
+    return k
+
+
+def _value_tokens(value) -> list:
+    return _WORD_RE.findall(normalize_attr_value(value))
+
+
+def _is_token_subsequence(sub: list, seq: list) -> bool:
+    """True if every token in `sub` appears in `seq` as a whole token, in
+    order. Whole-token boundaries mean `8gb` is NOT a subsequence of the
+    single token `128gb` — avoids numeric/unit collisions that raw substring
+    matching would create."""
+    if not sub:
+        return False
+    it = iter(seq)
+    return all(tok in it for tok in sub)
+
+
+def _build_attr_index(kv_pairs):
+    """From an iterable of (key, value) product tuples build:
+    - val_keys: normalized value -> set of normalized keys holding it
+    - key_tokens: normalized key -> list of token-lists of its values
+    """
+    val_keys = {}
+    key_tokens = {}
+    for k, v in kv_pairs:
+        nk = normalize_attr_key(k)
+        nv = normalize_attr_value(v)
+        val_keys.setdefault(nv, set()).add(nk)
+        key_tokens.setdefault(nk, []).append(_value_tokens(v))
+    return val_keys, key_tokens
+
+
+def _attr_constraint_hit(reward_key, reward_value, val_keys, key_tokens) -> bool:
+    """Does the product satisfy a single reward (key, value) constraint?
+
+    1. Same-key exact match after value + key normalization.
+    2. Same-key token-subset: the reward value's tokens are a whole-token
+       subsequence of one of the product's values under that (normalized) key.
+    """
+    nk = normalize_attr_key(reward_key)
+    nv = normalize_attr_value(reward_value)
+    if nk in val_keys.get(nv, ()):
+        return True
+    rt = _value_tokens(reward_value)
+    if rt:
+        for ptoks in key_tokens.get(nk, ()):
+            if _is_token_subsequence(rt, ptoks):
+                return True
+    return False
 
 
 def _get_sentence_model():
@@ -179,38 +263,38 @@ def rule_score_reward(product: dict, reward: dict, product_title_emb=None) -> tu
             if serv in product["service"]:
                 hit_count += 1
                 hit_counter["service"] += 1
-    # flat sku options
-    sku_flattens = [set()]
-    if "sku_options" in product and product["sku_options"]:
+    # sku options & attributes — normalized + same-key token-subset matching
+    # (see _attr_constraint_hit). Attributes are always available; sku options
+    # are variant-exclusive, so score against each option (plus an empty
+    # baseline for attribute-only products) and keep the best-matching variant.
+    attr_pairs = [
+        (k, v)
+        for k, vs in (product.get("attributes") or {}).items()
+        for v in vs
+    ]
+    product_options = [[]]
+    if product.get("sku_options"):
         for option in product["sku_options"].values():
-            flatten = set()
-            for k, v in option.items():
-                flatten.add((k, v))
-            sku_flattens.append(flatten)
-    # flat attributes
-    attr_flatten = set()
-    if "attributes" in product and product["attributes"]:
-        for k, vs in product["attributes"].items():
-            for v in vs:
-                attr_flatten.add((k, v))
-    # sku options & attributes
+            product_options.append(list(option.items()))
+
     max_total = 0
     max_hit = 0
-    for sku_flatten in sku_flattens:
+    for option_pairs in product_options:
+        val_keys, key_tokens = _build_attr_index(attr_pairs + option_pairs)
         cur_total = 0
         cur_hit = 0
         if "sku_options" in reward:
             for option in reward["sku_options"]:
                 for k, v in option.items():
                     cur_total += 1
-                    if (k, v) in sku_flatten or (k, v) in attr_flatten:
+                    if _attr_constraint_hit(k, v, val_keys, key_tokens):
                         cur_hit += 1
         if "attributes" in reward:
             for attr in reward["attributes"]:
                 for k, vs in attr.items():
                     for v in vs:
                         cur_total += 1
-                        if (k, v) in sku_flatten or (k, v) in attr_flatten:
+                        if _attr_constraint_hit(k, v, val_keys, key_tokens):
                             cur_hit += 1
         max_total = cur_total if cur_total > max_total else max_total
         max_hit = cur_hit if cur_hit > max_hit else max_hit

--- a/tests/test_attr_matching.py
+++ b/tests/test_attr_matching.py
@@ -1,0 +1,88 @@
+"""Tests for the normalized attribute matcher in rewards/orm.py.
+
+Covers value/key normalization + same-key token-subset matching, and the
+invariants that keep it exact-after-normalize (distinct enums never collide).
+Semantic cross-key aliases (color↔color_family) are intentionally NOT matched
+here — that needs corpus co-occurrence stats and is a separate change.
+"""
+
+from src.agent.rewards.orm import (
+    _attr_constraint_hit,
+    _build_attr_index,
+    _is_token_subsequence,
+    normalize_attr_key,
+    normalize_attr_value,
+)
+
+
+def _hit(reward_key, reward_value, product_pairs):
+    val_keys, key_tokens = _build_attr_index(product_pairs)
+    return _attr_constraint_hit(reward_key, reward_value, val_keys, key_tokens)
+
+
+# ── normalization ────────────────────────────────────────────────
+def test_value_normalization_brackets_and_case():
+    assert normalize_attr_value("7*9cm【10pcs】") == "7*9cm 10pcs"
+    assert normalize_attr_value("（1pcs）2#- 48mm") == "1pcs 2#- 48mm"
+    assert normalize_attr_value("MEDIUM") == "medium"
+
+
+def test_key_normalization_space_underscore_plural():
+    assert normalize_attr_key("color family") == normalize_attr_key("color_family")
+    assert normalize_attr_key("Color_Family") == normalize_attr_key("color family")
+    assert normalize_attr_key("flavors") == normalize_attr_key("flavor")
+    assert normalize_attr_key("power_consumption") == normalize_attr_key("power consumption")
+    # distinct keys stay distinct
+    assert normalize_attr_key("color") != normalize_attr_key("color_family")
+
+
+def test_token_subsequence_boundaries():
+    assert _is_token_subsequence(["48mm"], ["1pcs", "2", "48mm"])
+    assert _is_token_subsequence(["suede"], ["genuine", "suede", "leather"])
+    # whole-token: 8gb is not a subsequence of the single token 128gb
+    assert not _is_token_subsequence(["8gb"], ["128gb"])
+    assert not _is_token_subsequence(["48mm"], ["50mm"])
+    assert not _is_token_subsequence([], ["anything"])
+
+
+# ── positive matches (should recover) ────────────────────────────
+def test_key_string_normalization_match():
+    assert _hit("color family", "blue", [("color_family", "blue")])
+    assert _hit("flavors", "vanilla", [("flavor", "vanilla")])
+
+
+def test_value_bracket_normalization_match():
+    assert _hit("color_family", "7*9cm 10pcs", [("color_family", "7*9cm【10pcs】")])
+
+
+def test_token_subset_match_same_key():
+    assert _hit("size", "48mm", [("size", "1pcs 2#- 48mm")])
+    assert _hit("material", "suede", [("material", "genuine suede leather")])
+
+
+def test_exact_match_still_passes():
+    assert _hit("color", "red", [("color", "red")])
+
+
+# ── negative matches (must NOT collide) ──────────────────────────
+def test_distinct_enum_values_do_not_match():
+    assert not _hit("color", "blue", [("color", "black")])
+    assert not _hit("model", "2023", [("model", "2024")])
+    assert not _hit("color", "v1 red lining", [("color", "v1 black lining")])
+
+
+def test_numeric_unit_collision_avoided():
+    # 8gb must not match 128gb (token boundary), nor 43 match 42
+    assert not _hit("ram", "8gb", [("ram", "128gb")])
+    assert not _hit("size", "43", [("size", "42")])
+
+
+def test_product_underspecifies_does_not_match():
+    # reward wants "yellow-24inch"; product only says "yellow" -> reject
+    assert not _hit("color", "yellow-24inch", [("color", "yellow")])
+
+
+def test_semantic_cross_key_not_matched_here():
+    # color vs color_family is a semantic alias handled by the (separate)
+    # corpus co-occurrence layer, not by this string-normalization matcher.
+    assert not _hit("color", "blue", [("color_family", "blue")])


### PR DESCRIPTION
## Description

The per-problem grader (`src/agent/rewards/orm.py:rule_score_reward`) matched product attributes/sku to the reward by **exact `(key, value)` tuple** with no normalization, and binary success requires every constraint hit. This produced systematic **false-negatives**: a product that genuinely satisfies the query is scored incorrect when it encodes an attribute under a different key spelling or with extra descriptor tokens than the reference target.

Examples (both were valid products scored 0):
- reward `size: "48mm"` vs product `size: "1pcs 2#- 48mm"` (same size, extra packaging tokens)
- reward `color family: "..."` vs product `color_family: "..."` (space vs underscore)
- reward `color_family: "7*9cm 10pcs"` vs product `color_family: "7*9cm【10pcs】"` (full-width brackets)

Title (semantic embedding) and price (numeric range) matching are already robust — only attribute/sku matching is affected.

## Changes Made

- Replaced the exact `(key, value)` attribute/sku match with a layered matcher, all **exact-after-normalize** (no fuzzy/embedding):
  - **Value normalization** — NFKC + lowercase + strip brackets/full-width/whitespace; values still compared for exact equality, so distinct enums never collide (`43`≠`42`, `blue`≠`black`, `2023`≠`2024`).
  - **Key string-normalization** — space/underscore/case/plural equivalence (`color family`==`color_family`, `flavors`==`flavor`).
  - **Same-key token-subset** — a reward value matches if its tokens are a whole-token subsequence of one of the product's values under that (normalized) key (`48mm` in `1pcs 2#- 48mm`). Whole-token boundaries keep `8gb`≠`128gb`.
- Added `tests/test_attr_matching.py`.

Semantic cross-key aliases (e.g. `color`↔`color_family`, `model`↔`brand`) are **intentionally out of scope** here — they require corpus-derived key co-occurrence stats (with per-suite determinism handling) and are a planned follow-up.

## Issue Link

- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing

Backtested against a full historical race with the real scorer + live product catalog: re-scored sampled score-0 and score-1 product evals and compared to the recorded verdict.

**Test Results:**
```
score-0 sample (n=381): recovered (now pass) = 46  (12.1%)
score-1 sample (n=400): regressions (now fail) = 0  (0.0%)
```
Zero regressions is expected structurally — the matcher is strictly more permissive than exact match (normalization only adds matches), so no previously-passing eval can break. Recovered cases are token-subset (`48mm` in `1pcs 2#- 48mm`) and key-spelling variants.

### Automated Testing

**Test Command(s):**
```bash
python -m pytest tests/test_attr_matching.py -v
# 11 passed
```
Covers value/key normalization, token-subsequence boundaries, positive matches (key-variant, bracket, token-subset), and the negative invariants (`blue`≠`black`, `8gb`≠`128gb`, `2023`≠`2024`, `v1 red lining`≠`v1 black lining`, product-underspecifies `yellow` vs `yellow-24inch`, and that semantic cross-key is *not* matched here).

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:** Inline docstrings on the new matcher helpers explaining the exact-after-normalize invariant and the deliberate exclusion of semantic cross-key aliasing.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

This changes on-chain scoring, so it should roll out fleet-wide before it takes effect — mixed grader versions across validators would score the same agent differently. The matcher is fully deterministic (pure string ops), so validators on the same image produce identical results. Applies forward.
