### PR TITLE
Fix apply_weight_overlay rounding on tiny base vectors

### DIFF
--- a/subnet/tests/validator/test_weight_distribution.py
+++ b/subnet/tests/validator/test_weight_distribution.py
@@ -584,33 +584,33 @@ class TestApplyWeightOverlay:
         assert apply_weight_overlay(base, {}) == base
 
     def test_overlay_uids_get_their_share_of_the_total(self):
-        # base: one top at U16_MAX, small tail; overlay reserves 10% across 3 uids
         base = [0, 65535, 3, 2, 1, 0, 0]
-        overlay = {5: 0.09, 6: 0.005}  # 4 is untouched base tail
+        overlay = {5: 0.09, 6: 0.005}  # reserve 9.5% across 2 uids
         out = apply_weight_overlay(base, overlay)
         total = sum(out)
-        # overlay uids land at ~their share of the final total
-        assert abs(out[5] / total - 0.09) < 0.01
-        assert abs(out[6] / total - 0.005) < 0.005
-        # base proportions preserved among non-overlay uids (top still dominant)
-        assert out[1] == 65535
-        # final base share ~ (1 - 0.095)
+        # overlay uids land at exactly their share of the final total
+        assert abs(out[5] / total - 0.09) < 1e-3
+        assert abs(out[6] / total - 0.005) < 1e-3
+        # base collectively occupies (1 - share_total), proportions preserved
         base_share = (out[1] + out[2] + out[3] + out[4]) / total
-        assert abs(base_share - (1 - 0.095)) < 0.01
+        assert abs(base_share - (1 - 0.095)) < 1e-3
 
-    def test_exact_output_vector(self):
-        # Pin the precise integer vector, not just the shares. Base mass on the
-        # non-overlay uids = 0+65535+3+2+1 = 65541. share_total = 0.095, so
-        # total = 65541 / 0.905 = 72420.99; out[5] = round(0.09*total) = 6518,
-        # out[6] = round(0.005*total) = 362. Base bytes are left untouched.
-        base = [0, 65535, 3, 2, 1, 0, 0]
-        overlay = {5: 0.09, 6: 0.005}
-        assert apply_weight_overlay(base, overlay) == [0, 65535, 3, 2, 1, 6518, 362]
-        # And the resulting shares match the reserved fractions to ~1e-4.
+    def test_shares_exact_even_when_base_is_tiny(self):
+        # Regression: a short survivor taper (no admin top) gives a tiny base
+        # like 4,3,2,1. Working at that native scale rounds a 0.1% keep-alive to
+        # 0 and collapses the ~10% share into an adjacent bucket (10% -> 11.1%).
+        # Scaling to u16 first must give each assigned uid EXACTLY its share.
+        base = [0] * 15
+        base[3], base[9], base[13], base[11] = 4, 3, 2, 1  # taper; uid13 also decoy
+        overlay = {14: 0.098, 12: 0.001, 13: 0.001}  # 9.8% + 0.1% + 0.1% = 10%
         out = apply_weight_overlay(base, overlay)
         total = sum(out)
-        assert abs(out[5] / total - 0.09) < 1e-4
-        assert abs(out[6] / total - 0.005) < 1e-4
+        assert abs(out[14] / total - 0.098) < 1e-3
+        assert abs(out[12] / total - 0.001) < 1e-3  # keep-alive survives, not 0
+        assert abs(out[13] / total - 0.001) < 1e-3
+        assert out[12] > 0 and out[13] > 0
+        combined = (out[12] + out[13] + out[14]) / total
+        assert abs(combined - 0.10) < 1e-3  # exactly 10%, not 11.1%
 
     def test_deterministic_byte_identical(self):
         base = [0, 65535, 3, 2, 1, 0, 0, 0]
@@ -643,8 +643,10 @@ class TestApplyWeightOverlay:
         # not added on top (assigned uids shouldn't accumulate competitive weight)
         base = [0, 65535, 500, 1]
         out = apply_weight_overlay(base, {2: 0.10})
-        assert out[2] != 500  # replaced, sized against the base total
-        assert out[1] == 65535
+        total = sum(out)
+        assert abs(out[2] / total - 0.10) < 1e-3  # its share, not its base 500
+        # uid1 stays the dominant base slot (proportions preserved after rescale)
+        assert out[1] == max(out)
 
     def test_never_exceeds_u16_ceiling(self):
         # Safety net only: an out-of-contract oversized share (rejected upstream

