### PR TITLE
feat(grader): curated cross-key attribute aliases

### DIFF
--- a/src/agent/rewards/orm.py
+++ b/src/agent/rewards/orm.py
@@ -86,12 +86,44 @@ def _build_attr_index(kv_pairs):
     return val_keys, key_tokens
 
 
+# Curated cross-key aliases: pairs of attribute keys that are semantically the
+# same slot, so the SAME value found under either key satisfies the constraint
+# (e.g. a `color_family` requirement met by the product's `color`). Hand-vetted:
+# a dynamic corpus-co-occurrence approach over-matched because the catalog is
+# dirty — unrelated keys share junk values (e.g. `voltage`/`color`
+# both carry "4 modes 12v"), and no threshold separates real aliases from
+# coincidence. So this is an explicit allowlist. Pairs are stored normalized.
+_CROSS_KEY_ALIAS_PAIRS = [
+    ("color", "color_family"),
+    ("color_classification", "color_family"),
+    ("color_classification", "sort by color"),
+    ("color_family", "warna"),  # 'warna' == color (id/ms)
+    ("plate_size", "size"),
+    ("cord_length", "length"),
+    ("cookware_material", "material"),
+    ("finish_lipstick", "lips makeup finish"),
+    ("colored_gem_type", "main_stone"),
+    ("model", "compatibility_by_model"),
+    ("compatibility", "compatibility_by_model"),
+    ("concern_oral_care", "oral care benefits"),
+    ("flavor", "scent"),
+    ("leather_material", "material"),
+    ("leather_material", "material_filter"),
+]
+_CROSS_KEY_ALIASES = frozenset(
+    frozenset((normalize_attr_key(a), normalize_attr_key(b)))
+    for a, b in _CROSS_KEY_ALIAS_PAIRS
+)
+
+
 def _attr_constraint_hit(reward_key, reward_value, val_keys, key_tokens) -> bool:
     """Does the product satisfy a single reward (key, value) constraint?
 
     1. Same-key exact match after value + key normalization.
     2. Same-key token-subset: the reward value's tokens are a whole-token
        subsequence of one of the product's values under that (normalized) key.
+    3. Cross-key alias: the same value (exact, after normalization) sits under a
+       curated sibling key that is semantically the same slot (`_CROSS_KEY_ALIASES`).
     """
     nk = normalize_attr_key(reward_key)
     nv = normalize_attr_value(reward_value)
@@ -102,6 +134,9 @@ def _attr_constraint_hit(reward_key, reward_value, val_keys, key_tokens) -> bool
         for ptoks in key_tokens.get(nk, ()):
             if _is_token_subsequence(rt, ptoks):
                 return True
+    for pk in val_keys.get(nv, ()):
+        if pk != nk and frozenset((nk, pk)) in _CROSS_KEY_ALIASES:
+            return True
     return False
 
 

