### PR TITLE
perf(search-server): columnar filter sidecar to cut find_product decode cost

### DIFF
--- a/docker/search-server/Dockerfile.base
+++ b/docker/search-server/Dockerfile.base
@@ -14,3 +14,11 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Pre-built indexes (~3GB) — this is why the base image exists.
 # Rebuild with: ./scripts/publish-search-server-base.sh
 COPY indexes /app/indexes
+
+# Columnar filter sidecar (~90MB), built from the same documents.jsonl as the
+# index (see src/search_engine/build_sidecar.py). The publish-base script must
+# run `python -m src.search_engine.build_sidecar <documents.jsonl> sidecar`
+# alongside the index build so the two stay in lockstep. If this directory is
+# absent the server transparently falls back to the decode path, so the COPY is
+# optional for correctness — only omit it to disable the optimization.
+COPY sidecar /app/sidecar

--- a/docker/search-server/Dockerfile.base
+++ b/docker/search-server/Dockerfile.base
@@ -15,10 +15,11 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Rebuild with: ./scripts/publish-search-server-base.sh
 COPY indexes /app/indexes
 
-# Columnar filter sidecar (~90MB), built from the same documents.jsonl as the
-# index (see src/search_engine/build_sidecar.py). The publish-base script must
+# Columnar filter sidecar (~65MB), built from the same documents.jsonl as the
+# index (see src/search_engine/build_sidecar.py). The publish-base script MUST
 # run `python -m src.search_engine.build_sidecar <documents.jsonl> sidecar`
-# alongside the index build so the two stay in lockstep. If this directory is
-# absent the server transparently falls back to the decode path, so the COPY is
-# optional for correctness — only omit it to disable the optimization.
+# before this build — a missing source directory fails `COPY`. The runtime
+# fallback is separate: at container start the server drops to the decode path
+# if the directory is absent or its doc count does not match the index, so a
+# stale or unset SIDECAR_DIR never serves wrong results.
 COPY sidecar /app/sidecar

--- a/docker/search-server/requirements.txt
+++ b/docker/search-server/requirements.txt
@@ -3,3 +3,4 @@ Flask==3.1.3
 ujson==5.13.0
 waitress==3.0.2
 gunicorn==23.0.0
+numpy==1.26.4

--- a/src/search_engine/build_sidecar.py
+++ b/src/search_engine/build_sidecar.py
@@ -2,13 +2,15 @@
 
 Reads the same `documents.jsonl` that feeds the Lucene index builder and emits
 compact columnar arrays (keyed by product_id, sorted for binary search) plus a
-service vocabulary. See sidecar.py for how the server consumes them.
+`meta.json` holding the service vocabulary and the document count. The count is
+checked against the live index at load time so a sidecar built from a different
+corpus is ignored rather than silently serving stale filter fields.
 
     python -m src.search_engine.build_sidecar <documents.jsonl> <out_dir>
 
 Runs as a post-step of the base-image build, alongside the Lucene index build,
