### PR TITLE
feat(validator): apply Backend-provided supplementary weight assignments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ CLAUDE.md
 subnet/logs/
 data/single_problem.json
 data/test_agent.py
+
+# Root uv.lock is a stray artifact — the repo root uses requirements.txt.
+/uv.lock

--- a/docker/validator/pyproject.toml
+++ b/docker/validator/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "async-substrate-interface==2.2.1",
     "bittensor==10.5.0",
     "bittensor-wallet==4.1.0",
-    "oro-sdk==1.0.73",
+    "oro-sdk==1.0.96",
     "prometheus-client>=0.20.0",
     "psutil>=5.9.0",
     "py-spy>=0.4.1",

--- a/docker/validator/uv.lock
+++ b/docker/validator/uv.lock
@@ -1367,7 +1367,7 @@ wheels = [
 
 [[package]]
 name = "oro-sdk"
-version = "1.0.73"
+version = "1.0.96"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -1375,9 +1375,9 @@ dependencies = [
     { name = "httpx" },
     { name = "python-dateutil" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/87/e2dbe9e18ea1d619201859058565353a17dbc2cbdaedcfb45e90d643ed43/oro_sdk-1.0.73.tar.gz", hash = "sha256:6e83be34a5010974d8a16eb61a0529082739a87c00497a7802ceb50035cacc1a", size = 131684, upload-time = "2026-05-11T21:36:34.598Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/9c/0dd80438cfe05a1e911fb75b09a406274e41325e8869d0d12520d901e8bb/oro_sdk-1.0.96.tar.gz", hash = "sha256:d014f6d2aee19e8ccca0a0e695fc9d1260e13f8e09425da5d5e3222779c2a970", size = 142595, upload-time = "2026-07-20T22:40:59.932Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/4e/12e8ca1ab0ea07a71eaa8d6e45e80f8967169619e43919b8ad650666104c/oro_sdk-1.0.73-py3-none-any.whl", hash = "sha256:79c35b7e583d08facad27c427e6953c9904d3fc18cae035aad869307f757158a", size = 325477, upload-time = "2026-05-11T21:36:32.943Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/573295c89ddbf7463c65eefcbae1c23dd5a23afec6110c1306d1663c3bc0/oro_sdk-1.0.96-py3-none-any.whl", hash = "sha256:8a2ed8f25e2e34e1adfa49297ed6271beffd4da7cece372a8728778cf9eb35fb", size = 347461, upload-time = "2026-07-20T22:40:58.666Z" },
 ]
 
 [[package]]
@@ -1404,7 +1404,7 @@ requires-dist = [
     { name = "async-substrate-interface", specifier = "==2.2.1" },
     { name = "bittensor", specifier = "==10.5.0" },
     { name = "bittensor-wallet", specifier = "==4.1.0" },
-    { name = "oro-sdk", specifier = "==1.0.73" },
+    { name = "oro-sdk", specifier = "==1.0.96" },
     { name = "prometheus-client", specifier = ">=0.20.0" },
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "py-spy", specifier = ">=0.4.1" },

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ duckduckgo_search==8.1.1
 colorama==0.4.6
 googlesearch-python==1.3.0
 bittensor==10.5.0
-oro-sdk==1.0.75
+oro-sdk==1.0.96
 prometheus-client>=0.20.0
 psutil>=5.9.0

--- a/subnet/tests/validator/conftest.py
+++ b/subnet/tests/validator/conftest.py
@@ -71,7 +71,11 @@ def mock_backend_client():
 
     Test files can configure specific method return values as needed.
     """
-    return MagicMock(spec=BackendClient)
+    client = MagicMock(spec=BackendClient)
+    # Default: no supplementary weight assignments (matches a dark Backend). Set
+    # explicitly so tests don't depend on MagicMock's empty-iteration behaviour.
+    client.get_weight_overlay.return_value = {}
+    return client
 
 
 @pytest.fixture

--- a/subnet/tests/validator/test_backend_client.py
+++ b/subnet/tests/validator/test_backend_client.py
@@ -296,6 +296,84 @@ class TestBackendClientTopMiner:
         assert result.top_score == 0.92
 
 
+class TestBackendClientWeightOverlay:
+    def _client(self, mock_wallet):
+        return BackendClient("https://api.example.com", mock_wallet)
+
+    def _resp(self, overlay):
+        from oro_sdk.models.weight_salt_response import WeightSaltResponse
+
+        parsed = WeightSaltResponse.from_dict(
+            {
+                "active": True,
+                "eligible": True,
+                "epoch_index": 1,
+                "weight_overlay": overlay,
+            }
+        )
+        return _create_response(200, parsed)
+
+    def test_parses_overlay_to_int_float_dict(self, mock_wallet):
+        client = self._client(mock_wallet)
+        with patch(
+            "validator.backend_client.get_weight_salt.sync_detailed",
+            return_value=self._resp({"114": 0.09, "201": 0.005}),
+        ):
+            assert client.get_weight_overlay() == {114: 0.09, 201: 0.005}
+
+    def test_empty_overlay_returns_empty(self, mock_wallet):
+        client = self._client(mock_wallet)
+        with patch(
+            "validator.backend_client.get_weight_salt.sync_detailed",
+            return_value=self._resp({}),
+        ):
+            assert client.get_weight_overlay() == {}
+
+    def test_backend_error_returns_empty_not_raises(self, mock_wallet):
+        # Fetch failure must fail safe to {} (never raise → the caller submits
+        # its base vector rather than skipping the whole tick).
+        client = self._client(mock_wallet)
+        with patch(
+            "validator.backend_client.get_weight_salt.sync_detailed",
+            side_effect=httpx.TimeoutException("timeout"),
+        ):
+            assert client.get_weight_overlay() == {}
+
+    def test_malformed_payload_returns_empty_not_raises(self, mock_wallet):
+        # A non-numeric overlay value would raise on parse — the guard must catch
+        # it and fail safe to {}, not propagate past the client boundary.
+        client = self._client(mock_wallet)
+        bad = MagicMock()
+        bad.weight_overlay.to_dict.return_value = {"5": "not-a-number"}
+        with patch(
+            "validator.backend_client.get_weight_salt.sync_detailed",
+            return_value=_create_response(200, bad),
+        ):
+            assert client.get_weight_overlay() == {}
+
+    @pytest.mark.parametrize(
+        "overlay",
+        [
+            {"5": -0.1, "6": 0.2},  # negative share
+            {"5": float("inf")},  # non-finite
+            {"5": float("nan")},  # non-finite
+            {"5": 1.5},  # > 1
+            {"5": 0.4, "6": 0.4},  # total 0.8 > MAX_OVERLAY_SHARE
+        ],
+    )
+    def test_out_of_range_shares_rejected_to_empty(self, mock_wallet, overlay):
+        # The client boundary rejects the WHOLE overlay to {} on any invalid
+        # share, so every validator falls back to the same base vector.
+        client = self._client(mock_wallet)
+        bad = MagicMock()
+        bad.weight_overlay.to_dict.return_value = overlay
+        with patch(
+            "validator.backend_client.get_weight_salt.sync_detailed",
+            return_value=_create_response(200, bad),
+        ):
+            assert client.get_weight_overlay() == {}
+
+
 class TestBackendClientUploadToS3:
     def test_upload_to_s3_success(self, mock_wallet):
         from oro_sdk.models import PresignUploadResponse

--- a/subnet/tests/validator/test_weight_distribution.py
+++ b/subnet/tests/validator/test_weight_distribution.py
@@ -20,6 +20,7 @@ import pytest
 from subnet.validator.weight_distribution import (
     RankedFinisher,
     U16_MAX,
+    apply_weight_overlay,
     build_metagraph_weight_vector,
     compute_hotkey_weights,
     compute_pinned_weights,
@@ -573,3 +574,89 @@ def test_build_metagraph_vector_burn_zero_emits_top_dominant_vector():
     assert weights[0] == 0  # burn slot empty
     total = sum(weights)
     assert weights[rank1_idx] / total == pytest.approx(0.9882, abs=1e-3)
+
+
+class TestApplyWeightOverlay:
+    """Supplementary backend weight assignments merged into the base vector."""
+
+    def test_empty_overlay_returns_base_unchanged(self):
+        base = [0, 65535, 5, 4, 3, 2, 1]
+        assert apply_weight_overlay(base, {}) == base
+
+    def test_overlay_uids_get_their_share_of_the_total(self):
+        # base: one top at U16_MAX, small tail; overlay reserves 10% across 3 uids
+        base = [0, 65535, 3, 2, 1, 0, 0]
+        overlay = {5: 0.09, 6: 0.005}  # 4 is untouched base tail
+        out = apply_weight_overlay(base, overlay)
+        total = sum(out)
+        # overlay uids land at ~their share of the final total
+        assert abs(out[5] / total - 0.09) < 0.01
+        assert abs(out[6] / total - 0.005) < 0.005
+        # base proportions preserved among non-overlay uids (top still dominant)
+        assert out[1] == 65535
+        # final base share ~ (1 - 0.095)
+        base_share = (out[1] + out[2] + out[3] + out[4]) / total
+        assert abs(base_share - (1 - 0.095)) < 0.01
+
+    def test_exact_output_vector(self):
+        # Pin the precise integer vector, not just the shares. Base mass on the
+        # non-overlay uids = 0+65535+3+2+1 = 65541. share_total = 0.095, so
+        # total = 65541 / 0.905 = 72420.99; out[5] = round(0.09*total) = 6518,
+        # out[6] = round(0.005*total) = 362. Base bytes are left untouched.
+        base = [0, 65535, 3, 2, 1, 0, 0]
+        overlay = {5: 0.09, 6: 0.005}
+        assert apply_weight_overlay(base, overlay) == [0, 65535, 3, 2, 1, 6518, 362]
+        # And the resulting shares match the reserved fractions to ~1e-4.
+        out = apply_weight_overlay(base, overlay)
+        total = sum(out)
+        assert abs(out[5] / total - 0.09) < 1e-4
+        assert abs(out[6] / total - 0.005) < 1e-4
+
+    def test_deterministic_byte_identical(self):
+        base = [0, 65535, 3, 2, 1, 0, 0, 0]
+        overlay = {5: 0.09, 6: 0.005, 7: 0.005}
+        assert apply_weight_overlay(base, overlay) == apply_weight_overlay(base, overlay)
+
+    def test_out_of_range_overlay_uid_skipped(self):
+        base = [0, 65535, 2, 1]
+        # uid 99 not in the metagraph → skipped, base untouched otherwise
+        out = apply_weight_overlay(base, {99: 0.1})
+        assert out == base
+
+    def test_out_of_range_share_not_redistributed_to_in_range(self):
+        # An out-of-range uid's share must NOT inflate the in-range uid: uid 5
+        # should land at exactly its own 0.10, not 0.10/(1-0.40).
+        base = [0, 100, 0, 0, 0, 0, 0, 0, 0, 0]  # n=10
+        out = apply_weight_overlay(base, {5: 0.10, 999: 0.40})
+        total = sum(out)
+        assert abs(out[5] / total - 0.10) < 0.01  # exact share, not ~16.7%
+
+    def test_negative_share_clamped_to_zero(self):
+        # Defensive: apply_weight_overlay never emits a negative u16 even if a
+        # negative share slips past the client-boundary validation.
+        base = [0, 65535, 1, 0]
+        out = apply_weight_overlay(base, {3: -0.1, 2: 0.3})
+        assert all(w >= 0 for w in out)
+
+    def test_overlay_replaces_any_base_weight_on_its_uid(self):
+        # a uid that already carried base weight is set to its overlay share,
+        # not added on top (assigned uids shouldn't accumulate competitive weight)
+        base = [0, 65535, 500, 1]
+        out = apply_weight_overlay(base, {2: 0.10})
+        assert out[2] != 500  # replaced, sized against the base total
+        assert out[1] == 65535
+
+    def test_never_exceeds_u16_ceiling(self):
+        # Safety net only: an out-of-contract oversized share (rejected upstream
+        # by get_weight_overlay's MAX_OVERLAY_SHARE guard) must still never emit a
+        # value above the u16 ceiling. Proportion fidelity is NOT asserted here —
+        # it holds for the small in-contract shares (see test_exact_output_vector).
+        base = [0, 65535, 1]
+        out = apply_weight_overlay(base, {2: 0.99})
+        assert all(0 <= w <= U16_MAX for w in out)
+
+    def test_zero_base_sizes_against_u16(self):
+        base = [0, 0, 0, 0]
+        out = apply_weight_overlay(base, {2: 0.5, 3: 0.5})
+        assert out[2] == round(0.5 * U16_MAX)
+        assert out[3] == round(0.5 * U16_MAX)

--- a/subnet/tests/validator/test_weight_setter.py
+++ b/subnet/tests/validator/test_weight_setter.py
@@ -210,6 +210,48 @@ class TestWeightSetterThread:
         assert weights[5] == 2
         assert weights[6] == 1
 
+    def test_backend_overlay_is_applied_to_submitted_weights(
+        self, mock_backend_client, mock_subtensor, mock_wallet
+    ):
+        """A non-empty Backend overlay reassigns a fraction of the vector to the
+        given uids before submission; an untouched uid still carries base weight.
+        """
+        finishers = [
+            {"miner_hotkey": f"5HK{i}", "agent_version_id": str(uuid4()), "race_score": 0.9 - i * 0.05}
+            for i in range(6)
+        ]
+        metagraph = MagicMock()
+        # 7 base uids (0..6) + an extra uid 7 not in the race.
+        metagraph.hotkeys = ["5BurnUid"] + [e["miner_hotkey"] for e in finishers] + ["5Extra"]
+        metagraph.uids = list(range(len(metagraph.hotkeys)))
+
+        mock_backend_client.get_top_miner.return_value.top_miner_hotkey = "5HK0"
+        race_id = uuid4()
+        mock_backend_client.get_race_history.return_value = _race_complete_history(race_id)
+        mock_backend_client.get_race_detail.return_value = _race_detail(finishers)
+        # Backend directs 10% to the extra uid 7.
+        mock_backend_client.get_weight_overlay.return_value = {7: 0.10}
+
+        setter = WeightSetterThread(
+            backend_client=mock_backend_client,
+            subtensor=mock_subtensor,
+            metagraph=metagraph,
+            wallet=mock_wallet,
+            netuid=1,
+            interval_seconds=0.1,
+        )
+        setter.start()
+        time.sleep(0.15)
+        setter.stop()
+
+        weights = mock_subtensor.set_weights.call_args.kwargs["weights"]
+        total = sum(weights)
+        # Assigned uid 7 lands at ~10% of the final vector.
+        assert weights[7] > 0
+        assert abs(weights[7] / total - 0.10) < 0.02
+        # Base structure preserved: top miner (uid 1) still outranks its tail.
+        assert weights[1] > weights[2] > weights[6]
+
     def test_race_path_skips_in_progress_and_uses_prior_completed_race(
         self, mock_backend_client, mock_subtensor, mock_wallet
     ):

--- a/subnet/validator/backend_client.py
+++ b/subnet/validator/backend_client.py
@@ -10,6 +10,7 @@ Error Handling:
 """
 
 import logging
+import math
 import time
 from typing import Any, Callable, Optional
 from uuid import UUID
@@ -23,6 +24,7 @@ from oro_sdk.api.validator import (
     claim_work,
     complete_run,
     get_run_problems,
+    get_weight_salt,
     heartbeat,
     presign_upload,
     update_progress,
@@ -180,6 +182,11 @@ class BackendError(Exception):
 # per problem. Default urllib3 pool size (10) is enough to keep the
 # parallel uploader in _upload_logs cache-warm.
 _S3_SESSION = requests.Session()
+
+# Upper bound on the total supplementary-assignment share accepted from the
+# Backend. Real assignments reserve a small slice; a larger total signals a bad
+# payload, so the whole overlay is rejected (fail safe to the base vector).
+_MAX_OVERLAY_SHARE = 0.5
 
 
 class BackendClient:
@@ -564,6 +571,52 @@ class BackendClient:
             "get_top_miner",
             client=self._public_client,
         )
+
+    def get_weight_overlay(self) -> dict[int, float]:
+        """Fetch the Backend's supplementary weight assignments for this epoch.
+
+        Returns a mapping of miner uid → weight fraction to assign this epoch, or
+        an empty dict when the Backend provides none (the default). Uses the
+        signed client — the endpoint is participation-gated.
+
+        This is the trust boundary for the assignments: every share must be
+        finite and in [0, 1], and the total must be sane (<= MAX_OVERLAY_SHARE).
+        On ANY fetch/parse error OR any out-of-range value the whole overlay is
+        rejected and an empty dict is returned, so the caller submits its base
+        vector — a negative/inf/nan or oversized share would otherwise produce an
+        invalid u16 weight or wedge weight-setting. Rejecting the *whole* overlay
+        (rather than per-uid clamping) keeps every honest validator on the same
+        fallback, preserving consensus.
+        """
+        try:
+            resp = self._call_api(
+                get_weight_salt.sync_detailed,
+                "get_weight_overlay",
+                client=self._auth_client,
+            )
+            overlay = getattr(resp, "weight_overlay", None)
+            if overlay is None or overlay is UNSET:
+                return {}
+            parsed = {
+                int(uid): float(share) for uid, share in overlay.to_dict().items()
+            }
+        except (BackendError, ValueError, TypeError, AttributeError) as e:
+            # Fail safe: any fetch OR parse failure → no assignments, so the
+            # caller submits its base vector. A malformed payload must not raise
+            # past here (a wrong or missing vector would break Yuma consensus).
+            logging.warning(f"Weight overlay unavailable, using base vector: {e}")
+            return {}
+
+        if not all(
+            math.isfinite(s) and 0.0 <= s <= 1.0 for s in parsed.values()
+        ) or sum(parsed.values()) > _MAX_OVERLAY_SHARE:
+            logging.warning(
+                "Weight overlay had out-of-range shares (total=%s); using base "
+                "vector",
+                sum(parsed.values()),
+            )
+            return {}
+        return parsed
 
     def get_race_history(self, limit: int = 1) -> RaceHistoryResponse:
         """Fetch the most recent races (ordered newest-first).

--- a/subnet/validator/weight_distribution.py
+++ b/subnet/validator/weight_distribution.py
@@ -266,3 +266,57 @@ def build_metagraph_weight_vector(
         weights[hotkey_to_idx[top_hotkey]] += top_u16
 
     return list(range(n_meta)), weights
+
+
+def apply_weight_overlay(
+    weights_u16: list[int], overlay: dict[int, float]
+) -> list[int]:
+    """Apply backend-provided supplementary weight assignments to a vector.
+
+    The Backend may direct a validator to assign a fixed fraction of its weight
+    to specific miner uids for the current epoch (``overlay`` maps uid → fraction,
+    the fractions summing to the reserved share). The base vector keeps its
+    internal proportions but collectively occupies ``1 - sum(shares)`` of the
+    final vector; each overlay uid is set to its share of the total. Chain-side
+    normalisation makes the absolute scale irrelevant — only proportions matter —
+    so the result is deterministic and byte-identical across validators that
+    receive the same overlay and base vector.
+
+    An empty overlay returns the base vector unchanged (the default). Overlay
+    uids outside the metagraph range are dropped *before* the reserved share is
+    computed, so each in-range uid lands at exactly its share — an out-of-range
+    assignment is not redistributed onto the survivors. Shares are assumed finite
+    and in [0, 1] (validated at the client boundary, ``get_weight_overlay``);
+    outputs are clamped to [0, U16_MAX] defensively.
+    """
+    if not overlay:
+        return weights_u16
+
+    out = list(weights_u16)
+    n = len(out)
+
+    # Drop out-of-range uids FIRST — only assignments that land on the vector
+    # count toward the reserved share; otherwise the surviving uids would inflate.
+    overlay = {uid: share for uid, share in overlay.items() if 0 <= uid < n}
+    if not overlay:
+        return weights_u16
+
+    share_total = sum(overlay.values())
+    if share_total <= 0:
+        return weights_u16
+    # Defensive clamp — the reserved share is a small fraction in practice.
+    share_total = min(share_total, 0.999)
+
+    # Base weight on uids NOT in the overlay — this is the (1 - share_total)
+    # portion of the final vector. Overlay uids' base weight (if any) is replaced.
+    base = sum(w for i, w in enumerate(out) if i not in overlay)
+    if base <= 0:
+        # Degenerate base (empty/zero vector): size the overlay against the u16
+        # ceiling so the assignments still carry meaningful relative weight.
+        total = float(U16_MAX)
+    else:
+        total = base / (1.0 - share_total)
+
+    for uid, share in overlay.items():
+        out[uid] = max(0, min(round(share * total), U16_MAX))
+    return out

--- a/subnet/validator/weight_setter.py
+++ b/subnet/validator/weight_setter.py
@@ -20,6 +20,7 @@ from .backend_client import BackendClient, BackendError
 from .weight_distribution import (
     RankedFinisher,
     _validate_burn,
+    apply_weight_overlay,
     build_metagraph_weight_vector,
     compute_pinned_weights,
 )
@@ -292,6 +293,18 @@ class WeightSetterThread:
 
         top_hotkey, t_burn = self._fetch_top_state()
         uids, weights = self._build_weights_from_race(finishers, top_hotkey, t_burn)
+
+        # Apply any Backend-provided supplementary weight assignments for this
+        # epoch. An empty overlay — or a fetch failure (get_weight_overlay
+        # returns {} on error) — leaves the base vector unchanged, the safe
+        # default that every validator in the same state also produces.
+        overlay = self.backend_client.get_weight_overlay()
+        if overlay:
+            weights = apply_weight_overlay(weights, overlay)
+            logging.info(
+                f"Applied {len(overlay)} supplementary weight assignment(s)"
+            )
+
         non_zero = sum(1 for w in weights if w > 0)
         logging.info(
             f"Race-based weight vector: N={len(finishers)} finishers, "


### PR DESCRIPTION
## Description

Lets the Backend assign a fraction of a validator's weight vector to specific miner uids for an epoch, on top of the race-derived base vector. The weight setter fetches these supplementary assignments each tick (via the authenticated client) and merges them before submitting; when the Backend provides none — the default — the base vector is submitted unchanged.

The assignments are opaque backend guidance: the validator applies the given per-uid fractions and renormalizes. The merge is deterministic and byte-identical across validators that receive the same assignments and base vector (load-bearing for Yuma consensus).

## Changes Made

-
- `weight_distribution.apply_weight_overlay(weights, overlay)` — merge per-uid weight fractions into a vector: the base keeps its internal proportions but collectively occupies `1 - sum(shares)`; each assigned uid is set to its share of the total; values are u16-capped. Empty overlay returns the base unchanged; out-of-range uids are skipped.
- `backend_client.get_weight_overlay()` — signed fetch of the assignments; returns `{}` on any backend error so the caller falls back to its base vector rather than a guessed or desynced one.
- `weight_setter._tick()` — fetch and apply the assignments after building the base race vector, before submission.
- Bump `oro-sdk` → 1.0.96 (adds the client for the new endpoint) and regen `docker/validator/uv.lock`.

## Issue Link

- N/A

## Testing

### Manual Testing
With no assignments the submitted vector is unchanged from the race-derived base. With an assignment (e.g. 10% to a uid), that uid lands at ~its share of the final vector while the base structure (top miner outranks its tail) is preserved.

**Test Results:**
221 validator tests pass; ruff clean.

### Automated Testing
- `test_weight_distribution.py::TestApplyWeightOverlay` — shares of total, determinism, out-of-range skip, replace-not-add, u16 ceiling, zero-base sizing, empty-overlay no-op.
- `test_weight_setter.py::test_backend_overlay_is_applied_to_submitted_weights` — end-to-end: an assignment reaches the submitted weights; base structure preserved. Default fixture returns `{}` so existing full-path tests are deterministic.

**Test Command(s):**
```bash
python -m pytest subnet/tests/validator/ -q
ruff check subnet/validator/ subnet/tests/validator/
```

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**
Docstrings describe the assignments as opaque backend guidance and the empty-overlay fallback.

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been published and merged

## Additional Notes

Inert until the Backend starts returning assignments (it returns an empty overlay by default), so this is a no-op change to current behavior.
