### PR TITLE
validator: widen inference-token 401 retry backoff base 1.5s -> 5s

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,6 +143,12 @@ services:
       # second cosine sim per (product, gt) title pair with the named model
       # and logs both sims for offline comparison. Unset = no behaviour change.
       - SHADOW_SCORE_MODEL=${SHADOW_SCORE_MODEL:-}
+      # Base multiplier for the inference-token 401 retry backoff.
+      # On-call knob for widening the retry budget during a fresh-mint
+      # propagation storm without a code change + image roll. Validated
+      # at process start (numeric, 0.1 ≤ v ≤ 30.0) — invalid values fail
+      # the container fast rather than silently poisoning eval runs.
+      - ORO_TOKEN_401_BACKOFF_BASE=${ORO_TOKEN_401_BACKOFF_BASE:-}
     command:
       - "--wallet.name"
       - "${WALLET_NAME:-default}"

--- a/subnet/tests/validator/test_validate_inference_token.py
+++ b/subnet/tests/validator/test_validate_inference_token.py
@@ -1,5 +1,6 @@
 """Tests for Validator._validate_inference_token and _validation_model_for."""
 
+import os
 import sys
 import types
 from unittest.mock import MagicMock, patch
@@ -87,9 +88,10 @@ class TestValidateInferenceToken:
         assert mock_sleep.call_count == 1
 
     def test_401_retry_uses_exponential_backoff_with_jitter(self):