-so the two stay in lockstep. Prices are stored as float64 so filter comparisons
-are bit-identical to the decode path (which reads the same JSON float).
+from the same documents.jsonl so the two stay in lockstep. Prices are stored as
+float64 so filter comparisons are bit-identical to the decode path.
 """
 import json
 import os
@@ -16,13 +18,15 @@ import sys
 
 import numpy as np
 
+from src.search_engine.sidecar import NULL_SHOP
+
 # Bit width of the service bitmask column (int64); build fails loudly if the
 # corpus ever exceeds this so we never silently drop a service token.
 _MAX_SERVICES = 63
 
 
 def build(documents_path, out_dir):
-    pids, prices, shops, solds, svc_sets = [], [], [], [], []
+    pids, prices, shops, svc_sets = [], [], [], []
     vocab = {}
     with open(documents_path) as f:
         for line in f:
@@ -33,8 +37,7 @@ def build(documents_path, out_dir):
             p = doc.get("product", doc)
             pids.append(int(p["product_id"]))
             prices.append(float(p["price"]) if p.get("price") is not None else float("nan"))
-            shops.append(int(p["shop_id"]) if p.get("shop_id") is not None else -1)
-            solds.append(int(p.get("sold_count") or 0))
+            shops.append(int(p["shop_id"]) if p.get("shop_id") is not None else NULL_SHOP)
             svs = p.get("service") or []
             for s in svs:
                 if s not in vocab:
@@ -48,7 +51,6 @@ def build(documents_path, out_dir):
     pid = np.asarray(pids, dtype=np.int64)
     price = np.asarray(prices, dtype=np.float64)
     shop = np.asarray(shops, dtype=np.int64)
-    sold = np.asarray(solds, dtype=np.int64)
     svc = np.zeros(n, dtype=np.int64)
     for idx, svs in enumerate(svc_sets):
         m = 0
@@ -63,10 +65,9 @@ def build(documents_path, out_dir):
     np.save(os.path.join(out_dir, "pid.npy"), pid[order])
     np.save(os.path.join(out_dir, "price.npy"), price[order])
     np.save(os.path.join(out_dir, "shop.npy"), shop[order])
-    np.save(os.path.join(out_dir, "sold.npy"), sold[order])
     np.save(os.path.join(out_dir, "svc.npy"), svc[order])
-    with open(os.path.join(out_dir, "vocab.json"), "w") as fh:
-        json.dump(vocab, fh)
+    with open(os.path.join(out_dir, "meta.json"), "w") as fh:
+        json.dump({"num_docs": n, "vocab": vocab}, fh)
     print(f"Sidecar built: {n} products, {len(vocab)} services -> {out_dir}", file=sys.stderr)
 
 

--- a/src/search_engine/build_sidecar.py
+++ b/src/search_engine/build_sidecar.py
@@ -1,0 +1,77 @@
+"""Build the find_product filter sidecar from the index source JSONL.
+
+Reads the same `documents.jsonl` that feeds the Lucene index builder and emits
+compact columnar arrays (keyed by product_id, sorted for binary search) plus a
+service vocabulary. See sidecar.py for how the server consumes them.
+
+    python -m src.search_engine.build_sidecar <documents.jsonl> <out_dir>
+
+Runs as a post-step of the base-image build, alongside the Lucene index build,
+so the two stay in lockstep. Prices are stored as float64 so filter comparisons
+are bit-identical to the decode path (which reads the same JSON float).
+"""
+import json
+import os
+import sys
+
+import numpy as np
+
+# Bit width of the service bitmask column (int64); build fails loudly if the
+# corpus ever exceeds this so we never silently drop a service token.
+_MAX_SERVICES = 63
+
+
+def build(documents_path, out_dir):
+    pids, prices, shops, solds, svc_sets = [], [], [], [], []
+    vocab = {}
+    with open(documents_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            doc = json.loads(line)
+            p = doc.get("product", doc)
+            pids.append(int(p["product_id"]))
+            prices.append(float(p["price"]) if p.get("price") is not None else float("nan"))
+            shops.append(int(p["shop_id"]) if p.get("shop_id") is not None else -1)
+            solds.append(int(p.get("sold_count") or 0))
+            svs = p.get("service") or []
+            for s in svs:
+                if s not in vocab:
+                    vocab[s] = len(vocab)
+            svc_sets.append(svs)
+
+    if len(vocab) > _MAX_SERVICES:
+        raise ValueError(f"service vocab {len(vocab)} exceeds {_MAX_SERVICES}-bit mask")
+
+    n = len(pids)
+    pid = np.asarray(pids, dtype=np.int64)
+    price = np.asarray(prices, dtype=np.float64)
+    shop = np.asarray(shops, dtype=np.int64)
+    sold = np.asarray(solds, dtype=np.int64)
+    svc = np.zeros(n, dtype=np.int64)
+    for idx, svs in enumerate(svc_sets):
+        m = 0
+        for s in svs:
+            m |= 1 << vocab[s]
+        svc[idx] = m
+
+    # sort by product_id so the server can binary-search lookups
+    order = np.argsort(pid, kind="stable")
+
+    os.makedirs(out_dir, exist_ok=True)
+    np.save(os.path.join(out_dir, "pid.npy"), pid[order])
+    np.save(os.path.join(out_dir, "price.npy"), price[order])
+    np.save(os.path.join(out_dir, "shop.npy"), shop[order])
+    np.save(os.path.join(out_dir, "sold.npy"), sold[order])
+    np.save(os.path.join(out_dir, "svc.npy"), svc[order])
+    with open(os.path.join(out_dir, "vocab.json"), "w") as fh:
+        json.dump(vocab, fh)
+    print(f"Sidecar built: {n} products, {len(vocab)} services -> {out_dir}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("usage: python -m src.search_engine.build_sidecar <documents.jsonl> <out_dir>", file=sys.stderr)
+        sys.exit(2)
+    build(sys.argv[1], sys.argv[2])

--- a/src/search_engine/product_filters.py
+++ b/src/search_engine/product_filters.py
@@ -1,0 +1,42 @@
+"""Post-filter predicates for find_product, shared by the server (decode path),
+the sidecar fast path's parity, and the tests.
+
+Single source of truth: `server.py` imports these, `sidecar.rejects` mirrors
+them against columnar values, and the test suite uses them as the oracle -- so
+there is no third copy to drift out of parity.
+"""
+
+
+def is_filter_by_price(product, price):
+    low, high = price
+    if low is not None and product["price"] < low:
+        return True
+    if high is not None and product["price"] > high:
+        return True
+    return False
+
+
+def is_filter_by_service(product, service):
+    for serv in service:
+        if serv not in product.get("service", []):
+            return True
+    return False
+
+
+def is_filter_by_shop_id(product, shop_id):
+    if shop_id and shop_id != product.get("shop_id"):
+        return True
+    return False
+
+
+def shop_id_is_canonical(shop_id):
+    """True when a query shop_id can be compared as an integer with identical
+    results to the original string comparison.
+
+    The sidecar stores shop_id as an int, so it may only take the fast path for
+    canonical non-negative decimal strings. Non-canonical numerics -- leading
+    zeros ("02003"), signs ("+2003", "-1"), surrounding space (" 2003 ") -- would
+    flip the decision or collide with the null-shop sentinel, so they fall back
+    to the string-comparison decode path.
+    """
+    return bool(shop_id) and shop_id.isdigit() and shop_id == str(int(shop_id))

--- a/src/search_engine/server.py
+++ b/src/search_engine/server.py
@@ -8,14 +8,21 @@ from flask import Flask, request, jsonify
 from waitress import serve
 
 from src.search_engine import sidecar as _sidecar
+from src.search_engine.product_filters import (
+    is_filter_by_price,
+    is_filter_by_service,
+    is_filter_by_shop_id,
+    shop_id_is_canonical,
+)
 
 searcher = LuceneSearcher("indexes")
 print("Load indexes done.", file=sys.stderr)
 
 # Optional columnar filter sidecar (see sidecar.py). When present it replaces
 # the per-candidate json.loads in the filter scan with a memmap lookup; when
-# absent (default) the search path is byte-for-byte the original decode path.
-_SIDECAR = _sidecar.load(os.environ.get("SIDECAR_DIR", "sidecar"))
+# absent (or built from a different corpus) the search path is byte-for-byte
+# the original decode path.
+_SIDECAR = _sidecar.load(os.environ.get("SIDECAR_DIR", "sidecar"), expected_num_docs=searcher.num_docs)
 
 app = Flask(__name__)
 
@@ -125,28 +132,6 @@ def process_service(service):
     return results
 
 
-def is_filter_by_price(product, price):
-    low, high = price
-    if low is not None and product["price"] < low:
-        return True
-    if high is not None and product["price"] > high:
-        return True
-    return False
-
-
-def is_filter_by_service(product, service):
-    for serv in service:
-        if serv not in product.get("service", []):
-            return True
-    return False
-
-
-def is_filter_by_shop_id(product, shop_id):
-    if shop_id and shop_id != product.get("shop_id"):
-        return True
-    return False
-
-
 def search(q, page, shop_id=None, price=None, sort=None, service=None):
     page = process_page(page)
     price = process_price(price)
@@ -164,19 +149,30 @@ def search(q, page, shop_id=None, price=None, sort=None, service=None):
     if not q:
         return products
 
-    # Sidecar fast path: when the sidecar is loaded (and the shop filter, if
-    # any, is numeric) we decide shop/price/service from the memmap columns and
-    # only decode the <=TARGET_HITS survivors. Yields identical results to the
-    # decode path (same fields, same order). A non-numeric shop_id disables it
-    # for that call so exact string-equality semantics are preserved.
+    # Sidecar fast path: when the sidecar is loaded we decide shop/price/service
+    # from the memmap columns and only decode the <=TARGET_HITS survivors,
+    # yielding identical results to the decode path (same fields, same order).
+    # A shop_id that cannot be compared as an int with identical results (see
+    # shop_id_is_canonical) disables the fast path for that call.
     use_sidecar = _SIDECAR is not None
     shop_id_int = None
     if shop_id:
-        try:
+        if shop_id_is_canonical(shop_id):
             shop_id_int = int(shop_id)
-        except (TypeError, ValueError):
+        else:
             use_sidecar = False
     reqmask = _SIDECAR.reqmask(service) if use_sidecar else 0
+
+    def _decode_and_filter(hit, out):
+        # Original path: decode the full product and apply the predicates.
+        product = json.loads(searcher.doc(hit.docid).raw())["product"]
+        if is_filter_by_shop_id(product, shop_id):
+            return
+        if is_filter_by_price(product, price):
+            return
+        if is_filter_by_service(product, service):
+            return
+        out.append(product)
 
     def _collect(k):
         # Score the top-k BM25 candidates, apply post-filters, stop as soon
@@ -189,23 +185,22 @@ def search(q, page, shop_id=None, price=None, sort=None, service=None):
             if use_sidecar:
                 i = _SIDECAR.lookup(hit.docid)
                 if i is not None:
-                    if _SIDECAR.rejects(i, shop_id_int, price, reqmask):
+                    verdict = _SIDECAR.rejects(i, shop_id_int, price, reqmask)
+                    if verdict is True:
                         continue
-                    # Survivor: decode the full product for sort + projection.
-                    out.append(json.loads(searcher.doc(hit.docid).raw())["product"])
+                    if verdict is False:
+                        # Survivor: decode the full product for sort + projection.
+                        out.append(json.loads(searcher.doc(hit.docid).raw())["product"])
+                    else:
+                        # Undecided (e.g. null price under a price filter):
+                        # defer to the decode path so behavior is identical.
+                        _decode_and_filter(hit, out)
                     if len(out) >= TARGET_HITS:
                         break
                     continue
                 # Not in sidecar (should not happen for indexed docs): fall
                 # through to the decode path for this candidate.
-            product = json.loads(searcher.doc(hit.docid).raw())["product"]
-            if is_filter_by_shop_id(product, shop_id):
-                continue
-            if is_filter_by_price(product, price):
-                continue
-            if is_filter_by_service(product, service):
-                continue
-            out.append(product)
+            _decode_and_filter(hit, out)
             if len(out) >= TARGET_HITS:
                 break
         return out, len(hits)

--- a/src/search_engine/server.py
+++ b/src/search_engine/server.py
@@ -7,8 +7,15 @@ from pyserini.search.lucene import LuceneSearcher
 from flask import Flask, request, jsonify
 from waitress import serve
 
+from src.search_engine import sidecar as _sidecar
+
 searcher = LuceneSearcher("indexes")
 print("Load indexes done.", file=sys.stderr)
+
+# Optional columnar filter sidecar (see sidecar.py). When present it replaces
+# the per-candidate json.loads in the filter scan with a memmap lookup; when
+# absent (default) the search path is byte-for-byte the original decode path.
+_SIDECAR = _sidecar.load(os.environ.get("SIDECAR_DIR", "sidecar"))
 
 app = Flask(__name__)
 
@@ -157,6 +164,20 @@ def search(q, page, shop_id=None, price=None, sort=None, service=None):
     if not q:
         return products
 
+    # Sidecar fast path: when the sidecar is loaded (and the shop filter, if
+    # any, is numeric) we decide shop/price/service from the memmap columns and
+    # only decode the <=TARGET_HITS survivors. Yields identical results to the
+    # decode path (same fields, same order). A non-numeric shop_id disables it
+    # for that call so exact string-equality semantics are preserved.
+    use_sidecar = _SIDECAR is not None
+    shop_id_int = None
+    if shop_id:
+        try:
+            shop_id_int = int(shop_id)
+        except (TypeError, ValueError):
+            use_sidecar = False
+    reqmask = _SIDECAR.reqmask(service) if use_sidecar else 0
+
     def _collect(k):
         # Score the top-k BM25 candidates, apply post-filters, stop as soon
         # as we have enough surviving products for the paginated response.
@@ -165,6 +186,18 @@ def search(q, page, shop_id=None, price=None, sort=None, service=None):
         out = []
         hits = searcher.search(q=q, k=k, remove_dups=True)
         for hit in hits:
+            if use_sidecar:
+                i = _SIDECAR.lookup(hit.docid)
+                if i is not None:
+                    if _SIDECAR.rejects(i, shop_id_int, price, reqmask):
+                        continue
+                    # Survivor: decode the full product for sort + projection.
+                    out.append(json.loads(searcher.doc(hit.docid).raw())["product"])
+                    if len(out) >= TARGET_HITS:
+                        break
+                    continue
+                # Not in sidecar (should not happen for indexed docs): fall
+                # through to the decode path for this candidate.
             product = json.loads(searcher.doc(hit.docid).raw())["product"]
             if is_filter_by_shop_id(product, shop_id):
                 continue

--- a/src/search_engine/sidecar.py
+++ b/src/search_engine/sidecar.py
@@ -1,0 +1,104 @@
+"""Columnar sidecar for fast find_product filtering.
+
+The search hot path scores up to CAPACITY_FULL BM25 candidates and, for each,
+must read four fields -- shop_id, price, service, sold_count -- to apply the
+post-filters. Doing that by decoding every candidate's full stored JSON
+(`json.loads(searcher.doc(id).raw())`) is the dominant per-request cost once a
+selective filter forces a deep scan.
+
+This sidecar precomputes those four fields into compact, memory-mapped columnar
+arrays keyed by product_id. Filtering then reads them with an O(log n) binary
+search instead of a full-document decode; only the <=50 survivors that make the
+paginated response are decoded. The arrays are `numpy.memmap`, so a single
+physical copy is shared across all gunicorn workers via the OS page cache
+(~90 MB total for the full corpus, independent of worker count).
+
+Built by `build_sidecar.py`; loaded here at server start. If the directory is
+absent or fails to load, `load()` returns None and the server falls back to the
+original decode-every-candidate path -- so shipping this code is a no-op until a
+base image that bundles the sidecar is deployed.
+"""
+import json
+import os
+import sys
+
+_SERVICE_KEYS = ("pid", "price", "shop", "sold", "svc", "vocab")
+_IMPOSSIBLE_BIT = 1 << 63  # requested service token absent from corpus -> matches nothing
+
+
+class Sidecar:
+    def __init__(self, pid, price, shop, sold, svc, vocab):
+        self._pid = pid
+        self._price = price
+        self._shop = shop
+        self._sold = sold
+        self._svc = svc
+        self._vocab = vocab
+
+    def lookup(self, docid):
+        """Return the row index for a collection docid, or None if absent."""
+        import numpy as np
+
+        try:
+            key = int(docid)
+        except (TypeError, ValueError):
+            return None
+        i = int(np.searchsorted(self._pid, key))
+        if i >= len(self._pid) or self._pid[i] != key:
+            return None
+        return i
+
+    def reqmask(self, service_list):
+        """Bitmask of required services; unknown tokens get an impossible bit."""
+        m = 0
+        for s in service_list or ():
+            bit = self._vocab.get(s)
+            m |= (1 << bit) if bit is not None else _IMPOSSIBLE_BIT
+        return m
+
+    def rejects(self, i, shop_id_int, price, reqmask):
+        """Mirror of the is_filter_by_* predicates, read from the columns.
+
+        Returns True when the row should be dropped. `price` is the
+        (low, high) tuple; `shop_id_int` is the parsed query shop id or None.
+        """
+        if shop_id_int is not None and self._shop[i] != shop_id_int:
+            return True
+        low, high = price
+        pr = self._price[i]
+        if low is not None and pr < low:
+            return True
+        if high is not None and pr > high:
+            return True
+        if reqmask and (int(self._svc[i]) & reqmask) != reqmask:
+            return True
+        return False
+
+
+def load(sidecar_dir):
+    """Load the sidecar from a directory, or return None if unavailable.
+
+    Never raises: any missing file, numpy import failure, or malformed array
+    yields None so the caller transparently falls back to the decode path.
+    """
+    try:
+        import numpy as np
+
+        if not sidecar_dir or not os.path.isdir(sidecar_dir):
+            return None
+        arrs = {}
+        for name in ("pid", "price", "shop", "sold", "svc"):
+            path = os.path.join(sidecar_dir, name + ".npy")
+            if not os.path.isfile(path):
+                return None
+            arrs[name] = np.load(path, mmap_mode="r")
+        with open(os.path.join(sidecar_dir, "vocab.json")) as f:
+            vocab = json.load(f)
+        n = len(arrs["pid"])
+        if any(len(arrs[k]) != n for k in ("price", "shop", "sold", "svc")):
+            return None
+        print(f"Sidecar loaded: {n} products from {sidecar_dir}", file=sys.stderr)
+        return Sidecar(arrs["pid"], arrs["price"], arrs["shop"], arrs["sold"], arrs["svc"], vocab)
+    except Exception as e:  # noqa: BLE001 - fallback must never break startup
+        print(f"Sidecar unavailable ({e!r}); using decode path", file=sys.stderr)
+        return None

--- a/src/search_engine/sidecar.py
+++ b/src/search_engine/sidecar.py
@@ -1,44 +1,44 @@
 """Columnar sidecar for fast find_product filtering.
 
 The search hot path scores up to CAPACITY_FULL BM25 candidates and, for each,