--- a/subnet/validator/weight_distribution.py
+++ b/subnet/validator/weight_distribution.py
@@ -277,23 +277,28 @@ def apply_weight_overlay(
     to specific miner uids for the current epoch (``overlay`` maps uid → fraction,
     the fractions summing to the reserved share). The base vector keeps its
     internal proportions but collectively occupies ``1 - sum(shares)`` of the
-    final vector; each overlay uid is set to its share of the total. Chain-side
-    normalisation makes the absolute scale irrelevant — only proportions matter —
-    so the result is deterministic and byte-identical across validators that
-    receive the same overlay and base vector.
+    final vector; each overlay uid is set to its share of the total.
+
+    The result is rebuilt at ``U16_MAX`` resolution so the (typically small)
+    overlay shares survive integer rounding even when the base weights are tiny
+    — e.g. a short survivor taper of ``4, 3, 2, 1``. At the base's native scale a
+    0.1% share rounds to 0 and a ~10% share collapses into an adjacent integer
+    bucket, so the on-chain fractions come out wrong (a 10% assignment landing at
+    ~11%). Scaling first makes each assigned uid land at exactly its share. The
+    output is deterministic and byte-identical across validators given the same
+    overlay and base vector.
 
     An empty overlay returns the base vector unchanged (the default). Overlay
     uids outside the metagraph range are dropped *before* the reserved share is
     computed, so each in-range uid lands at exactly its share — an out-of-range
     assignment is not redistributed onto the survivors. Shares are assumed finite
     and in [0, 1] (validated at the client boundary, ``get_weight_overlay``);
-    outputs are clamped to [0, U16_MAX] defensively.
+    outputs are clamped to [0, U16_MAX].
     """
     if not overlay:
         return weights_u16
 
-    out = list(weights_u16)
-    n = len(out)
+    n = len(weights_u16)
 
     # Drop out-of-range uids FIRST — only assignments that land on the vector
     # count toward the reserved share; otherwise the surviving uids would inflate.
@@ -307,16 +312,19 @@ def apply_weight_overlay(
     # Defensive clamp — the reserved share is a small fraction in practice.
     share_total = min(share_total, 0.999)
 
-    # Base weight on uids NOT in the overlay — this is the (1 - share_total)
+    # Base weight on uids NOT in the overlay — collectively the (1 - share_total)
     # portion of the final vector. Overlay uids' base weight (if any) is replaced.
-    base = sum(w for i, w in enumerate(out) if i not in overlay)
-    if base <= 0:
-        # Degenerate base (empty/zero vector): size the overlay against the u16
-        # ceiling so the assignments still carry meaningful relative weight.
-        total = float(U16_MAX)
-    else:
-        total = base / (1.0 - share_total)
+    base = sum(w for i, w in enumerate(weights_u16) if i not in overlay)
 
+    # Rebuild at U16_MAX resolution. Base uids keep their proportions but are
+    # scaled to occupy (1 - share_total); each overlay uid is set to its share of
+    # the full scale. When the base is empty/zero the base stays zero and the
+    # overlay still carries meaningful weight.
+    result = [0] * n
+    if base > 0:
+        for i, w in enumerate(weights_u16):
+            if i not in overlay:
+                result[i] = round(w / base * (1.0 - share_total) * U16_MAX)
     for uid, share in overlay.items():
-        out[uid] = max(0, min(round(share * total), U16_MAX))
-    return out
+        result[uid] = max(0, min(round(share * U16_MAX), U16_MAX))
+    return result


### PR DESCRIPTION
## Description

`apply_weight_overlay` merges a `{uid: fraction}` overlay of supplementary weight assignments into the base u16 weight vector. It sized the output against the base vector's native scale, which loses resolution when the base is tiny.

A short survivor taper (e.g. `4, 3, 2, 1` — few finishers, no admin top, zero burn) can't represent small overlay shares: a 0.1% share rounds to 0 and a ~10% share collapses into an adjacent integer bucket. On chain this showed up as a 10% assignment landing at ~11%, and the small keep-alive assignments rounding to 0.

Fix: rebuild the merged vector at `U16_MAX` resolution. Base uids keep their proportions scaled to occupy `1 - sum(shares)`; each overlay uid is set to its share of the full u16 scale. Each assigned uid then lands at exactly its share regardless of base magnitude.

## Changes Made

- `apply_weight_overlay`: build result at `U16_MAX` resolution instead of `base / (1 - share_total)`.
- Regression test `test_shares_exact_even_when_base_is_tiny` (base `4,3,2,1`; combined assigned share == 10% exactly; keep-alive shares stay non-zero).
- Updated existing overlay tests to assert final shares (robust to the rescale) rather than pinning base bytes that are now scaled.

## Issue Link

- Related to: N/A
- Closes: N/A

## Testing

### Manual Testing

Base `[…,3:4, 9:3, 13:2, 11:1]` with overlay `{14:0.098, 12:0.001, 13:0.001}` → `{3:29491, 9:22118, 11:7373, 12:66, 13:66, 14:6422}`; assigned shares 9.80% / 0.10% / 0.10%, combined **10.00%** (was 11.11% with keep-alives at 0).

**Test Results:**

All 10 `TestApplyWeightOverlay` cases pass.

### Automated Testing

Ran the `apply_weight_overlay` test class.

**Test Command(s):**
```bash
pytest subnet/tests/validator/test_weight_distribution.py -k ApplyWeightOverlay
```

## Documentation

- [ ] README updated
- [x] Code comments added/updated
- [ ] API documentation updated
- [ ] Configuration documentation updated
- [ ] Other documentation updated (please specify):

**Documentation Changes:**

Docstring explains why the output is rebuilt at u16 resolution (tiny-base rounding).

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been published and merged

## Additional Notes

N/A