### PR TITLE
docker(validator): bake BT_NO_PARSE_CLI_ARGS=false into the image

### DIFF
--- a/docker/validator/Dockerfile
+++ b/docker/validator/Dockerfile
@@ -40,4 +40,18 @@ COPY data/ /app/data/
 
 ENV PYTHONPATH=/app
 
+# bittensor 10.3+ ships CLI parsing OFF by default
+# (`bittensor.core.config.no_parse_cli` reads `BT_NO_PARSE_CLI_ARGS` and
+# defaults it to "true"), which makes `Config(parser)` early-return
+# without applying our `--wallet.name`/`--wallet.hotkey`/`--netuid`/
+# `--subtensor.network` command-line arguments. Without those the
+# validator falls back to class defaults `netuid=None, wallet=default,
+# network=finney` and crashes at metagraph sync inside the runtime
+# panic `NeuronInfoRuntimeApi::get_neurons_lite(None)`.
+#
+# Baked into the image (not just docker-compose.yml) so operators
+# whose compose file hasn't been re-pulled since PR #229 don't crash
+# on Watchtower auto-update.
+ENV BT_NO_PARSE_CLI_ARGS=false
+
 ENTRYPOINT [".venv/bin/python", "-m", "subnet.validator.main"]


### PR DESCRIPTION
## Description

Blocker for the prod-fleet recovery. #229 added \`BT_NO_PARSE_CLI_ARGS=false\` only to \`docker-compose.yml\`. That covers our own hosts (launch template ships the current compose file), but Watchtower's auto-update flow recreates external validators using their **existing** compose file. External operators haven't pulled #229. Promoting v1.1.27 → \`stable\` would auto-update the whole external fleet into the wasm-trap crash we chased down on staging yesterday.

Bake the env var into \`docker/validator/Dockerfile\` so the image is safe by default.

## Changes Made

- \`docker/validator/Dockerfile\`: \`ENV BT_NO_PARSE_CLI_ARGS=false\` between \`ENV PYTHONPATH=/app\` and \`ENTRYPOINT\`. Inline block comment documents the bittensor 10.3+ default and the crash it prevents.

## Issue Link

- Related to: #229 (compose fix — this PR is the image-side counterpart before Promote-to-Stable ships the v1.1.26 SDK bump to external operators)

## Testing

### Manual Testing

Prod outage forensics — all 4 \`oro-validator-production\` EC2 hosts crashed at 00:37 UTC on the same scale-codec ValueError that hit staging yesterday. Finney mainnet has now also rev'd its runtime past bittensor 10.1.0. Once #226 + #228 land as v1.1.28 and we promote to stable, Watchtower on both our hosts *and* external operators' hosts pulls the fix.

Our hosts already have the compose-side env var (from launch template rebuild after #229). External operators do not. This PR closes that gap in the image.

**Test Results:**

Verified locally (bittensor 10.5.0 install) that removing the container's compose-side env, then re-launching with only the image-baked \`BT_NO_PARSE_CLI_ARGS=false\`, still produces \`c.netuid=469, c.wallet.name="testnet_wallet"\`.

### Automated Testing

No new test — the invariant is a single \`ENV\` line in the Dockerfile. Existing 213-test validator suite unaffected.

**Test Command(s):**

\`\`\`bash
docker build -f docker/validator/Dockerfile -t oro-validator-test .
docker run --rm oro-validator-test /app/.venv/bin/python -c "import os; print(os.environ.get('BT_NO_PARSE_CLI_ARGS'))"
# Expect: false
\`\`\`

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**

Inline block comment in the Dockerfile documents:
- The bittensor 10.3+ default change.
- The exact failure mode without the env var.
- The design principle (env vars needed to boot go in the image; compose is site-specific).

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

**Sequencing** (P0, prod is down):

1. Merge this PR.
2. Tag \`v1.1.28\` on main.
3. \`Publish Docker Images\` fires, publishes the fix into \`latest\`.
4. \`Promote Images to Stable\` with \`source_tag=latest\`.
5. Watchtower pulls on both our hosts and external operators' hosts. Both boot cleanly.

**Not touching** in this PR (worth a follow-up):

- Compose-side \`BT_NO_PARSE_CLI_ARGS=false\` from #229 stays as belt-and-suspenders. Image ENV and compose environment: agree, so no conflict.
- Same treatment probably belongs on future bittensor version quirks (\`no_parse_cli\`, similar toggles) — worth a note in the runbook so we don't hit this shape again.