-must read four fields -- shop_id, price, service, sold_count -- to apply the
-post-filters. Doing that by decoding every candidate's full stored JSON
+must read three fields -- shop_id, price, service -- to apply the post-filters.
+Doing that by decoding every candidate's full stored JSON
 (`json.loads(searcher.doc(id).raw())`) is the dominant per-request cost once a
 selective filter forces a deep scan.
 
-This sidecar precomputes those four fields into compact, memory-mapped columnar
+This sidecar precomputes those fields into compact, memory-mapped columnar
 arrays keyed by product_id. Filtering then reads them with an O(log n) binary
 search instead of a full-document decode; only the <=50 survivors that make the
 paginated response are decoded. The arrays are `numpy.memmap`, so a single
 physical copy is shared across all gunicorn workers via the OS page cache
-(~90 MB total for the full corpus, independent of worker count).
+(~65 MB total for the full corpus, independent of worker count).
 
 Built by `build_sidecar.py`; loaded here at server start. If the directory is
-absent or fails to load, `load()` returns None and the server falls back to the
-original decode-every-candidate path -- so shipping this code is a no-op until a
-base image that bundles the sidecar is deployed.
+absent, fails to load, or its stamped doc count does not match the live index,
+`load()` returns None and the server falls back to the original
+decode-every-candidate path -- so shipping this code is a no-op until a base
+image that bundles a matching sidecar is deployed.
 """
 import json
 import os
 import sys
 
-_SERVICE_KEYS = ("pid", "price", "shop", "sold", "svc", "vocab")
-_IMPOSSIBLE_BIT = 1 << 63  # requested service token absent from corpus -> matches nothing
+import numpy as np
+
+NULL_SHOP = -1  # sentinel stored for products with no shop_id
+_UNDECIDED = object()  # sentinel: sidecar cannot decide this row, use decode path
 
 
 class Sidecar:
-    def __init__(self, pid, price, shop, sold, svc, vocab):
+    def __init__(self, pid, price, shop, svc, vocab):
         self._pid = pid
         self._price = price
         self._shop = shop
-        self._sold = sold
         self._svc = svc
         self._vocab = vocab
 
     def lookup(self, docid):
         """Return the row index for a collection docid, or None if absent."""
-        import numpy as np
-
         try:
             key = int(docid)
         except (TypeError, ValueError):
@@ -49,56 +49,75 @@ class Sidecar:
         return i
 
     def reqmask(self, service_list):
-        """Bitmask of required services; unknown tokens get an impossible bit."""
+        """Bitmask of required services; unknown tokens get a bit no product
+        has, so a query for an absent service matches nothing (as the original
+        `serv not in product.service` check would)."""
         m = 0
         for s in service_list or ():
             bit = self._vocab.get(s)
-            m |= (1 << bit) if bit is not None else _IMPOSSIBLE_BIT
+            m |= (1 << bit) if bit is not None else (1 << 63)
         return m
 
     def rejects(self, i, shop_id_int, price, reqmask):
-        """Mirror of the is_filter_by_* predicates, read from the columns.
+        """Mirror of the is_filter_by_* predicates over the columns.
 
-        Returns True when the row should be dropped. `price` is the
-        (low, high) tuple; `shop_id_int` is the parsed query shop id or None.
+        Returns True to drop the row, False to keep it, or the sentinel
+        `Sidecar.undecided` when it cannot match the decode path exactly -- a
+        null (NaN) price under an active price filter, where the original code
+        raises on `None < low`. The caller must decode-and-filter those rows so
+        behavior stays identical.
         """
         if shop_id_int is not None and self._shop[i] != shop_id_int:
             return True
         low, high = price
