### PR TITLE
grader: alias British "colour" to "color_family"

### DIFF
--- a/src/agent/rewards/orm.py
+++ b/src/agent/rewards/orm.py
@@ -95,6 +95,7 @@ def _build_attr_index(kv_pairs):
 # coincidence. So this is an explicit allowlist. Pairs are stored normalized.
 _CROSS_KEY_ALIAS_PAIRS = [
     ("color", "color_family"),
+    ("colour", "color_family"),  # British spelling
     ("color_classification", "color_family"),
     ("color_classification", "sort by color"),
     ("color_family", "warna"),  # 'warna' == color (id/ms)

--- a/tests/test_attr_matching.py
+++ b/tests/test_attr_matching.py
@@ -86,6 +86,8 @@ def test_cross_key_alias_positive():
     # same value under a curated semantically-equivalent sibling key matches
     assert _hit("color_family", "blue", [("color", "blue")])
     assert _hit("color", "blue", [("color_family", "blue")])  # symmetric
+    # British spelling: product carries the colour under `colour`, reward `color_family`
+    assert _hit("color_family", "black", [("colour", "black")])
     # miner-reported cases
     assert _hit("colored_gem_type", "no stones", [("main_stone", "no stones")])
     assert _hit("model", "samsung galaxy a04e", [("compatibility_by_model", "samsung galaxy a04e")])


### PR DESCRIPTION
## Description

Adds the British spelling `colour` as a cross-key alias of `color_family` in the grader's attribute matcher. Products in the catalog sometimes encode a variant's color under the key `colour` while a reward requires `color_family`. These are the same attribute slot, but key normalization does not fold the spelling difference, so a product that genuinely matches (e.g. a black variant listed as `colour: black` against a `color_family: black` requirement) scores 0 on that constraint and the whole product is marked incorrect.

## Changes Made

- Add `("colour", "color_family")` to the curated `_CROSS_KEY_ALIAS_PAIRS` allowlist in `src/agent/rewards/orm.py`.
- Add a positive unit test for the `colour` → `color_family` recovery.

This also takes effect through the `sku_options` matching path, which reuses the same `_attr_constraint_hit` matcher — verified the change flips a real `colour: black` variant from rule 0.0 → 1.0 against a `color_family: black` requirement.

## Issue Link

- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing
Ran the matcher against a real `colour: black` sku variant vs a `color_family: black` reward — constraint hit flips from 0 → 1 (product now correctly satisfies).

**Test Results:**
Attribute-matching suite passes (13 tests), including the new positive case.

### Automated Testing

**Test Command(s):**
```bash
uv run --with pytest python -m pytest tests/test_attr_matching.py -q
```

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
Inline comment marks the entry as the British spelling.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

Stopgap. The curated allowlist is inherently incomplete (spelling/synonym variants keep appearing); a corpus-co-occurrence approach that derives aliases automatically is the durable follow-up. This is an on-chain scoring change — roll out fleet-wide (all validators pinned to the same version) before it takes effect, and run the attribute-recovery backtest to confirm no correct-reject regressions.
