### PR TITLE
validator: log OpenRouter response body on inference-token 401

### DIFF
--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -1231,6 +1231,10 @@ class Validator:
                 if resp.status_code == 200:
                     return True, ""
                 if resp.status_code == 401:
+                    try:
+                        body = (resp.text or "")[:500]
+                    except Exception:
+                        body = ""
                     if attempt < max_401_retries:
                         sleep_for = (
                             backoff_base
@@ -1240,10 +1244,16 @@ class Validator:
                         logging.warning(
                             f"Inference token 401 (attempt {attempt + 1}/"
                             f"{max_401_retries + 1}) — likely provider "
-                            f"key-propagation lag, retrying in {sleep_for:.1f}s"
+                            f"key-propagation lag, retrying in {sleep_for:.1f}s "
+                            f"body={body!r}"
                         )
                         time.sleep(sleep_for)
                         continue
+                    logging.warning(
+                        f"Inference token 401 on final attempt "
+                        f"({max_401_retries + 1}/{max_401_retries + 1}), "
+                        f"giving up — body={body!r}"
+                    )
                     return False, "Inference token invalid or expired (HTTP 401)"
                 if resp.status_code == 402:
                     detail = resp.json().get("detail", {})


### PR DESCRIPTION
## Description

We're debugging intermittent 401s from a freshly-minted OpenRouter scoped inference key (propagation-lag suspected, tracked via an open OpenRouter support thread). The token smoke-test in `_validate_inference_token` currently discards the HTTP response body on a 401, so we have no visibility into the provider's exact error message when trying to diagnose this. This PR logs the response body (truncated) on both 401 code paths so future occurrences are diagnosable, without changing the returned failure string (which may be user/run-facing and needs to stay stable).

## Changes Made

- On the retry-loop 401 branch, append the response body (truncated to 500 chars, `!r`-quoted) to the existing `logging.warning(...)` message.
- Add a new `logging.warning(...)` on the final-failure 401 path (after retries are exhausted) that logs the response body before returning — the returned `(False, "Inference token invalid or expired (HTTP 401)")` string is unchanged.
- Compute the body once per 401 response via `body = (resp.text or "")[:500]` wrapped in a `try/except` so a raising `.text` accessor can't break the smoke-test.

## Issue Link

- Related to: an internal investigation into intermittent OpenRouter 401s on newly-minted scoped tokens.
- Closes: N/A

## Testing

### Manual Testing

N/A — this is a pure logging addition; behavior (return values) is unchanged and covered by existing unit tests.

**Test Results:**

N/A

### Automated Testing

Ran the full existing test suite plus targeted `_validate_inference_token` tests locally (uv-managed venv built from `docker/validator/pyproject.toml`, matching CI).

**Test Command(s):**
```bash
ruff check
python -m pytest subnet/tests/validator/test_validate_inference_token.py -v
python -m pytest tests/ subnet/tests/ -q \
  --ignore=subnet/tests/validator/test_auto_update.py \
  --ignore=subnet/tests/validator/test_weight_setter.py \
  --ignore=tests/integration/test_sandbox_isolation.py
```

Results: `ruff check` — all checks passed. Targeted test file — 15/15 passed. Full suite — 460/460 passed.

## Documentation

- [ ] README updated
- [ ] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**

N/A — internal logging only, no user-facing behavior or docs affected.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

Log-only change: the returned failure string for a 401 (`"Inference token invalid or expired (HTTP 401)"`) is intentionally unchanged since it may be surfaced to users/runs. Body is truncated to 500 chars and repr-quoted to keep logs bounded and safe against huge/multiline provider error payloads.