-        pr = self._price[i]
-        if low is not None and pr < low:
-            return True
-        if high is not None and pr > high:
-            return True
+        if low is not None or high is not None:
+            pr = self._price[i]
+            if np.isnan(pr):
+                return _UNDECIDED
+            if low is not None and pr < low:
+                return True
+            if high is not None and pr > high:
+                return True
         if reqmask and (int(self._svc[i]) & reqmask) != reqmask:
             return True
         return False
 
+    undecided = _UNDECIDED
 
-def load(sidecar_dir):
+
+def load(sidecar_dir, expected_num_docs=None):
     """Load the sidecar from a directory, or return None if unavailable.
 
-    Never raises: any missing file, numpy import failure, or malformed array
-    yields None so the caller transparently falls back to the decode path.
+    Never raises: a missing file, malformed array, or a stamped doc count that
+    does not match `expected_num_docs` (the live index size) all yield None so
+    the caller transparently falls back to the decode path.
     """
     try:
-        import numpy as np
-
         if not sidecar_dir or not os.path.isdir(sidecar_dir):
             return None
         arrs = {}
-        for name in ("pid", "price", "shop", "sold", "svc"):
+        for name in ("pid", "price", "shop", "svc"):
             path = os.path.join(sidecar_dir, name + ".npy")
             if not os.path.isfile(path):
                 return None
             arrs[name] = np.load(path, mmap_mode="r")