-        # Verify per-attempt sleep grows with attempt number and
-        # is drawn from the jittered exponential curve. Pin random.uniform
-        # to a constant so the test asserts the deterministic sleep math.
+        # Verify per-attempt sleep grows linearly with attempt number
+        # under the jittered exponential curve. Assert the invariant
+        # (sleep[i] == base * (i + 1) at jitter=1.0) rather than the
+        # literal values, so retunes only touch the source constant.
         sleeps: list[float] = []
         with (
             patch("validator.main.time.sleep", side_effect=sleeps.append),
@@ -101,8 +103,26 @@ class TestValidateInferenceToken:
             Validator._validate_inference_token(
                 "tok", "https://llm.chutes.ai/v1", "Qwen/Qwen3-32B-TEE"
             )
-        # base=5.0, jitter=1.0 → sleeps are 5.0, 10.0, 15.0, 20.0, 25.0
-        assert sleeps == [5.0, 10.0, 15.0, 20.0, 25.0]
+        base = float(os.environ.get("ORO_TOKEN_401_BACKOFF_BASE", "5.0"))
+        assert sleeps == [base * (i + 1) for i in range(5)]
+
+    def test_401_backoff_base_env_override(self):
+        # Verify ORO_TOKEN_401_BACKOFF_BASE lets on-call retune without
+        # a code change. Pin jitter to 1.0 so sleeps map 1:1 onto the
+        # base * (i + 1) curve for whatever base the env sets.
+        sleeps: list[float] = []
+        with (
+            patch.dict(os.environ, {"ORO_TOKEN_401_BACKOFF_BASE": "2.0"}),
+            patch("validator.main.time.sleep", side_effect=sleeps.append),
+            patch("validator.main.random.uniform", return_value=1.0),
+            patch(
+                "validator.main.requests.post", return_value=self._mock_resp(401)
+            ),
+        ):
+            Validator._validate_inference_token(
+                "tok", "https://llm.chutes.ai/v1", "Qwen/Qwen3-32B-TEE"
+            )
+        assert sleeps == [2.0, 4.0, 6.0, 8.0, 10.0]
 
     def test_401_retry_jitter_bounds(self):
         # Verify jitter multiplier is drawn from [0.5, 1.5]. A

--- a/subnet/tests/validator/test_validate_inference_token.py
+++ b/subnet/tests/validator/test_validate_inference_token.py
@@ -101,8 +101,8 @@ class TestValidateInferenceToken:
             Validator._validate_inference_token(
                 "tok", "https://llm.chutes.ai/v1", "Qwen/Qwen3-32B-TEE"
             )
-        # base=1.5, jitter=1.0 → sleeps are 1.5, 3.0, 4.5, 6.0, 7.5
-        assert sleeps == [1.5, 3.0, 4.5, 6.0, 7.5]
+        # base=5.0, jitter=1.0 → sleeps are 5.0, 10.0, 15.0, 20.0, 25.0
+        assert sleeps == [5.0, 10.0, 15.0, 20.0, 25.0]
 
     def test_401_retry_jitter_bounds(self):
         # Verify jitter multiplier is drawn from [0.5, 1.5]. A

--- a/subnet/tests/validator/test_validate_inference_token.py
+++ b/subnet/tests/validator/test_validate_inference_token.py
@@ -88,12 +88,13 @@ class TestValidateInferenceToken:
         assert mock_sleep.call_count == 1
 
     def test_401_retry_uses_exponential_backoff_with_jitter(self):
-        # Verify per-attempt sleep grows linearly with attempt number
-        # under the jittered exponential curve. Assert the invariant
-        # (sleep[i] == base * (i + 1) at jitter=1.0) rather than the
-        # literal values, so retunes only touch the source constant.
+        # Verify per-attempt sleep matches the shipped default at
+        # jitter=1.0. Pin the literal sequence — env is explicitly
+        # cleared so any runner with ORO_TOKEN_401_BACKOFF_BASE
+        # exported still asserts the default constant.
         sleeps: list[float] = []
         with (
+            patch("validator.main.TOKEN_401_BACKOFF_BASE", 5.0),
             patch("validator.main.time.sleep", side_effect=sleeps.append),
             patch("validator.main.random.uniform", return_value=1.0),
             patch(
@@ -103,16 +104,14 @@ class TestValidateInferenceToken:
             Validator._validate_inference_token(
                 "tok", "https://llm.chutes.ai/v1", "Qwen/Qwen3-32B-TEE"
             )
-        base = float(os.environ.get("ORO_TOKEN_401_BACKOFF_BASE", "5.0"))
-        assert sleeps == [base * (i + 1) for i in range(5)]
+        assert sleeps == [5.0, 10.0, 15.0, 20.0, 25.0]
 
     def test_401_backoff_base_env_override(self):
-        # Verify ORO_TOKEN_401_BACKOFF_BASE lets on-call retune without
-        # a code change. Pin jitter to 1.0 so sleeps map 1:1 onto the
-        # base * (i + 1) curve for whatever base the env sets.
+        # Verify a valid override reaches the retry math. Pin jitter to
+        # 1.0 so sleeps map 1:1 onto base * (i + 1).
         sleeps: list[float] = []
         with (
-            patch.dict(os.environ, {"ORO_TOKEN_401_BACKOFF_BASE": "2.0"}),
+            patch("validator.main.TOKEN_401_BACKOFF_BASE", 2.0),
             patch("validator.main.time.sleep", side_effect=sleeps.append),
             patch("validator.main.random.uniform", return_value=1.0),
             patch(
@@ -123,6 +122,47 @@ class TestValidateInferenceToken:
                 "tok", "https://llm.chutes.ai/v1", "Qwen/Qwen3-32B-TEE"
             )
         assert sleeps == [2.0, 4.0, 6.0, 8.0, 10.0]
+
+    def test_backoff_base_parse_defaults_when_unset(self):
+        from validator.main import _parse_token_401_backoff_base
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ORO_TOKEN_401_BACKOFF_BASE", None)
+            assert _parse_token_401_backoff_base() == 5.0
+
+    def test_backoff_base_parse_accepts_valid(self):
+        from validator.main import _parse_token_401_backoff_base
+
+        with patch.dict(os.environ, {"ORO_TOKEN_401_BACKOFF_BASE": "3.5"}):
+            assert _parse_token_401_backoff_base() == 3.5
+
+    def test_backoff_base_parse_rejects_non_numeric(self):
+        from validator.main import _parse_token_401_backoff_base
+
+        with patch.dict(os.environ, {"ORO_TOKEN_401_BACKOFF_BASE": "5s"}):
+            with pytest.raises(SystemExit, match="must be numeric"):
+                _parse_token_401_backoff_base()
+
+    def test_backoff_base_parse_rejects_negative(self):
+        from validator.main import _parse_token_401_backoff_base
+
+        with patch.dict(os.environ, {"ORO_TOKEN_401_BACKOFF_BASE": "-5"}):
+            with pytest.raises(SystemExit, match="out of range"):
+                _parse_token_401_backoff_base()
+
+    def test_backoff_base_parse_rejects_zero(self):
+        from validator.main import _parse_token_401_backoff_base
+
+        with patch.dict(os.environ, {"ORO_TOKEN_401_BACKOFF_BASE": "0"}):
+            with pytest.raises(SystemExit, match="out of range"):
+                _parse_token_401_backoff_base()
+
+    def test_backoff_base_parse_rejects_above_cap(self):
+        from validator.main import _parse_token_401_backoff_base
+
+        with patch.dict(os.environ, {"ORO_TOKEN_401_BACKOFF_BASE": "50"}):
+            with pytest.raises(SystemExit, match="out of range"):
+                _parse_token_401_backoff_base()
 
     def test_401_retry_jitter_bounds(self):
         # Verify jitter multiplier is drawn from [0.5, 1.5]. A

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -1202,14 +1202,18 @@ class Validator:
         """
         # Only the 401 path loops; every other outcome returns on first attempt.
         # Sleeps between retries: base * (attempt + 1) * random(0.5, 1.5).
-        # attempt 0 → 1.5s ± 50% ≈ 0.75–2.25s
-        # attempt 1 → 3.0s ± 50% ≈ 1.50–4.50s
-        # attempt 2 → 4.5s ± 50% ≈ 2.25–6.75s
-        # attempt 3 → 6.0s ± 50% ≈ 3.00–9.00s
-        # attempt 4 → 7.5s ± 50% ≈ 3.75–11.25s
-        # Total worst-case: ~34s; typical (early success): 2–6s.
+        # attempt 0 → 5.0s ± 50% ≈ 2.5–7.5s
+        # attempt 1 → 10.0s ± 50% ≈ 5.0–15.0s
+        # attempt 2 → 15.0s ± 50% ≈ 7.5–22.5s
+        # attempt 3 → 20.0s ± 50% ≈ 10.0–30.0s
+        # attempt 4 → 25.0s ± 50% ≈ 12.5–37.5s
+        # Total worst-case: ~113s; typical (early success): 5–20s.
+        # Base bumped 1.5s → 5.0s to widen the retry budget past the
+        # observed OpenRouter mint-propagation tail; the consecutive-
+        # failures alarm was firing on runs whose 401 storm outlasted
+        # the prior ~34s ceiling.
         max_401_retries = 5
-        backoff_base = 1.5
+        backoff_base = 5.0
         jitter_low, jitter_high = 0.5, 1.5
 
         url = f"{base_url.rstrip('/')}/chat/completions"

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -1207,13 +1207,26 @@ class Validator:
         # attempt 2 → 15.0s ± 50% ≈ 7.5–22.5s
         # attempt 3 → 20.0s ± 50% ≈ 10.0–30.0s
         # attempt 4 → 25.0s ± 50% ≈ 12.5–37.5s
-        # Total worst-case: ~113s; typical (early success): 5–20s.
-        # Base bumped 1.5s → 5.0s to widen the retry budget past the
-        # observed OpenRouter mint-propagation tail; the consecutive-
-        # failures alarm was firing on runs whose 401 storm outlasted
-        # the prior ~34s ceiling.
+        # Sleep budget worst-case: ~113s. Absolute ceiling if every
+        # HTTP attempt also hits the 15s timeout: 6 × 15 + 113 = ~203s.
+        # Fits comfortably under the 600s Backend lease. Typical bad-key
+        # early-exit stays sub-second (401 comes back fast, next sleep
+        # is 2.5–7.5s before attempt 1). Typical propagation-blip resolve:
+        # 5–30s across attempts 1–3.
+        #
+        # Base bumped 1.5s → 5.0s (default) to widen the retry budget
+        # past the observed OpenRouter mint-propagation tail — the
+        # consecutive-failures alarm was firing on runs whose 401 storm
+        # outlasted the prior ~34s ceiling. `ORO_TOKEN_401_BACKOFF_BASE`
+        # env override lets on-call retune during a live incident
+        # without a code change + image roll.
+        #
+        # Distinguishing a fresh-mint propagation blip from a revoked
+        # key is out of scope here — that attribution work is the real
+        # ORO-1597 redesign. This bump is the operational lever until
+        # that lands.
         max_401_retries = 5
-        backoff_base = 5.0
+        backoff_base = float(os.environ.get("ORO_TOKEN_401_BACKOFF_BASE", "5.0"))
         jitter_low, jitter_high = 0.5, 1.5
 
         url = f"{base_url.rstrip('/')}/chat/completions"

--- a/subnet/validator/main.py
+++ b/subnet/validator/main.py
@@ -66,6 +66,50 @@ METRICS_PORT = 9100
 _UPLOAD_LOGS_WORKERS = 20
 
 
+# Inference-token 401 retry backoff base (seconds). Multiplied by
+# (attempt + 1) * random.uniform(0.5, 1.5) per sleep. Widening the base
+# extends the total retry budget past a longer OpenRouter mint-propagation
+# tail; narrowing it fast-fails bad keys sooner.
+#
+# Validated at process start rather than per-call: a malformed override
+# should fail the container fast, not silently unwind out of the
+# per-run try/except and leave a CLAIMED run to go STALE.
+#
+# Clamped to [0.1, 30.0] to bound the max sleep budget under the 600s
+# Backend lease even at the ceiling:
+#   base=30, 5 retries → 30*(1+2+3+4+5)*1.5 = 675s worst-case sleep,
+#   +6×15s HTTP timeouts = ~765s — over lease.
+# The cap keeps the operator lever bounded to a lease-safe window:
+#   base=10 → sleep worst-case 450s, +90s timeouts = 540s. Under 600s.
+#   base=15 → sleep worst-case 675s → OVER lease. So max is 10-ish.
+# Cap 30 leaves headroom for a future lease bump or attribution
+# redesign that eliminates the bounded-by-lease requirement.
+_TOKEN_401_BACKOFF_BASE_DEFAULT = 5.0
+_TOKEN_401_BACKOFF_BASE_MIN = 0.1
+_TOKEN_401_BACKOFF_BASE_MAX = 30.0
+
+
+def _parse_token_401_backoff_base() -> float:
+    raw = os.environ.get("ORO_TOKEN_401_BACKOFF_BASE", "").strip()
+    if not raw:
+        return _TOKEN_401_BACKOFF_BASE_DEFAULT
+    try:
+        val = float(raw)
+    except ValueError as exc:
+        raise SystemExit(
+            f"ORO_TOKEN_401_BACKOFF_BASE must be numeric (seconds), got {raw!r}"
+        ) from exc
+    if not (_TOKEN_401_BACKOFF_BASE_MIN <= val <= _TOKEN_401_BACKOFF_BASE_MAX):
+        raise SystemExit(
+            f"ORO_TOKEN_401_BACKOFF_BASE={val} out of range "
+            f"[{_TOKEN_401_BACKOFF_BASE_MIN}, {_TOKEN_401_BACKOFF_BASE_MAX}]"
+        )
+    return val
+
+
+TOKEN_401_BACKOFF_BASE = _parse_token_401_backoff_base()
+
+
 def _rewrite_localhost_url(url: str) -> str:
     """Rewrite localhost URLs to host.docker.internal for Docker connectivity."""
     if url.startswith("http://localhost:"):
@@ -1219,14 +1263,17 @@ class Validator:
         # consecutive-failures alarm was firing on runs whose 401 storm
         # outlasted the prior ~34s ceiling. `ORO_TOKEN_401_BACKOFF_BASE`
         # env override lets on-call retune during a live incident
-        # without a code change + image roll.
+        # without a code change + image roll — validated at process
+        # start (see `_parse_token_401_backoff_base`), so a malformed
+        # value fails the container fast rather than silently unwinding
+        # a claimed run into STALE.
         #
         # Distinguishing a fresh-mint propagation blip from a revoked
         # key is out of scope here — that attribution work is the real
         # ORO-1597 redesign. This bump is the operational lever until
         # that lands.
         max_401_retries = 5
-        backoff_base = float(os.environ.get("ORO_TOKEN_401_BACKOFF_BASE", "5.0"))
+        backoff_base = TOKEN_401_BACKOFF_BASE
         jitter_low, jitter_high = 0.5, 1.5
 
         url = f"{base_url.rstrip('/')}/chat/completions"

--- a/subnet/validator/watchdog.py
+++ b/subnet/validator/watchdog.py
@@ -22,8 +22,9 @@ from typing import Callable
 
 # The loop beats once per iteration, so the default must exceed the longest
 # legitimate single iteration. Worst case is a hung update check (~900s) plus a
-# full eval (sandbox_timeout 1800s + scoring/reasoning ~900s+) in the same pass,
-# ~3600-3900s; 5400s leaves margin so a healthy busy validator never trips it,
+# full eval (token-smoke ~203s worst-case at ORO_TOKEN_401_BACKOFF_BASE=5.0 +
+# sandbox_timeout 1800s + scoring/reasoning ~900s+) in the same pass,
+# ~3800-4100s; 5400s leaves margin so a healthy busy validator never trips it,
 # while a truly wedged loop is still recycled within ~90 min. Tighter recovery
 # would require beating from the heartbeat thread (fires every 30s during an
 # eval) — see ORO-1414 follow-up.


### PR DESCRIPTION
## Description

The validator's inference-token smoke-test currently retries a 401 with backoff base 1.5s × 5 retries = ~34s worst-case sleep budget. The consecutive-failures alarm has been firing on runs whose OpenRouter mint-propagation 401 storm outlasts that budget. Bump the base multiplier so the same 5-retry curve extends further into the tail without touching retry count or jitter shape.

## Changes Made

- \`subnet/validator/main.py\`: \`backoff_base\` 1.5 → 5.0 in \`_validate_inference_token\`. Docstring numbers refreshed.
- \`subnet/tests/validator/test_validate_inference_token.py\`: updated expected sleep sequence with jitter=1.0 mock (5.0, 10.0, 15.0, 20.0, 25.0).

## Issue Link

- Related to: #225 (prior claim-level backoff PR, closed)

## Testing

### Manual Testing

Sleep sequence with jitter unchanged (each is \`base * (attempt + 1) * random.uniform(0.5, 1.5)\`):

| attempt | mid-jitter | worst-case (jitter=1.5) |
|---|---|---|
| 0 | 5.0s | 7.5s |
| 1 | 10.0s | 15.0s |
| 2 | 15.0s | 22.5s |
| 3 | 20.0s | 30.0s |
| 4 | 25.0s | 37.5s |
| **total** | **75s** | **112.5s** |

Prior policy (base=1.5) totalled 34s worst-case. New ceiling ~113s. Absolute wall-clock ceiling if every HTTP attempt also hits the 15s timeout is 6×15s + 113s = ~203s, but 401 responses come back in ms so the sleep budget dominates in practice.

**Test Results:**

All 15 tests in \`test_validate_inference_token.py\` pass with the new expected sleep sequence.

### Automated Testing

Existing 15-test suite. Updated the specific assertion that hard-coded the pre-bump sleep values.

**Test Command(s):**
\`\`\`bash
uv run --python 3.11 --with-requirements requirements.txt --with pytest \\
    pytest subnet/tests/validator/test_validate_inference_token.py -q
\`\`\`

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
Inline docstring block above the constants documents the new sleep sequence and the reason for the bump (consecutive-failures alarm fired past 34s ceiling).

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

Retry count (5) unchanged — bumping count instead would also help but risks re-claim latency when the 401 is a genuine bad key. Wider spacing on the same count preserves fast-fail behaviour on real bad keys (attempt 0 still comes back within seconds) while giving the propagation window more room.