### PR TITLE
validator: set BT_NO_PARSE_CLI_ARGS=false so 10.5.0 reads CLI args

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,6 +139,15 @@ services:
       - SUBTENSOR_NETWORK=${SUBTENSOR_NETWORK:-finney}
       - ORO_BACKEND_URL=${BACKEND_URL:-https://api.oroagents.com}
       - WATCHTOWER_TOKEN=${WATCHTOWER_TOKEN:-oro-watchtower-token}
+      # bittensor 10.3+ ships CLI parsing OFF by default (BT_NO_PARSE_CLI_ARGS
+      # defaults to "true" in `bittensor.core.config.no_parse_cli`), so
+      # `Config(parser)` early-returns without applying `--wallet.name`,
+      # `--wallet.hotkey`, `--netuid`, `--subtensor.network`. We DO drive the
+      # validator from those flags in the `command:` block below, so flip it
+      # back on. Without this the container silently falls to
+      # `netuid=None, network=finney, wallet=default` and crashes in
+      # `metagraph()` before the run loop starts.
+      - BT_NO_PARSE_CLI_ARGS=false
       # Opt-in shadow scoring. When set, the validator computes a
       # second cosine sim per (product, gt) title pair with the named model
       # and logs both sims for offline comparison. Unset = no behaviour change.


### PR DESCRIPTION
## Description

Follow-up to #228. bittensor 10.5.0 introduced \`bittensor.core.config.no_parse_cli()\` which reads \`BT_NO_PARSE_CLI_ARGS\` and **defaults it to \`"true"\`** — meaning \`Config(parser)\` early-returns without applying parsed args by default. Our container-side \`command:\` block passes \`--wallet.name testnet_wallet --wallet.hotkey validator --netuid 469 --subtensor.network test\`, and none of it lands. Config falls to \`wallet=default/default, netuid=None, network=finney\`.

Post-#228 the staging validator boots past the scale-codec crash but immediately hits a wasm trap: \`NeuronInfoRuntimeApi::get_neurons_lite(netuid=None)\` panics inside the runtime.

Fix: \`BT_NO_PARSE_CLI_ARGS=false\` in the validator env block re-enables argparse consumption, matching the pre-10.3 behaviour we still depend on.

## Changes Made

- \`docker-compose.yml\`: added \`BT_NO_PARSE_CLI_ARGS=false\` to the validator service env block with an inline comment tying it to the 10.5.0 change and the metagraph crash.
- Test-profile validator at line 240 skipped — it uses \`test_runner\`, not the metagraph path.

## Issue Link

- Related to: #228 (bittensor 10.5.0 bump — this is the config-parsing follow-up)

## Testing

### Manual Testing

Reproduced locally in a clean \`bittensor==10.5.0\` env:

\`\`\`python
from bittensor import Config
from bittensor.core.subtensor import Subtensor
from bittensor_wallet import Wallet
import argparse

p = argparse.ArgumentParser()
p.add_argument("--netuid", type=int, default=15)
Subtensor.add_args(p); Wallet.add_args(p)
c = Config(p, args=["--netuid","469","--subtensor.network","test",
                    "--wallet.name","testnet_wallet"])
print(c.netuid, c.subtensor.network, c.wallet.name)
# Default (BT_NO_PARSE_CLI_ARGS unset → "true"):  None finney default
# BT_NO_PARSE_CLI_ARGS=false:                     469  test   testnet_wallet
\`\`\`

**Test Results:**

Bittensor 10.5.0 \`no_parse_cli\` source (from installed package):

\`\`\`python
def no_parse_cli():
    return not os.getenv("BT_NO_PARSE_CLI_ARGS", "true").lower() in (
        "0", "false", "no", "off",
    )
\`\`\`

Default env value \`"true"\` → \`no_parse_cli() == True\` → \`Config.__init__\` returns early → args ignored.

### Automated Testing

No new test — this is a compose env change, exercised end-to-end at container boot.

**Test Command(s):**

\`\`\`bash
docker compose --profile validator up -d --force-recreate validator
docker logs oro-validator-1 --tail 100
# Expect: "Running validator for subnet: 469 on network: test"
# NOT:    "Running validator for subnet: None on network: finney"
\`\`\`

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
Inline comment in \`docker-compose.yml\` explains the exact bittensor.core.config API change, why we need the flag, and what the failure mode looks like without it. Future upgrades that revisit the flag will see the trace.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

This is the second undocumented bittensor 10.3+ behaviour change we've tripped in as many days (the first being the ASI 2.0 cyscale swap that #228 addressed). Together they lend weight to the dependabot + testnet-metagraph-smoke-in-CI follow-up called out in #228.

Once merged, retag as \`v1.1.27\`. Staging picks up on Watchtower cycle. Then #227 can finally be verified live.