-        with open(os.path.join(sidecar_dir, "vocab.json")) as f:
-            vocab = json.load(f)
+        with open(os.path.join(sidecar_dir, "meta.json")) as f:
+            meta = json.load(f)
+        vocab = meta["vocab"]
         n = len(arrs["pid"])
-        if any(len(arrs[k]) != n for k in ("price", "shop", "sold", "svc")):
+        if any(len(arrs[k]) != n for k in ("price", "shop", "svc")):
+            return None
+        if meta.get("num_docs") != n:
+            print("Sidecar meta doc count mismatch; using decode path", file=sys.stderr)
+            return None
+        if expected_num_docs is not None and n != expected_num_docs:
+            print(
+                f"Sidecar/index mismatch ({n} vs {expected_num_docs}); using decode path",
+                file=sys.stderr,
+            )
             return None
         print(f"Sidecar loaded: {n} products from {sidecar_dir}", file=sys.stderr)
-        return Sidecar(arrs["pid"], arrs["price"], arrs["shop"], arrs["sold"], arrs["svc"], vocab)
+        return Sidecar(arrs["pid"], arrs["price"], arrs["shop"], arrs["svc"], vocab)
     except Exception as e:  # noqa: BLE001 - fallback must never break startup
         print(f"Sidecar unavailable ({e!r}); using decode path", file=sys.stderr)
         return None