--- a/tests/test_attr_matching.py
+++ b/tests/test_attr_matching.py
@@ -1,9 +1,8 @@
 """Tests for the normalized attribute matcher in rewards/orm.py.
 
-Covers value/key normalization + same-key token-subset matching, and the
-invariants that keep it exact-after-normalize (distinct enums never collide).
-Semantic cross-key aliases (color↔color_family) are intentionally NOT matched
-here — that needs corpus co-occurrence stats and is a separate change.
+Covers value/key normalization + same-key token-subset matching, curated
+cross-key aliases, and the invariants that keep it exact-after-normalize
+(distinct enums never collide, non-allowlisted keys never cross-match).
 """
 
 from src.agent.rewards.orm import (
@@ -82,7 +81,28 @@ def test_product_underspecifies_does_not_match():
     assert not _hit("color", "yellow-24inch", [("color", "yellow")])
 
 
-def test_semantic_cross_key_not_matched_here():
-    # color vs color_family is a semantic alias handled by the (separate)
-    # corpus co-occurrence layer, not by this string-normalization matcher.
-    assert not _hit("color", "blue", [("color_family", "blue")])
+# ── curated cross-key aliases ────────────────────────────────────
+def test_cross_key_alias_positive():
+    # same value under a curated semantically-equivalent sibling key matches
+    assert _hit("color_family", "blue", [("color", "blue")])
+    assert _hit("color", "blue", [("color_family", "blue")])  # symmetric
+    # miner-reported cases
+    assert _hit("colored_gem_type", "no stones", [("main_stone", "no stones")])
+    assert _hit("model", "samsung galaxy a04e", [("compatibility_by_model", "samsung galaxy a04e")])
+    assert _hit("plate_size", "30x40cm", [("size", "30x40cm")])
+    assert _hit("concern_oral_care", "tooth decay", [("oral care benefits", "tooth decay")])
+
+
+def test_cross_key_alias_requires_exact_value():
+    # cross-key is exact-value only: a distinct value does not match even under
+    # an allowlisted sibling key
+    assert not _hit("color_family", "blue", [("color", "black")])
+    assert not _hit("model", "iphone 15", [("compatibility_by_model", "iphone 14")])
+
+
+def test_cross_key_non_allowlisted_pairs_never_match():
+    # unrelated keys sharing a value must NOT cross-match (the over-match the
+    # curated allowlist exists to prevent)
+    assert not _hit("voltage", "4 modes 12v", [("color", "4 modes 12v")])
+    assert not _hit("color_family", "washi tape", [("size", "washi tape")])
+    assert not _hit("size", "large", [("style", "large")])


### PR DESCRIPTION
## Description

Adds a curated cross-key alias layer to the attribute matcher so a product that encodes a required attribute value under a *semantically-equivalent sibling key* satisfies the constraint. Example: a query requiring `color_family = "blue"` is satisfied by a product listing `color = "blue"`; a `model = "samsung galaxy a04e"` requirement is satisfied by `compatibility_by_model = "samsung galaxy a04e"`.

These are real false-negatives — the product genuinely meets the requirement, but the reward and the product happen to use different (equivalent) key names for the same slot.

The list is an **explicit hand-vetted allowlist**, not derived dynamically. A corpus co-occurrence approach was prototyped and rejected: the catalog is dirty (sellers dump compound junk like `"4 modes 12v"` into unrelated fields such as both `voltage` and `color`), so no automatic distinctiveness/support threshold separates real aliases from coincidence. The allowlist is also deterministic by construction — identical across all validators with no per-suite artifact to ship.

## Changes Made

- `src/agent/rewards/orm.py`
  - Added `_CROSS_KEY_ALIAS_PAIRS` (15 hand-vetted pairs) + normalized `_CROSS_KEY_ALIASES` frozenset.
  - Extended `_attr_constraint_hit` with a third match layer (after same-key exact + same-key token-subset): exact value found under a curated sibling key.
- `tests/test_attr_matching.py`
  - Added positive (allowlisted pairs match, incl. real reported cases), exact-value-only, and negative (non-allowlisted pairs like `voltage`/`color` never cross-match) tests. Updated the module docstring.

## Issue Link

- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing
Verified the reported false-negative products now reach attribute-full under the new matcher (necklace `colored_gem_type`↔`main_stone`, phone battery `model`↔`compatibility_by_model`), while distinct-value and non-allowlisted-key cases still correctly fail.

**Test Results:**
Offline backtest over ~213k historical evals: the curated list recovers ~126 distinct (problem, product) false-negatives (~8k eval-level) with the deliberately-excluded junk key-pairs (`color_family`↔`size`, `voltage`↔`color`, …) producing zero matches. `color`↔`color_family` alone accounts for ~60% of the recovery.

### Automated Testing
Attribute-matcher unit tests (existing + new cross-key cases).

**Test Command(s):**
```bash
python -m pytest tests/test_attr_matching.py -q
python -m ruff check src/agent/rewards/orm.py tests/test_attr_matching.py
```

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
Inline rationale on the allowlist explaining why it is explicit rather than corpus-derived.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

This changes on-chain scoring (grader). **Not for immediate merge/deploy** — it should land fleet-wide, deterministically, and bundle into a grader release *after* the current attribute-normalization change has baked a race or two (no two grader changes in the same race window). Value-level matches within legit key-pairs are exact-after-normalize; the allowlist restricts the key dimension so unrelated-key over-matches cannot occur.
