### PR TITLE
compose: loopback-bind search-server 5632 + proxy 8080

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,14 @@ services:
       # overrides the image ENV). Index is off-heap/mmap, so 1g/worker is plenty;
       # keeps total heap modest across N workers on memory-constrained hosts.
       - _JAVA_OPTIONS=${_JAVA_OPTIONS:--Xmx1g -Xms256m}
+    # Loopback-only publish. Validator + proxy reach search-server over the
+    # `main` docker network (`http://search-server:5632`), so no host publish
+    # is required for normal operation. Keeping a loopback publish lets an
+    # operator `curl 127.0.0.1:5632/health` from an EC2 shell without
+    # exposing the port on any external interface — docker binds to the wildcard
+    # address by default, and Docker's iptables rules bypass UFW.
     ports:
-      - "${PORT:-5632}:${PORT:-5632}"
+      - "127.0.0.1:${PORT:-5632}:${PORT:-5632}"
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import os; import urllib.request; urllib.request.urlopen('http://localhost:' + os.environ.get('PORT', '5632') + '/health').read()\""]
       interval: 10s
@@ -53,8 +59,14 @@ services:
       # production; staging/dev override via BACKEND_URL env var.
       - BACKEND_URL=${BACKEND_URL:-https://api.oroagents.com}
       - BACKEND_HOST=${BACKEND_HOST:-api.oroagents.com}
+    # Loopback-only publish. Sandbox agents reach the proxy over the `main`
+    # docker network (`SANDBOX_PROXY_URL=http://proxy:80`), so no host publish
+    # is required for normal operation. Keeping a loopback publish preserves
+    # `docker/README.md`'s operator debugging path (`curl localhost:8080/health`)
+    # and integration-test wait-for-healthy in `tests/integration/conftest.py`
+    # without exposing the port on any external interface.
     ports:
-      - "${PROXY_PORT:-8080}:80"
+      - "127.0.0.1:${PROXY_PORT:-8080}:80"
     networks:
       - main
       - sandbox


### PR DESCRIPTION
## Description

Both \`search-server\` and \`proxy\` currently publish to \`0.0.0.0\` (Docker's default). Neither port has an off-host consumer — validator + sandbox reach these over the docker network via DNS. The \`0.0.0.0\` publish is a latent hazard: Docker installs its own \`PREROUTING\`/\`FORWARD\` rules and bypasses UFW, so the AWS Security Group is the sole reason external \`nc\` scans time out today. One over-broad ingress rule (or an external validator on a host without an equivalent SG) and both ports are open.

Switch both to \`127.0.0.1:PORT:PORT\`.

## Changes Made

- \`docker-compose.yml\` search-server \`ports:\` → \`"127.0.0.1:\${PORT:-5632}:\${PORT:-5632}"\`.
- \`docker-compose.yml\` proxy \`ports:\` → \`"127.0.0.1:\${PROXY_PORT:-8080}:80"\`.
- Inline comments on each block explaining why (docker network access + loopback preserves operator debugging + tests).

## Issue Link

- Related to: N/A (internal-scan follow-up)

## Testing

### Manual Testing

**Consumers audited before touching**:

| Path | Uses | Loopback bind preserves? |
|---|---|---|
| Validator → search-server | env \`SEARCH_SERVER_URL=http://search-server:5632\` (docker DNS) | ✓ unaffected |
| search-server healthcheck | \`localhost:5632\` inside container | ✓ unaffected |
| Sandbox → proxy | env \`SANDBOX_PROXY_URL=http://proxy:80\` (docker DNS) | ✓ unaffected |
| nginx upstream → search-server | \`http://search-server:5632\` (docker DNS) | ✓ unaffected |
| nginx upstream → Chutes/OpenRouter/Backend | external HTTPS | ✓ unaffected |
| Operator EC2 shell \`curl localhost:8080/health\` (\`docker/README.md\`) | localhost | ✓ preserved by loopback bind |
| \`tests/integration/conftest.py\` wait-for-healthy | \`http://localhost:8080/health\` | ✓ preserved by loopback bind |
| Prometheus scrape \`validator:9100\` / \`proxy-exporter:9113\` | docker DNS | ✓ unaffected (already unpublished) |

**External scan against staging validator \`34.206.254.86\`** (pre-change baseline):
- \`:5632\` → timeout (SG deny)
- \`:8080\` → timeout (SG deny)
- \`:9100\` → not host-published (confirmed via \`ss -tlnp\`)
- \`:9090\` → 127.0.0.1 only (already loopback)

**Test Results:**

Post-change, from-EC2-shell:
\`\`\`bash
curl -sI http://127.0.0.1:5632/health   # 200
curl -sI http://127.0.0.1:8080/health   # 200
\`\`\`

Post-change, external:
\`\`\`bash
nc -zvw 5 34.206.254.86 5632            # timeout (unchanged)
nc -zvw 5 34.206.254.86 8080            # timeout (unchanged)
\`\`\`

### Automated Testing

Existing 213-test validator suite unaffected — the change is only host-network topology, no code paths touched.

**Test Command(s):**

\`\`\`bash
cd /opt/oro && docker compose --profile validator up -d --force-recreate proxy search-server
docker exec oro-validator-1 wget -qO- http://search-server:5632/health   # verifies intra-network still works
\`\`\`

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**

- Inline block comments in \`docker-compose.yml\` on each \`ports:\` entry documenting the loopback rationale + the UFW-bypass hazard.
- \`Frontend/content/docs/validators/configuration.mdx:41\` still lists \`PROXY_PORT=8080\` — the port number is unchanged, only the bind interface changed. No public-doc update needed.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

**Not touched** (verified as unrelated to this change):

- Watchtower's exposed \`8080/tcp\` — unpublished, docker-network only (\`ORO_WATCHTOWER_URL=http://watchtower:8080\`).
- Prometheus \`--web.listen-address=:9090\` — already loopback-bound via the compose \`ports:\` entry.
- Validator \`METRICS_PORT=9100\` — already not host-published; scraped via docker DNS.

**Why this is worth landing** even though the SG blocks the ports today:

1. **Defense in depth.** Docker+UFW is a well-documented footgun. Any accidental ingress rule turns the SG into a single point of failure.
2. **External validators.** \`oro-public\` is the public repo; operators outside AWS don't have an SG. Loopback-by-default is the safe posture.
3. **Zero blast radius.** No consumer changes, no functional behavior changes, no deploy re-ordering.

**Follow-up worth its own PR** (called out in the commit message): a smoke test that runs \`nc -zvw 5 <public-ip> 5632 8080\` against every ORO-managed validator host from an external runner, alarming if either port becomes reachable. Codifies the invariant instead of relying on grep-ability of \`0.0.0.0\`.