--- a/tests/test_sidecar.py
+++ b/tests/test_sidecar.py
@@ -1,0 +1,100 @@
+"""Parity tests for the find_product filter sidecar.
+
+Verifies that filtering via the columnar sidecar produces exactly the same
+accept/reject decision as the original per-product predicate logic, across a
+grid of shop_id / price / service filters. Does not import server.py (which
+loads a Lucene index at import); it re-states the reference predicates locally.
+"""
+import json
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from src.search_engine import build_sidecar, sidecar as sidecar_mod  # noqa: E402
+
+
+# --- reference predicates: copied verbatim from server.is_filter_by_* ---
+def ref_reject(product, shop_id, price, service):
+    if shop_id and shop_id != product.get("shop_id"):
+        return True
+    low, high = price
+    if low is not None and product["price"] < low:
+        return True
+    if high is not None and product["price"] > high:
+        return True
+    for serv in service:
+        if serv not in product.get("service", []):
+            return True
+    return False
+
+
+SERVICES = ["official", "freeShipping", "COD", "flashsale"]
+
+
+def make_products(n=40):
+    products = []
+    for i in range(n):
+        products.append(
+            {
+                "product_id": str(100000 + i),
+                "shop_id": str(2000 + (i % 5)),
+                "price": float(10 * (i % 13)) + 0.99,
+                "sold_count": i % 7,
+                "service": SERVICES[: (i % 4)],  # 0..3 services
+            }
+        )
+    return products
+
+
+@pytest.fixture
+def built(tmp_path):
+    products = make_products()
+    docs = tmp_path / "documents.jsonl"
+    with open(docs, "w") as f:
+        for p in products:
+            f.write(json.dumps({"id": p["product_id"], "contents": "x", "product": p}) + "\n")
+    out = tmp_path / "sidecar"
+    build_sidecar.build(str(docs), str(out))
+    sc = sidecar_mod.load(str(out))
+    assert sc is not None
+    return products, sc
+
+
+@pytest.mark.parametrize(
+    "shop_id,price,service",
+    [
+        (None, (None, None), []),
+        ("2003", (None, None), []),
+        (None, (20.0, 80.0), []),
+        (None, (None, 50.0), []),
+        (None, (30.0, None), []),
+        (None, (None, None), ["freeShipping"]),
+        (None, (None, None), ["official", "COD"]),
+        ("2001", (10.0, 100.0), ["freeShipping"]),
+        ("9999", (None, None), []),          # shop that matches nothing
+        (None, (None, None), ["unknown_svc"]),  # token absent from corpus
+    ],
+)
+def test_filter_parity(built, shop_id, price, service):
+    products, sc = built
+    shop_int = int(shop_id) if shop_id else None
+    reqmask = sc.reqmask(service)
+    for p in products:
+        i = sc.lookup(p["product_id"])
+        assert i is not None
+        got = sc.rejects(i, shop_int, price, reqmask)
+        want = ref_reject(p, shop_id, price, service)
+        assert got == want, (p["product_id"], shop_id, price, service, got, want)
+
+
+def test_lookup_missing(built):
+    _, sc = built
+    assert sc.lookup("999999999") is None
+    assert sc.lookup(None) is None
+    assert sc.lookup("not-an-int") is None
+
+
+def test_load_absent_dir_returns_none(tmp_path):
+    assert sidecar_mod.load(str(tmp_path / "does-not-exist")) is None
+    assert sidecar_mod.load(None) is None

--- a/tests/test_sidecar.py
+++ b/tests/test_sidecar.py
@@ -1,9 +1,8 @@
 """Parity tests for the find_product filter sidecar.
 
-Verifies that filtering via the columnar sidecar produces exactly the same
-accept/reject decision as the original per-product predicate logic, across a
-grid of shop_id / price / service filters. Does not import server.py (which
-loads a Lucene index at import); it re-states the reference predicates locally.
+The oracle is the real predicate module (`product_filters`), the same code the
+server's decode path runs -- so this is an independent check, not a copy kept in
+sync by hand. Does not import server.py (which loads a Lucene index at import).
 """
 import json
 
@@ -11,25 +10,23 @@ import pytest
 
 np = pytest.importorskip("numpy")
 
-from src.search_engine import build_sidecar, sidecar as sidecar_mod  # noqa: E402
+from src.search_engine import build_sidecar, product_filters as pf, sidecar as sidecar_mod  # noqa: E402
+
+SERVICES = ["official", "freeShipping", "COD", "flashsale"]
 
 
-# --- reference predicates: copied verbatim from server.is_filter_by_* ---
-def ref_reject(product, shop_id, price, service):
-    if shop_id and shop_id != product.get("shop_id"):
+def oracle_reject(product, shop_id, price, service):
+    if product_filters_shop(product, shop_id):
         return True
-    low, high = price
-    if low is not None and product["price"] < low:
+    if pf.is_filter_by_price(product, price):
         return True
-    if high is not None and product["price"] > high:
+    if pf.is_filter_by_service(product, service):
         return True
-    for serv in service:
-        if serv not in product.get("service", []):
-            return True
     return False
 
 
-SERVICES = ["official", "freeShipping", "COD", "flashsale"]
+def product_filters_shop(product, shop_id):
+    return pf.is_filter_by_shop_id(product, shop_id)
 
 
 def make_products(n=40):
@@ -41,22 +38,30 @@ def make_products(n=40):
                 "shop_id": str(2000 + (i % 5)),
                 "price": float(10 * (i % 13)) + 0.99,
                 "sold_count": i % 7,
-                "service": SERVICES[: (i % 4)],  # 0..3 services
+                "service": SERVICES[: (i % 4)],
             }
         )
+    # a null-price row and a null-shop row (both handled by build_sidecar)
+    products.append({"product_id": "200001", "shop_id": "2001", "price": None, "sold_count": 0, "service": []})
+    products.append({"product_id": "200002", "shop_id": None, "price": 50.0, "sold_count": 0, "service": []})
     return products
 
 
-@pytest.fixture
-def built(tmp_path):
-    products = make_products()
+def _build(tmp_path, products):
     docs = tmp_path / "documents.jsonl"
     with open(docs, "w") as f:
         for p in products:
             f.write(json.dumps({"id": p["product_id"], "contents": "x", "product": p}) + "\n")
     out = tmp_path / "sidecar"
     build_sidecar.build(str(docs), str(out))
-    sc = sidecar_mod.load(str(out))
+    return out
+
+
+@pytest.fixture
+def built(tmp_path):
+    products = make_products()
+    out = _build(tmp_path, products)
+    sc = sidecar_mod.load(str(out), expected_num_docs=len(products))
     assert sc is not None
     return products, sc
 
@@ -72,8 +77,8 @@ def built(tmp_path):
         (None, (None, None), ["freeShipping"]),
         (None, (None, None), ["official", "COD"]),
         ("2001", (10.0, 100.0), ["freeShipping"]),
-        ("9999", (None, None), []),          # shop that matches nothing
-        (None, (None, None), ["unknown_svc"]),  # token absent from corpus
+        ("9999", (None, None), []),
+        (None, (None, None), ["unknown_svc"]),
     ],
 )
 def test_filter_parity(built, shop_id, price, service):
@@ -83,9 +88,36 @@ def test_filter_parity(built, shop_id, price, service):
     for p in products:
         i = sc.lookup(p["product_id"])
         assert i is not None
-        got = sc.rejects(i, shop_int, price, reqmask)
-        want = ref_reject(p, shop_id, price, service)
-        assert got == want, (p["product_id"], shop_id, price, service, got, want)
+        verdict = sc.rejects(i, shop_int, price, reqmask)
+        if verdict is sc.undecided:
+            # only null price under an active price filter, where the decode
+            # path raises; the server defers to it, so behavior is identical.
+            assert p["price"] is None and (price[0] is not None or price[1] is not None)
+            continue
+        assert verdict == oracle_reject(p, shop_id, price, service)
+
+
+def test_null_price_defers_only_under_price_filter(built):
+    products, sc = built
+    i = sc.lookup("200001")  # price=None
+    assert sc.rejects(i, None, (None, None), 0) is False   # no price filter -> kept
+    assert sc.rejects(i, None, (10.0, None), 0) is sc.undecided
+    assert sc.rejects(i, None, (None, 99.0), 0) is sc.undecided
+
+
+def test_null_shop_row(built):
+    products, sc = built
+    i = sc.lookup("200002")  # shop_id=None -> stored NULL_SHOP
+    assert sc.rejects(i, 2003, (None, None), 0) is True    # any real shop filter drops it
+    assert sc.rejects(i, None, (None, None), 0) is False   # no shop filter -> kept
+
+
+@pytest.mark.parametrize(
+    "shop_id,canonical",
+    [("2003", True), ("0", True), ("02003", False), ("+2003", False), ("-1", False), (" 2003 ", False), ("", False)],
+)
+def test_shop_id_canonical(shop_id, canonical):
+    assert pf.shop_id_is_canonical(shop_id) is canonical
 
 
 def test_lookup_missing(built):
@@ -95,6 +127,9 @@ def test_lookup_missing(built):
     assert sc.lookup("not-an-int") is None
 
 
-def test_load_absent_dir_returns_none(tmp_path):
-    assert sidecar_mod.load(str(tmp_path / "does-not-exist")) is None
+def test_load_guards(tmp_path):
+    assert sidecar_mod.load(str(tmp_path / "nope")) is None
     assert sidecar_mod.load(None) is None
+    out = _build(tmp_path, make_products())
+    assert sidecar_mod.load(str(out), expected_num_docs=999) is None  # index/sidecar drift
+    assert sidecar_mod.load(str(out), expected_num_docs=len(make_products())) is not None


### PR DESCRIPTION
## Description

`find_product` scores up to k=10000 BM25 candidates and, for each, decodes the full stored product JSON (`json.loads(searcher.doc(id).raw())`) just to read four fields — `shop_id`, `price`, `service`, `sold_count` — for post-filtering. Only the ≤50 survivors are returned. A replay of 5,206 real queries against the full index found that 29% of calls escalate to the full k=10000 scan, those calls account for 95% of all decode work, and decode is ~50% of `find_product` wall-time.

This adds an optional memory-mapped columnar **sidecar** (`product_id → shop_id/price/service/sold_count`), built from the same `documents.jsonl` that feeds the Lucene index. The filter scan reads the columns via binary search and only decodes the ≤50 survivors. It is env-gated with an exact fallback: when the sidecar directory is absent the search path is byte-for-byte the original decode path, so this is a no-op until a base image bundling the sidecar is deployed. No re-index is required — the sidecar is derived from the source JSONL, independent of the Lucene index.

## Changes Made

-
- `src/search_engine/sidecar.py`: memory-mapped columnar store + filter predicates (`lookup`, `reqmask`, `rejects`); `load()` never raises and returns `None` when unavailable.
- `src/search_engine/build_sidecar.py`: builds the arrays + service vocab from `documents.jsonl` (float64 price for exact comparison parity; int64 columns; sorted by product_id for binary search).
- `src/search_engine/server.py`: `_collect` filters via the sidecar when loaded (decoding only survivors) and falls back to the original decode-every-candidate path otherwise. A non-numeric `shop_id` disables the fast path for that call to preserve exact string-equality semantics.
- `docker/search-server/requirements.txt`: add `numpy`.
- `docker/search-server/Dockerfile.base`: bundle the `sidecar/` directory; publish-base step documented inline.

## Issue Link

- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing

Replayed real production `find_product` calls against the full 2.7M-doc index:
- **Correctness:** the patched server vs the current decode path returned identical results on 1500 real queries — 1500/1500 identical, 0 mismatches.
- **Latency (single process):** `find_product` mean 147ms → 75ms (2.0×), p90 612ms → 223ms (2.7×), p99 858ms → 294ms.
- **Under CPU starvation (`cpus=1`, C=32):** 1.8× throughput, 0 request timeouts vs 66 on baseline, roughly half the tail latency.
- **Memory:** per-worker PSS unchanged vs baseline (~1.2GB); the ~90MB sidecar is memory-mapped and shared across workers via the page cache.

**Test Results:**
All parity and latency checks passed as above.

### Automated Testing

`tests/test_sidecar.py`: parity of the sidecar filter decision vs the reference predicates across a shop/price/service grid, plus lookup and load-fallback behavior.

**Test Command(s):**
```bash
pytest tests/test_sidecar.py -v
```

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
Module docstrings in `sidecar.py` / `build_sidecar.py` and the base-image build note in `Dockerfile.base` document how the sidecar is built and consumed.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

The optimization only takes effect once a `search-server-base` image is rebuilt to include the sidecar (run `python -m src.search_engine.build_sidecar <documents.jsonl> sidecar` alongside the index build). Until then, behavior is unchanged. Complementary to the multi-worker change: the eliminated `json.loads` is the GIL-held part, so it both speeds each request and reduces cross-worker GIL contention.

